### PR TITLE
Show Honey Icon in DiplomacyDealView

### DIFF
--- a/Assets/UI/diplomacydealview_CQUI.lua
+++ b/Assets/UI/diplomacydealview_CQUI.lua
@@ -230,7 +230,7 @@ function CQUI_RenderResourceButton(resource, resourceCategory, iconList, howAcqu
     icon.SelectButton:SetTextureOffsetVal(0, 50);
   end
 
-  SetIconToSize(icon.Icon, "ICON_" .. resourceDesc.ResourceType, icon.Icon:GetSizeX());
+  SetIconToSize(icon.Icon, "ICON_" .. resourceDesc.ResourceType);
   icon.AmountText:SetText(tostring(resource.MaxAmount));
   icon.AmountText:SetHide(false);
   icon.SelectButton:SetDisabled( buttonDisabled );


### PR DESCRIPTION
Issue #9 - When initiating a trade, Honey would not show correctly in the DealContentStack (on either player side).

![image](https://user-images.githubusercontent.com/8787640/83621264-4c512680-a543-11ea-9a55-3789a9b241bd.png)

**Details:**
Fix was to _not_ include a size value when calling the SetIconToSize method.  The size value specified would cause the game to look for a 64x64 icon.   The definitions for the Honey and Maize resources are found in GranColombia_Maya_Icons_Resources.xml.  There does not appear to be a 64x64 icon in MayaGran_Resources.dds.

In Vanilla, this icon size is 50x50.  Before completing this fix, I added special-case code so I could side-by-size compare the size 50x50 icon with the supposed size 64x64...and there is no discernable difference.  That may be due to the fact that this object - IconAndText as defined in DiplomacyDealView.xml, only allows 44x44 for the Icon size.

Either way, the fix is to simply allow the game to use the 50x50 icon instead of trying to get the 64x64 icon, which is what the previous version was doing.
