### PR TITLE
Fix CityBanners for Exp1

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -55,7 +55,7 @@
           <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" Padding="10" >
             <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" Padding="2" />
             <Stack ID="CQUI_Districts" Anchor="L,C" Offset="0,1" StackGrowth="Right" Padding="-12" />
-            <Label ID="CityName" Anchor="L,C" Style="HeaderSmallCaps" />
+            <Label ID="CityName" Anchor="L,C" Style="FontFlair16" FontStyle="Shadow" Color0="255,255,255,255"	Color1="0,0,0,20" SmallCaps="18" SmallCapsType="EveryWord" />
             <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" Padding="2"/>
           </Stack>
         </Button>
@@ -81,7 +81,9 @@
 
   <!-- Instances populate in CityDetailsStack -->
   <Instance Name="CityDetailEffect">
-    <Image ID="Icon" Size="20,20" Anchor="C,C"/>
+    <Button ID="Button" Size="20,20" Anchor="C,C">
+      <Image ID="Icon" Size="20,20" Anchor="C,C"/>
+    </Button>
   </Instance>
 
   <!-- Instances populate in CityInfoStack -->
@@ -231,16 +233,8 @@
     <ZoomAnchor ID="Anchor" ZoomOffsetNear="0,0,0" ZoomOffsetFar="0,0,-20">
       <Container ID="EncampmentBannerContainer" Anchor="C,C" Size="106,34">
 
-        <!-- District strength -->
-        <Grid ID="DistrictDefenseGrid" Texture="Banner_StatusFrame" Size="55,20" Anchor="C,T" AnchorSide="I,O" Offset="0,-3" SliceTextureSize="24,20" SliceCorner="9,2" SliceSize="5,15">
-          <Stack Anchor="C,C" Offset="-2,0" StackGrowth="Right">
-            <Image Size="21,18" Texture="Banner_StrengthIcon_Shields"/>
-            <Label ID="DistrictDefenseStrengthLabel" Offset="0,2" Style="StrongSmall" String="17"/>
-          </Stack>
-        </Grid>
-
         <!-- Banner Background -->
-        <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="14,14" SliceSize="51,5" SliceTextureSize="80,34"/>
+        <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
 
         <!-- District Font Icon -->
         <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
@@ -248,6 +242,14 @@
         <!-- Healthbars -->
         <TextureBar ID="CityHealthBar" Anchor="R,C" Offset="8,3" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" />
         <TextureBar ID="CityDefenseBar" Anchor="R,C" Offset="8,-4" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
+
+        <!-- District strength -->
+        <Grid ID="DistrictDefenseGrid" Texture="Banner_StrengthBacking" Size="60,15" Anchor="C,T" AnchorSide="I,O" SliceTextureSize="42,15" SliceCorner="21,7" Color="255,255,255,150">
+          <Stack Anchor="C,C" Offset="-2,1" StackGrowth="Right">
+            <Image Size="21,18" Texture="Banner_StrengthIcon_Shields"/>
+            <Label ID="DistrictDefenseStrengthLabel" Offset="0,2" Style="StrongSmall" String="17"/>
+          </Stack>
+        </Grid>
 
         <!-- District ranged strike button -->
         <Image ID="CityStrike" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" Offset="0,-4" AnchorSide="I,O" >

--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -34,6 +34,7 @@
 
         <!-- CENTER: MAIN BUTTON -->
         <Button ID="CityBannerButton" Anchor="L,T" Size="parent,parent" NoStateChange="true">
+          <!-- COLORED BG -->
           <Grid ID="CityBannerFill" Anchor="C,T" Size="parent,parent" Texture="Banner_FrameBase_Combo" SliceTextureSize="113,41" SliceCorner="18,7" SliceSize="76,27"/>
 
           <!-- OUTLINE: MOUSE IN / OUT -->
@@ -55,7 +56,7 @@
           <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" Padding="10" >
             <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" Padding="2" />
             <Stack ID="CQUI_Districts" Anchor="L,C" Offset="0,1" StackGrowth="Right" Padding="-12" />
-            <Label ID="CityName" Anchor="L,C" Style="FontFlair16" FontStyle="Shadow" Color0="255,255,255,255"	Color1="0,0,0,20" SmallCaps="18" SmallCapsType="EveryWord" />
+            <Label ID="CityName" Anchor="L,C" Style="HeaderSmallCaps" />
             <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" Padding="2"/>
           </Stack>
         </Button>
@@ -81,9 +82,7 @@
 
   <!-- Instances populate in CityDetailsStack -->
   <Instance Name="CityDetailEffect">
-    <Button ID="Button" Size="20,20" Anchor="C,C">
       <Image ID="Icon" Size="20,20" Anchor="C,C"/>
-    </Button>
   </Instance>
 
   <!-- Instances populate in CityInfoStack -->
@@ -95,7 +94,7 @@
 
   <Instance Name="CityInfoCondition">
     <Button ID="Button" Anchor="C,C" Size="20,20" Texture="Banner_TypeSlot" NoStateChange="1">
-      <Image ID="Icon" Anchor="C,C" Size="22,22" Texture="Cities22">
+      <Image ID="Icon" Anchor="C,C" Size="22,22" Offset="0,-1" Texture="Cities22">
         <Image ID="ConditionRising" Offset="-4,-1" Anchor="R,B" Size="12,12" Texture="CityCondition_Rising" Hidden="1"/>
         <Image ID="ConditionFalling" Offset="-4,-1" Anchor="R,B" Size="12,12" Texture="CityCondition_Falling" Hidden="1"/>
       </Image>
@@ -233,8 +232,16 @@
     <ZoomAnchor ID="Anchor" ZoomOffsetNear="0,0,0" ZoomOffsetFar="0,0,-20">
       <Container ID="EncampmentBannerContainer" Anchor="C,C" Size="106,34">
 
+        <!-- District strength -->
+        <Grid ID="DistrictDefenseGrid" Texture="Banner_StatusFrame" Size="55,20" Anchor="C,T" AnchorSide="I,O" Offset="0,-3" SliceTextureSize="24,20" SliceCorner="9,2" SliceSize="5,15">
+          <Stack Anchor="C,C" Offset="-2,0" StackGrowth="Right">
+            <Image Size="21,18" Texture="Banner_StrengthIcon_Shields"/>
+            <Label ID="DistrictDefenseStrengthLabel" Offset="0,2" Style="StrongSmall" String="17"/>
+          </Stack>
+        </Grid>
+
         <!-- Banner Background -->
-        <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
+        <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="14,14" SliceSize="51,5" SliceTextureSize="80,34"/>
 
         <!-- District Font Icon -->
         <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
@@ -242,14 +249,6 @@
         <!-- Healthbars -->
         <TextureBar ID="CityHealthBar" Anchor="R,C" Offset="8,3" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" />
         <TextureBar ID="CityDefenseBar" Anchor="R,C" Offset="8,-4" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
-
-        <!-- District strength -->
-        <Grid ID="DistrictDefenseGrid" Texture="Banner_StrengthBacking" Size="60,15" Anchor="C,T" AnchorSide="I,O" SliceTextureSize="42,15" SliceCorner="21,7" Color="255,255,255,150">
-          <Stack Anchor="C,C" Offset="-2,1" StackGrowth="Right">
-            <Image Size="21,18" Texture="Banner_StrengthIcon_Shields"/>
-            <Label ID="DistrictDefenseStrengthLabel" Offset="0,2" Style="StrongSmall" String="17"/>
-          </Stack>
-        </Grid>
 
         <!-- District ranged strike button -->
         <Image ID="CityStrike" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" Offset="0,-4" AnchorSide="I,O" >

--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -82,7 +82,7 @@
 
   <!-- Instances populate in CityDetailsStack -->
   <Instance Name="CityDetailEffect">
-      <Image ID="Icon" Size="20,20" Anchor="C,C"/>
+    <Image ID="Icon" Size="20,20" Anchor="C,C"/>
   </Instance>
 
   <!-- Instances populate in CityInfoStack -->

--- a/Assets/Expansion1/CityBanners/citybannermanager.lua
+++ b/Assets/Expansion1/CityBanners/citybannermanager.lua
@@ -1,5 +1,5 @@
 -- ===========================================================================
---  City Banner Manager
+--  City Banner Manager (Expansion 1)
 -- ===========================================================================
 
 include( "CivilizationIcon" );
@@ -7,9 +7,19 @@ include( "InstanceManager" );
 include( "SupportFunctions" );
 include( "LoyaltySupport" );
 include( "Civ6Common" );
-include( "LuaClass" );
+include( "Colors" );
 include( "CitySupport" );
 
+-- ===========================================================================
+--	GLOBALS
+-- ===========================================================================
+CityBanner = {};
+
+BANNERTYPE_CITY_CENTER    = 0;
+BANNERTYPE_ENCAMPMENT     = 1;
+BANNERTYPE_AERODROME      = 2;
+BANNERTYPE_MISSILE_SILO   = 3;
+BANNERTYPE_OTHER_DISTRICT = 4;
 -- ===========================================================================
 --  CONSTANTS
 -- ===========================================================================
@@ -68,12 +78,6 @@ local ZOFFSET_3DVIEW            :number = 36;
 local SIZEOFPOPANDPROD          :number = 80;    --The amount to add to the city banner to account for the size of the production icon and population number
 local SIZEOFPOPANDPRODMETERS    :number = 15;    --The amount to add to the city banner backing width to allow for the production and population meters to appear
 
-local BANNERTYPE_CITY_CENTER    :number = 0;
-local BANNERTYPE_ENCAMPMENT     :number = 1;
-local BANNERTYPE_AERODROME      :number = 2;
-local BANNERTYPE_MISSILE_SILO   :number = 3;
-local BANNERTYPE_OTHER_DISTRICT :number = 4;
-
 local BANNERSTYLE_LOCAL_TEAM    :number = 0;
 local BANNERSTYLE_OTHER_TEAM    :number = 1;
 
@@ -91,8 +95,6 @@ local m_DelayedUpdate : table = {};
 -- ===========================================================================
 --  MEMBERS
 -- ===========================================================================
-
-CityBanner = {};
 local CityBannerInstances  :table = {};
 local MiniBannerInstances  :table = {};
 
@@ -130,7 +132,7 @@ local CQUI_ShowCityManageAreaOnCityHover :boolean = true;
 local CQUI_CityManageAreaShown           :boolean = false;
 local CQUI_CityManageAreaShouldShow      :boolean = false;
 
-local CQUI_WorkIconSize       :number = 48;
+local CQUI_WorkIconSize      :number = 48;
 local CQUI_WorkIconAlpha              = 0.60;
 local CQUI_SmartWorkIcon     :boolean = true;
 local CQUI_SmartWorkIconSize :number  = 64;
@@ -193,37 +195,41 @@ function GetMiniBanner( playerID:number, districtID:number )
 end
 
 -- ===========================================================================
--- constructor
+-- Constructor
 -- ===========================================================================
 function CityBanner:new( playerID: number, cityID : number, districtID : number, bannerType : number, bannerStyle : number )
-  self = LuaClass.new(CityBanner);
-  
-  self.m_eMajorityReligion = -1; -- << Assign default values
-  self.m_eLoyaltyWarningPlayer = -1; -- which player the city might flip to within 20 turns
+if bannerStyle == nil then 
+  UI.DataError("Missing bannerStyle: "..tostring(playerID)..", "..tostring(cityID)..", "..tostring(districtID)..", "..tostring(bannerType) ); 
+end
 
-  if bannerStyle == nil then UI.DataError("Missing bannerStyle: "..tostring(playerID)..", "..tostring(cityID)..", "..tostring(districtID)..", "..tostring(bannerType) ); end
+local oNewCityBanner:object = {};
+setmetatable(oNewCityBanner, {__index = CityBanner });
+oNewCityBanner:Initialize(playerID, cityID, districtID, bannerType, bannerStyle);
 
-  self:Initialize(playerID, cityID, districtID, bannerType, bannerStyle);
-
-  if (bannerType == BANNERTYPE_CITY_CENTER) then
-    if (CityBannerInstances[playerID] == nil) then
-      CityBannerInstances[playerID] = {};
-    end
-
-    CityBannerInstances[playerID][cityID] = self;
-  else
-    if (MiniBannerInstances[playerID] == nil) then
-      MiniBannerInstances[playerID] = {};
-    end
-
-    MiniBannerInstances[playerID][districtID] = self;
+if (bannerType == BANNERTYPE_CITY_CENTER) then
+  if (CityBannerInstances[playerID] == nil) then
+    CityBannerInstances[playerID] = {};
   end
 
-  return self;
+  CityBannerInstances[playerID][cityID] = oNewCityBanner;
+else
+  if (MiniBannerInstances[playerID] == nil) then
+    MiniBannerInstances[playerID] = {};
+  end
+
+  MiniBannerInstances[playerID][districtID] = oNewCityBanner;
+end
+
+return oNewCityBanner;
 end
 
 -- ===========================================================================
 function CityBanner:destroy()
+  self:Uninitialize( self.m_Player:GetID(), self.m_CityID, self.m_DistrictID, self.m_Type , self.m_Style );
+end
+
+-- ===========================================================================
+function CityBanner:Uninitialize()
   if self.m_DetailStatusIM then
     self.m_DetailStatusIM:DestroyInstances();
   end
@@ -380,7 +386,6 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
         table.insert(yields, plotId);
         yieldsIndex[index] = plotId;
-
       end
 
       local plotCount = Map.GetPlotCount();
@@ -514,6 +519,9 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
   self.m_UnitListEnabled = false;
   self.m_IsCurrentlyVisible = false;
 
+  self.m_eMajorityReligion     = -1;  -- Assign default values
+  self.m_eLoyaltyWarningPlayer = -1;  -- which player the city might flip to within X turns (default 20)
+
   if (bannerType == BANNERTYPE_CITY_CENTER) then
     local pCity = self:GetCity();
     if pCity ~= nil then
@@ -531,7 +539,7 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
     end
 
     if self.m_DetailEffectsIM == nil then
-      self.m_DetailEffectsIM = InstanceManager:new( "CityDetailEffect", "Icon", self.m_Instance.CityDetailsEffects );
+      self.m_DetailEffectsIM = InstanceManager:new( "CityDetailEffect", "Button", self.m_Instance.CityDetailsEffects );
     end
 
     if self.m_InfoIconIM == nil then
@@ -619,7 +627,7 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
   self:UpdateColor();
 end
 
---- ===========================================================================
+-- ===========================================================================
 function CityBanner:CreateAerodromeBanner()
   -- Set the appropriate instance factory (mini banner one) for this flag...
   self.m_InstanceManager = m_AerodromeBannerIM;
@@ -1063,7 +1071,7 @@ function CityBanner:UpdateColor()
   if (self.m_Type == BANNERTYPE_CITY_CENTER) then
     self.m_Instance.CityBannerFill:SetColor( backColor );
     self.m_Instance.CityBannerFillOver:SetColor( frontColor );
-    self.m_Instance.CityBannerFillOut:SetColor( brighterBackColor );
+    self.m_Instance.CityBannerFillOut:SetColor( frontColor );
     self.m_Instance.CityName:SetColor( frontColor, 0 );
     self.m_Instance.CityName:SetColor( darkerBackColor, 1 );
     if self.m_CivIconInstance then
@@ -1128,9 +1136,13 @@ function CityBanner:UpdateProduction(pCity:table)
   self.m_StatProductionIM:ResetInstances();
 
   local productionInstance:table = self.m_StatProductionIM:GetInstance();
-  productionInstance.Button:RegisterCallback( Mouse.eLClick, OnProductionClick );
-  productionInstance.Button:SetVoid1(pCity:GetOwner());
-  productionInstance.Button:SetVoid2(pCity:GetID());
+  if pCity:GetOwner() == Game.GetLocalPlayer() then
+    productionInstance.Button:RegisterCallback( Mouse.eLClick, OnProductionClick );
+    productionInstance.Button:SetVoid1(pCity:GetOwner());
+    productionInstance.Button:SetVoid2(pCity:GetID());
+  else
+    productionInstance.Button:ClearCallback( Mouse.eLClick );
+  end
 
   local pBuildQueue     :table  = pCity:GetBuildQueue();
   if (pBuildQueue ~= nil) then
@@ -1149,8 +1161,8 @@ function CityBanner:UpdateProduction(pCity:table)
     if currentProductionHash ~= 0 then
       pBuildingDef = GameInfo.Buildings[currentProductionHash];
       pDistrictDef = GameInfo.Districts[currentProductionHash];
-      pUnitDef   = GameInfo.Units[currentProductionHash];
-      pProjectDef    = GameInfo.Projects[currentProductionHash];
+      pUnitDef     = GameInfo.Units[currentProductionHash];
+      pProjectDef  = GameInfo.Projects[currentProductionHash];
     end
 
     if (pBuildingDef ~= nil) then
@@ -1225,7 +1237,7 @@ function CityBanner:UpdateProduction(pCity:table)
 
       productionTip = productionTip .. "[NEWLINE]" .. productionTurnsLeftString;
       productionInstance.Button:SetToolTipString(productionTip);
-      productionInstance.Button:SetColor(UI.GetColorValueFromHexLiteral(0x00FFFFFF));
+      productionInstance.Button:SetColor(UI.GetColorValue("COLOR_CLEAR"));
             
       if (prodTypeName ~= nil) then
         productionInstance.Slot:SetHide(false);
@@ -1236,7 +1248,7 @@ function CityBanner:UpdateProduction(pCity:table)
         UI.DataError("City has current production, but no prodTypeName");
       end
     else
-      productionInstance.Button:SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+      productionInstance.Button:SetColor(UI.GetColorValue("COLOR_WHITE"));
       productionInstance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_NO_PRODUCTION"));
       productionInstance.FillMeter:SetHide(true);
       productionInstance.IconMeter:SetHide(true);
@@ -1255,7 +1267,7 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
 
   if isLocalPlayer then
     local food              :number = pCityGrowth:GetFood();
-    local pCityData   :table  = GetCityData(pCity);
+    local pCityData         :table  = GetCityData(pCity);
     local isGrowing         :boolean= pCityGrowth:GetTurnsUntilGrowth() ~= -1;
     local isStarving        :boolean= pCityGrowth:GetTurnsUntilStarvation() ~= -1;
     local growthThreshold   :number = pCityGrowth:GetGrowthThreshold();
@@ -1276,7 +1288,7 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
     if isGrowing then
       turnsUntilGrowth = pCityGrowth:GetTurnsUntilGrowth();
     elseif isStarving then
-      turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();    -- negative
+      turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();  -- negative
     end
 
     -- Get real housing from improvements value
@@ -1287,16 +1299,13 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
     end
 
     local CQUI_housingLeftPopupText = ""
-
     -- CQUI : housing left
     if g_smartbanner and g_smartbanner_population then
       local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[localPlayerID][pCityID];    -- CQUI real housing from improvements value
-
       if CQUI_HousingFromImprovements ~= nil then    -- CQUI real housing from improvements fix to show correct values when waiting for the next turn
         local housingLeft = pCityGrowth:GetHousing() - pCityGrowth:GetHousingFromImprovements() + CQUI_HousingFromImprovements - currentPopulation; -- CQUI calculate real housing
         CQUI_housingLeftPopupText = housingLeft
         local housingLeftColor = "StatNormalCS";
-
         if housingLeft <= 1.5 and housingLeft > 0.5 then
           housingLeftColor = "WarningMinor";
         elseif housingLeft <= 0.5 then
@@ -1513,21 +1522,6 @@ function CityBanner:UpdateGovernor(pCity:table)
   end
 end
 
--- CQUI : TODO check if it's still needed
-function GetPopulationTooltip(turnsUntilGrowth:number, currentPopulation:number, foodSurplus:number)
-  --- POPULATION AND GROWTH INFO ---
-  local popTooltip:string = Locale.Lookup("LOC_CITY_BANNER_POPULATION") .. ": " .. currentPopulation;
-  if turnsUntilGrowth > 0 then
-    popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_GROWTH", turnsUntilGrowth);
-    popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_FOOD_SURPLUS", round(foodSurplus,1));
-  elseif turnsUntilGrowth == 0 then
-    popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_STAGNATE");
-  elseif turnsUntilGrowth < 0 then
-    popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_STARVATION", -turnsUntilGrowth);
-  end
-  return popTooltip;
-end
-
 -- ===========================================================================
 function CityBanner:UpdateStats()
   local pDistrict:table = self:GetDistrict();
@@ -1603,7 +1597,7 @@ function CityBanner:UpdateStats()
       end
 
       self:SetHealthBarColor(); 
-      
+
       if (((districtHitpoints-currentDistrictDamage) / districtHitpoints) == 1 and wallHitpoints == 0) then
         self.m_Instance.CityHealthBar:SetHide(true);
         self.m_Instance.CityHealthBarBacking:SetHide(true);
@@ -1615,7 +1609,6 @@ function CityBanner:UpdateStats()
       self:UpdateDetails();
       --------------------------------------
     else -- it should be a miniBanner
-      
       if (self.m_Type == BANNERTYPE_ENCAMPMENT) then 
         self:UpdateEncampmentBanner();
       elseif (self.m_Type == BANNERTYPE_AERODROME) then
@@ -1624,7 +1617,6 @@ function CityBanner:UpdateStats()
         self:UpdateDistrictBanner();
       end
     end
-
   else  --it's a banner not associated with a district
     if (self.m_IsImprovementBanner) then
       local bannerPlot = Map.GetPlot(self.m_PlotX, self.m_PlotY);
@@ -1644,11 +1636,15 @@ function SetDetailIcon(instance:table, icon:string, tooltip:string)
   instance.Icon:SetHide(icon == nil);
   if icon then instance.Icon:SetIcon(icon); end
   instance.Icon:SetToolTipString(tooltip and tooltip or "");
+
+    -- If we have a button clear the callback incase we were previously doing something else
+    if instance.Button ~= nil then
+      instance.Button:ClearCallback( Mouse.eLClick );
+    end
 end
 
 -- ===========================================================================
 function CityBanner:UpdateDetails()
-  
   local pCity:table = self:GetCity();
   local pDistrict:table = self:GetDistrict();
   if pCity and pDistrict then
@@ -1700,7 +1696,7 @@ function CityBanner:UpdateDetails()
 
       -- Update occupied icon
       if pCity:IsOccupied() then
-        local pCityIdentity     :table = pCity:GetCulturalIdentity();       
+        local pCityIdentity     :table = pCity:GetCulturalIdentity();
         local loyaltyLevel      :number = pCityIdentity:GetLoyaltyLevel();
         local loyaltyLevelName  :string = GameInfo.LoyaltyLevels[loyaltyLevel].Name;
         SetDetailIcon(self.m_DetailEffectsIM:GetInstance(), "ICON_CITY_EFFECTS_OCCUPIED", Locale.Lookup("LOC_HUD_CITY_OCCUPIED_LOYALITY_STATUS", loyaltyLevelName));
@@ -1951,9 +1947,7 @@ function CityBanner:UpdateInfo( pCity : table )
     -- CAPITAL ICON
     if pPlayer then
       local instance:table = self.m_InfoIconIM:GetInstance();
-      instance.Button:RegisterCallback(Mouse.eLClick, OnCapitalIconClicked);
-      instance.Button:SetVoid1(playerID);
-      instance.Button:SetVoid2(cityID);
+      local tooltip:string = "";
 
       if pPlayer:IsMajor() then
         if pCity:IsOriginalCapital() and pCity:GetOriginalOwner() == pCity:GetOwner() then
@@ -1965,23 +1959,30 @@ function CityBanner:UpdateInfo( pCity : table )
             instance.Icon:SetIcon("ICON_FORMER_CAPITAL");
           end
 
-          instance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_ORIGINAL_CAPITAL_TT", pPlayerConfig:GetCivilizationShortDescription()));
+          tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_ORIGINAL_CAPITAL_TT", pPlayerConfig:GetCivilizationShortDescription());
         elseif pCity:IsCapital() then
           -- New capital
           instance.Icon:SetIcon("ICON_NEW_CAPITAL");
-          instance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_NEW_CAPITAL_TT", pPlayerConfig:GetCivilizationShortDescription()));
+          tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_NEW_CAPITAL_TT", pPlayerConfig:GetCivilizationShortDescription());
         else
           -- Other cities
           instance.Icon:SetIcon("ICON_OTHER_CITIES");
-          instance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_OTHER_CITY_TT", pPlayerConfig:GetCivilizationShortDescription()));
+          tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_OTHER_CITY_TT", pPlayerConfig:GetCivilizationShortDescription());
         end
+
       elseif pPlayer:IsFreeCities() then
         instance.Icon:SetIcon("ICON_CIVILIZATION_FREE_CITIES");
-        instance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_FREE_CITY_TT"));
+        tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_FREE_CITY_TT");
       else
         instance.Icon:SetIcon("ICON_CITY_STATE");
-        instance.Button:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_CITY_STATE_TT"));
+        tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_CITY_STATE_TT");
       end
+
+      instance.Button:SetTexture("Banner_TypeSlot");
+      instance.Button:RegisterCallback(Mouse.eLClick, OnCapitalIconClicked);
+      instance.Button:SetVoid1(playerID);
+      instance.Button:SetVoid2(cityID);
+      instance.Button:SetToolTipString(tooltip);
 
       -- ORIGINAL OWNER CAPITAL ICON
       if pCity:GetOwner() ~= pCity:GetOriginalOwner() and pCity:IsOriginalCapital() then
@@ -2004,7 +2005,8 @@ function CityBanner:UpdateInfo( pCity : table )
     if civType ~= nil then
       self.m_CivIconInstance = self.m_InfoConditionIM:GetInstance();
       self.m_CivIconInstance.Icon:SetIcon("ICON_" .. civType);
-  
+      self.m_CivIconInstance.Button:SetTexture("Banner_TypeSlot");
+
       local tooltip, isLoyaltyRising, isLoyaltyFalling = GetLoyaltyStatusTooltip(pCity);
       -- Add belongs to string at the beginning of the tooltip
       if civType == "CIVILIZATION_FREE_CITIES" then
@@ -2021,7 +2023,9 @@ function CityBanner:UpdateInfo( pCity : table )
       self.m_CivIconInstance.Button:SetVoid1(playerID);
       self.m_CivIconInstance.Button:SetVoid2(cityID);
     else
-      UI.DataError("Invalid type name returned by GetCivilizationTypeName");
+      if WorldBuilder.IsActive() == false then
+        UI.DataError("Invalid type name returned by GetCivilizationTypeName");
+      end
     end
 
     -- RELIGION ICON
@@ -2032,6 +2036,7 @@ function CityBanner:UpdateInfo( pCity : table )
       local majorityReligionColor:number = UI.GetColorValue(GameInfo.Religions[eMajorityReligion].Color);
       instance.Icon:SetColor(majorityReligionColor and majorityReligionColor or COLOR_HOLY_SITE);
       instance.Icon:SetIcon("ICON_" .. GameInfo.Religions[eMajorityReligion].ReligionType);
+      instance.Button:SetTexture("Banner_TypeSlot_Religion");
       instance.Button:SetToolTipString(Locale.Lookup("LOC_HUD_CITY_RELIGION_TT", Game.GetReligion():GetName(eMajorityReligion)));
       instance.Button:RegisterCallback( Mouse.eLClick, OnReligionIconClicked );
       instance.Button:SetVoid1(playerID);
@@ -2060,6 +2065,7 @@ function CityBanner:UpdateInfo( pCity : table )
         local instance:table = self.m_InfoIconIM:GetInstance();
         instance.Icon:SetIcon("ICON_" .. GameInfo.Religions[0].ReligionType);
         instance.Icon:SetColor(COLOR_HOLY_SITE);
+        instance.Button:SetTexture("Banner_TypeSlot_Religion");
         instance.Button:SetToolTipString(Locale.Lookup("LOC_HUD_CITY_PANTHEON_TT", GameInfo.Beliefs[activePantheon].Name));
         instance.Button:RegisterCallback( Mouse.eLClick, OnReligionIconClicked );
         instance.Button:SetVoid1(playerID);
@@ -2102,196 +2108,6 @@ function CityBanner:UpdateInfo( pCity : table )
 
   self:Resize();
 end
-
--- ===========================================================================
--- function CityBanner.UpdateName( self : CityBanner )
---   if (self.m_Type == BANNERTYPE_CITY_CENTER) then
---     local pCity : table = self:GetCity();
---     if pCity ~= nil then
---       local owner     :number = pCity:GetOwner();
---       local pPlayer   :table  = Players[owner];
---       local capitalIcon :string = (pPlayer ~= nil and pPlayer:IsMajor() and pCity:IsCapital()) and "[ICON_Capital]" or "";
---       local cityName    :string = capitalIcon .. Locale.ToUpper(pCity:GetName());
-
---       if not self:IsTeam() then
---         local civType:string = PlayerConfigurations[owner]:GetCivilizationTypeName();
---         if civType ~= nil then
---           self.m_Instance.CivIcon:SetIcon("ICON_" .. civType);
---         else
---           UI.DataError("Invalid type name returned by GetCivilizationTypeName");
---         end
---       end
-
---       local questsManager : table = Game.GetQuestsManager();
---       local questTooltip  : string = Locale.Lookup("LOC_CITY_STATES_QUESTS");
---       local statusString  : string = "";
---       if (questsManager ~= nil) then
---         for questInfo in GameInfo.Quests() do
---           if (questsManager:HasActiveQuestFromPlayer(Game.GetLocalPlayer(), owner, questInfo.Index)) then
---             statusString = "[ICON_CityStateQuest]";
---             questTooltip = questTooltip .. "[NEWLINE]" .. questInfo.IconString .. questsManager:GetActiveQuestName(Game.GetLocalPlayer(), owner, questInfo.Index);
---           end
---         end
---       end
-
---       -- Update under siege icon
---       local pDistrict:table = self:GetDistrict();
---       if pDistrict and pDistrict:IsUnderSiege() then
---         self.m_Instance.CityUnderSiegeIcon:SetHide(false);
---       else
---         self.m_Instance.CityUnderSiegeIcon:SetHide(true);
---       end
-
---       -- Update district icons
---       -- districtType:number == Index
---       function GetDistrictIndexSafe(sDistrict)
---         if GameInfo.Districts[sDistrict] == nil then return -1;
---         else return GameInfo.Districts[sDistrict].Index; end
---       end
-
---       local iAquaduct = GetDistrictIndexSafe("DISTRICT_AQUEDUCT");
---       local iBath = GetDistrictIndexSafe("DISTRICT_BATH");
---       local iNeighborhood = GetDistrictIndexSafe("DISTRICT_NEIGHBORHOOD");
---       local iMbanza = GetDistrictIndexSafe("DISTRICT_MBANZA");
---       local iCampus = GetDistrictIndexSafe("DISTRICT_CAMPUS");
---       local iTheater = GetDistrictIndexSafe("DISTRICT_THEATER");
---       local iAcropolis = GetDistrictIndexSafe("DISTRICT_ACROPOLIS");
---       local iIndustrial = GetDistrictIndexSafe("DISTRICT_INDUSTRIAL_ZONE");
---       local iHansa = GetDistrictIndexSafe("DISTRICT_HANSA");
---       local iCommerce = GetDistrictIndexSafe("DISTRICT_COMMERCIAL_HUB");
---       local iEncampment = GetDistrictIndexSafe("DISTRICT_ENCAMPMENT");
---       local iHarbor = GetDistrictIndexSafe("DISTRICT_HARBOR");
---       local iRoyalNavy = GetDistrictIndexSafe("DISTRICT_ROYAL_NAVY_DOCKYARD");
---       local iSpaceport = GetDistrictIndexSafe("DISTRICT_SPACEPORT");
---       local iEntertainmentComplex = GetDistrictIndexSafe("DISTRICT_ENTERTAINMENT_COMPLEX");
---       local iHolySite = GetDistrictIndexSafe("DISTRICT_HOLY_SITE");
---       local iAerodrome = GetDistrictIndexSafe("DISTRICT_AERODROME");
---       local iStreetCarnival = GetDistrictIndexSafe("DISTRICT_STREET_CARNIVAL");
---       local iLavra = GetDistrictIndexSafe("DISTRICT_LAVRA");
-
---       if self.m_Instance.CityBuiltDistrictAquaduct ~= nil then
---         self.m_Instance.CityUnlockedCitizen:SetHide(true);
---         self.m_Instance.CityBuiltDistrictAquaduct:SetHide(true);
---         self.m_Instance.CityBuiltDistrictBath:SetHide(true);
---         self.m_Instance.CityBuiltDistrictNeighborhood:SetHide(true);
---         self.m_Instance.CityBuiltDistrictMbanza:SetHide(true);
---         self.m_Instance.CityBuiltDistrictCampus:SetHide(true);
---         self.m_Instance.CityBuiltDistrictCommercial:SetHide(true);
---         self.m_Instance.CityBuiltDistrictEncampment:SetHide(true);
---         self.m_Instance.CityBuiltDistrictTheatre:SetHide(true);
---         self.m_Instance.CityBuiltDistrictAcropolis:SetHide(true);
---         self.m_Instance.CityBuiltDistrictIndustrial:SetHide(true);
---         self.m_Instance.CityBuiltDistrictHansa:SetHide(true);
---         self.m_Instance.CityBuiltDistrictHarbor:SetHide(true);
---         self.m_Instance.CityBuiltDistrictRoyalNavy:SetHide(true);
---         self.m_Instance.CityBuiltDistrictSpaceport:SetHide(true);
---         self.m_Instance.CityBuiltDistrictEntertainment:SetHide(true);
---         self.m_Instance.CityBuiltDistrictHoly:SetHide(true);
---         self.m_Instance.CityBuiltDistrictAerodrome:SetHide(true);
---         self.m_Instance.CityBuiltDistrictStreetCarnival:SetHide(true);
---         self.m_Instance.CityBuiltDistrictLavra:SetHide(true);
---       end
-
---       local pCityDistricts:table  = pCity:GetDistricts();
---       if g_smartbanner and self.m_Instance.CityBuiltDistrictAquaduct ~= nil then
---         --Unlocked citizen check
---         if g_smartbanner_unmanaged_citizen then
---           local tParameters :table = {};
---           tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-
---           local tResults  :table = CityManager.GetCommandTargets( pCity, CityCommandTypes.MANAGE, tParameters );
---           if tResults ~= nil then
---             local tPlots    :table = tResults[CityCommandResults.PLOTS];
---             local tUnits    :table = tResults[CityCommandResults.CITIZENS];
---             local tMaxUnits   :table = tResults[CityCommandResults.MAX_CITIZENS];
---             local tLockedUnits  :table = tResults[CityCommandResults.LOCKED_CITIZENS];
---             if tPlots ~= nil and (table.count(tPlots) > 0) then
---               for i,plotId in pairs(tPlots) do
---                 local kPlot :table = Map.GetPlotByIndex(plotId);
---                 if (tMaxUnits[i] >= 1 and tUnits[i] >= 1 and tLockedUnits[i] <= 0) then
---                   self.m_Instance.CityUnlockedCitizen:SetHide(false);
---                 end
---               end
---             end
---           end
---         end
---         -- End Unlocked Citizen Check
-
---         if g_smartbanner_districts then
---           for i, district in pCityDistricts:Members() do
---             local districtType = district:GetType();
---             local districtInfo:table = GameInfo.Districts[districtType];
---             local isBuilt = pCityDistricts:HasDistrict(districtInfo.Index, true);
---             if isBuilt then
---               if (districtType == iAquaduct) then self.m_Instance.CityBuiltDistrictAquaduct:SetHide(false); end
---               if (districtType == iBath) then self.m_Instance.CityBuiltDistrictBath:SetHide(false); end
---               if (districtType == iNeighborhood) then self.m_Instance.CityBuiltDistrictNeighborhood:SetHide(false); end
---               if (districtType == iMbanza) then self.m_Instance.CityBuiltDistrictMbanza:SetHide(false); end
---               if (districtType == iCampus) then self.m_Instance.CityBuiltDistrictCampus:SetHide(false); end
---               if (districtType == iCommerce) then self.m_Instance.CityBuiltDistrictCommercial:SetHide(false); end
---               if (districtType == iEncampment) then self.m_Instance.CityBuiltDistrictEncampment:SetHide(false); end
---               if (districtType == iTheater) then self.m_Instance.CityBuiltDistrictTheatre:SetHide(false); end
---               if (districtType == iAcropolis) then self.m_Instance.CityBuiltDistrictAcropolis:SetHide(false); end
---               if (districtType == iIndustrial) then self.m_Instance.CityBuiltDistrictIndustrial:SetHide(false); end
---               if (districtType == iHansa) then self.m_Instance.CityBuiltDistrictHansa:SetHide(false); end
---               if (districtType == iHarbor) then self.m_Instance.CityBuiltDistrictHarbor:SetHide(false); end
---               if (districtType == iRoyalNavy) then self.m_Instance.CityBuiltDistrictRoyalNavy:SetHide(false); end
---               if (districtType == iSpaceport) then self.m_Instance.CityBuiltDistrictSpaceport:SetHide(false); end
---               if (districtType == iEntertainmentComplex) then self.m_Instance.CityBuiltDistrictEntertainment:SetHide(false); end
---               if (districtType == iHolySite) then self.m_Instance.CityBuiltDistrictHoly:SetHide(false); end
---               if (districtType == iAerodrome) then self.m_Instance.CityBuiltDistrictAerodrome:SetHide(false); end
---               if (districtType == iStreetCarnival) then self.m_Instance.CityBuiltDistrictStreetCarnival:SetHide(false); end
---               if (districtType == iLavra) then self.m_Instance.CityBuiltDistrictLavra:SetHide(false); end
---             end
---           end
---         end
---       end
-
---       -- Update insufficient housing icon
---       if self.m_Instance.CityHousingInsufficientIcon ~= nil then
---         local pCityGrowth:table = pCity:GetGrowth();
---         if pCityGrowth and pCityGrowth:GetHousing() < pCity:GetPopulation() then
---           self.m_Instance.CityHousingInsufficientIcon:SetHide(false);
---         else
---           self.m_Instance.CityHousingInsufficientIcon:SetHide(true);
---         end
---       end
-
---       -- Update insufficient amenities icon
---       if self.m_Instance.CityAmenitiesInsufficientIcon ~= nil then
---         local pCityGrowth:table = pCity:GetGrowth();
---         if pCityGrowth and pCityGrowth:GetAmenitiesNeeded() > pCityGrowth:GetAmenities() then
---           self.m_Instance.CityAmenitiesInsufficientIcon:SetHide(false);
---         else
---           self.m_Instance.CityAmenitiesInsufficientIcon:SetHide(true);
---         end
---       end
-
---       -- Update occupied icon
---       if self.m_Instance.CityOccupiedIcon ~= nil then
---         if pCity:IsOccupied() then
---           self.m_Instance.CityOccupiedIcon:SetHide(false);
---         else
---           self.m_Instance.CityOccupiedIcon:SetHide(true);
---         end
---       end
-
---       -- CQUI: Show leader icon for the suzerain
---       local pPlayerConfig :table = PlayerConfigurations[owner];
---       local isMinorCiv :boolean = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
---       if isMinorCiv then
---         CQUI_UpdateSuzerainIcon(pPlayer, self);
---       end
-
---       self.m_Instance.CityQuestIcon:SetToolTipString(questTooltip);
---       self.m_Instance.CityQuestIcon:SetText(statusString);
---       self.m_Instance.CityName:SetText( cityName );
---       self.m_Instance.CityNameStack:ReprocessAnchoring();
---       self.m_Instance.ContentStack:ReprocessAnchoring();
---       self:Resize();
---     end
---   end
--- end
 
 -- ===========================================================================
 function CityBanner:UpdateReligion()
@@ -2560,9 +2376,9 @@ end
 function SpawnHolySiteIconAtLocation( locX : number, locY:number, label:string )
   local iconInst:table = m_HolySiteIconsIM:GetInstance();
 
-  local xOffset:number = -4;    --offset to center UI element on tile
-  local yOffset:number = 4; --offset to center UI element on tile
-  local zOffset:number = 10;    --offset for 3D world view
+  local xOffset:number = -4;  --offset to center UI element on tile
+  local yOffset:number = 4;   --offset to center UI element on tile
+  local zOffset:number = 10;  --offset for 3D world view
   if (UI.GetWorldRenderView() == WorldRenderView.VIEW_2D) then
     zOffset = 0;
   end
@@ -2690,7 +2506,7 @@ function CityBanner:UpdateLoyalty()
                   instance.LineTitle:SetText(hasBeenMet and civName or Locale.Lookup("LOC_LOYALTY_PANEL_UNMET_CIV"));
                   instance.LineValue:SetText(lineVal);
 
-                  local civIconManager = CivilizationIcon:AttachInstance(instance.CivilizationIcon);
+                  local civIconManager :object = CivilizationIcon:AttachInstance(instance.CivilizationIcon);
                   civIconManager:UpdateIconFromPlayerID(playerPresence.Player);
                 end
               end
@@ -2851,9 +2667,9 @@ function OnRefreshBannerPositions()
           isVisChange = true;
         end
 
-        local bannerInstance = GetCityBanner( playerID, cityID );
-        if (bannerInstance ~= nil) then
-          bannerInstance:UpdatePosition( bannerInstance );
+        local cityBanner:table = GetCityBanner( playerID, cityID );
+        if (cityBanner ~= nil) then
+          cityBanner:UpdatePosition();
         end
       end
       local playerDistricts = players[i]:GetDistricts();
@@ -2954,7 +2770,6 @@ function OnDistrictRangeStrikeButtonClick( playerID, districtID )
   UI.LookAtPlot(pDistrict:GetX(), pDistrict:GetY());
   UI.SetInterfaceMode(InterfaceModeTypes.DISTRICT_RANGE_ATTACK);
 end
-
 LuaEvents.CQUI_DistrictRangeStrike.Add( OnDistrictRangeStrikeButtonClick ); -- AZURENCY : to acces it in the actionpannel on the district range attack button
 
 -- ===========================================================================
@@ -3030,7 +2845,8 @@ function OnCityAddedToMap( playerID: number, cityID : number, cityX : number, ci
   if (CityBannerInstances[ playerID ] ~= nil and
       CityBannerInstances[ playerID ][ cityID ] ~= nil) then
       return;
-    end
+  end
+
   AddCityBannerToMap( playerID, cityID );
 end
 
@@ -3257,16 +3073,17 @@ function OnImprovementVisibilityChanged( locX :number, locY :number, eImprovemen
   if (eImprovementType == -1) then
     return;
   end
+  local data:table = GameInfo.Improvements[eImprovementType];
   -- We're only interested in the Airstrip or Missile Silo improvements
-  if (GameInfo.Improvements[eImprovementType].AirSlots > 0 or GameInfo.Improvements[eImprovementType].WeaponSlots > 0) then
-    local plotID = Map.GetPlotIndex(locX, locY);
+  if (data.AirSlots > 0 or data.WeaponSlots > 0) then
+    local plotID:number = Map.GetPlotIndex(locX, locY);
     if (plotID > 0) then
       local plot = Map.GetPlotByIndex(plotID);
       if (plot ~= nil) then
-        local x = plot:GetX();
-        local y = plot:GetY();
-        local playerID = plot:GetImprovementOwner();
-        local bannerInstance = GetMiniBanner( playerID, plotID );
+        local x             :number = plot:GetX();
+        local y             :number = plot:GetY();
+        local playerID      :number = plot:GetImprovementOwner();
+        local bannerInstance:table = GetMiniBanner( playerID, plotID );
         if (bannerInstance ~= nil) then
           bannerInstance:SetFogState( eVisibility );
         end
@@ -3881,11 +3698,15 @@ end
 -- ===========================================================================
 function OnEventPlaybackComplete()
   if m_DelayedUpdate.UpdateAll == true then
+    local bUpdateLoyalty = m_DelayedUpdate.UpdateLoyalty == true or false;
     for _, playerBannerInstances in pairs(CityBannerInstances) do
       for id, banner in pairs(playerBannerInstances) do
         if (banner ~= nil and banner:IsVisible()) then
           -- Always update the stats
           banner:UpdateStats();
+          if bUpdateLoyalty == true then
+            banner:UpdateLoyalty();
+          end
         end
       end
     end
@@ -3905,7 +3726,6 @@ end
 
 ----------------------------------------------------------------
 function OnLocalPlayerChanged( localPlayerID:number , prevLocalPlayerID:number )
-
   -- Hide all the flags, we will get updates later
   for _, playerBannerInstances in pairs(CityBannerInstances) do
     for id, banner in pairs(playerBannerInstances) do
@@ -3965,7 +3785,6 @@ end
 function OnObjectPairingChanged(eSubType, parentOwner, parentType, parentID, childOwner, childType, childID)
   local pPlayer = Players[ parentOwner ];
   if (pPlayer ~= nil) then
-
     local bannerInstance = GetCityBanner( parentOwner, parentID );
     if (bannerInstance ~= nil) then
       bannerInstance:UpdateStats( bannerInstance );
@@ -4119,7 +3938,7 @@ end
 --  or when a player explicitly turns off the layer from the "player" lens.
 -- ===========================================================================
 function OnLensLayerOff( layerNum:number )
-  if    layerNum == m_HexColoringReligion then
+  if  layerNum == m_HexColoringReligion then
     m_isReligionLensActive = false;
     RealizeReligion();
   elseif layerNum == m_CulturalIdentityLens then
@@ -4248,15 +4067,10 @@ end
 
 -- ===========================================================================
 function OnGovernorAssigned( playerID: number, governorID: number, cityOwner: number, cityID: number )
-  local cityBanner:table = GetCityBanner(cityOwner, cityID);
-  for _, playerBannerInstances in pairs(CityBannerInstances) do
-    for id, banner in pairs(playerBannerInstances) do
-      if (banner ~= nil and banner:IsVisible()) then
-        banner:UpdateStats();
-        banner:UpdateLoyalty();
-      end
-    end
-  end
+  -- Set some flags for a delayed update when the events are finsihed publishing.
+  m_DelayedUpdate.UpdateAll = true;
+  m_DelayedUpdate.ReligionChanged = true;
+  m_DelayedUpdate.UpdateLoyalty = true;
 end
 
 -- ===========================================================================
@@ -4275,13 +4089,12 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
   local kCityPlots :table = Map.GetCityPlots():GetPurchasedPlots(pCity);
   if kCityPlots ~= nil then
     for _, plotID in pairs(kCityPlots) do
-      local kPlot   :table = Map.GetPlotByIndex(plotID);
+      local kPlot :table = Map.GetPlotByIndex(plotID);
       if Map.GetPlotDistance( pCity:GetX(), pCity:GetY(), kPlot:GetX(), kPlot:GetY() ) <= 3 then
         local eImprovementType :number = kPlot:GetImprovementType();
         if eImprovementType ~= -1 then
           if not kPlot:IsImprovementPillaged() then
             local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
-  
             if kImprovementData == 1 then    -- farms, pastures etc.
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
             elseif kImprovementData == 2 then    -- stepwells, kampungs, mekewaps, golf courses
@@ -4317,7 +4130,7 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
         end
       end
     end
-  
+
     CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
     if CQUI_HousingFromImprovementsTable[PlayerID] == nil then
       CQUI_HousingFromImprovementsTable[PlayerID] = {};
@@ -4388,6 +4201,7 @@ function Initialize()
   Events.CityNameChanged.Add(         OnCityNameChange );
   Events.CityProductionQueueChanged.Add(  OnCityProductionChanged);
   Events.CityProductionUpdated.Add(       OnCityProductionUpdate);
+  Events.CityProductionChanged.Add(       OnCityProductionChanged);
   Events.CityProductionCompleted.Add(     OnCityProductionCompleted);
   Events.CityReligionChanged.Add(         OnCityReligionChanged );
   Events.CityReligionFollowersChanged.Add(OnCityReligionChanged );

--- a/Assets/Expansion1/CityBanners/citybannermanager.lua
+++ b/Assets/Expansion1/CityBanners/citybannermanager.lua
@@ -20,6 +20,7 @@ BANNERTYPE_ENCAMPMENT     = 1;
 BANNERTYPE_AERODROME      = 2;
 BANNERTYPE_MISSILE_SILO   = 3;
 BANNERTYPE_OTHER_DISTRICT = 4;
+
 -- ===========================================================================
 --  CONSTANTS
 -- ===========================================================================
@@ -539,7 +540,7 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
     end
 
     if self.m_DetailEffectsIM == nil then
-      self.m_DetailEffectsIM = InstanceManager:new( "CityDetailEffect", "Button", self.m_Instance.CityDetailsEffects );
+      self.m_DetailEffectsIM = InstanceManager:new( "CityDetailEffect", "Icon", self.m_Instance.CityDetailsEffects );
     end
 
     if self.m_InfoIconIM == nil then

--- a/Assets/Expansion2/CityBanners/citybannermanager.lua
+++ b/Assets/Expansion2/CityBanners/citybannermanager.lua
@@ -1,5 +1,5 @@
 -- ===========================================================================
---  City Banner Manager
+--  City Banner Manager (Expansion 2)
 -- ===========================================================================
 
 include( "CivilizationIcon" );
@@ -15,25 +15,25 @@ include( "CitySupport" );
 -- ===========================================================================
 CityBanner = {};
 
-BANNERTYPE_CITY_CENTER		= 0;
-BANNERTYPE_ENCAMPMENT		= 1;
-BANNERTYPE_AERODROME		= 2;
-BANNERTYPE_MISSILE_SILO		= 3;
-BANNERTYPE_OTHER_DISTRICT	= 4;
-BANNERTYPE_MOUNTAIN_TUNNEL	= 5;
-BANNERTYPE_QHAPAQ_NAN		= 6;
+BANNERTYPE_CITY_CENTER    = 0;
+BANNERTYPE_ENCAMPMENT     = 1;
+BANNERTYPE_AERODROME      = 2;
+BANNERTYPE_MISSILE_SILO   = 3;
+BANNERTYPE_OTHER_DISTRICT = 4;
+BANNERTYPE_MOUNTAIN_TUNNEL= 5;
+BANNERTYPE_QHAPAQ_NAN     = 6;
 
 -- ===========================================================================
 --  CONSTANTS
 -- ===========================================================================
 
-local ANIM_SPEED_RELIGION_CHANGE      :number = 1;
-local COLOR_CITY_GREEN						:number	= UI.GetColorValueFromHexLiteral(0xFF4CE710);
-local COLOR_CITY_RED						:number	= UI.GetColorValueFromHexLiteral(0xFF0101F5);
-local COLOR_CITY_YELLOW						:number	= UI.GetColorValueFromHexLiteral(0xFF2DFFF8);
-local COLOR_HOLY_SITE						:number = UI.GetColorValueFromHexLiteral(0xFFFFFFFF);
-local COLOR_NO_MAJOR_RELIGION				:number = UI.GetColorValueFromHexLiteral(0x00000000);
-local COLOR_RELIGION_DEFAULT				:number = UI.GetColorValueFromHexLiteral(0x02000000);
+local ANIM_SPEED_RELIGION_CHANGE :number = 1;
+local COLOR_CITY_GREEN           :number = UI.GetColorValueFromHexLiteral(0xFF4CE710);
+local COLOR_CITY_RED             :number = UI.GetColorValueFromHexLiteral(0xFF0101F5);
+local COLOR_CITY_YELLOW          :number = UI.GetColorValueFromHexLiteral(0xFF2DFFF8);
+local COLOR_HOLY_SITE            :number = UI.GetColorValueFromHexLiteral(0xFFFFFFFF);
+local COLOR_NO_MAJOR_RELIGION    :number = UI.GetColorValueFromHexLiteral(0x00000000);
+local COLOR_RELIGION_DEFAULT     :number = UI.GetColorValueFromHexLiteral(0x02000000);
 
 -- LOYALTY
 local PRESSURE_BREAKDOWN_TYPE_POPULATION_PRESSURE :string = "PopulationPressure";
@@ -53,33 +53,33 @@ local DATA_FIELD_RELIGION_FOLLOWER_LIST_IM  :string = "m_FollowerListIM";
 local DATA_FIELD_RELIGION_POP_CHART_IM      :string = "m_PopChartIM";
 local DATA_FIELD_PRODUCTION_CLICK_CALLBACK  :string = "m_ProductionClickCallback";
 
-local RELIGION_POP_CHART_TOOLTIP_HEADER		:string = Locale.Lookup("LOC_CITY_BANNER_FOLLOWER_PRESSURE_TOOLTIP_HEADER");
+local RELIGION_POP_CHART_TOOLTIP_HEADER     :string = Locale.Lookup("LOC_CITY_BANNER_FOLLOWER_PRESSURE_TOOLTIP_HEADER");
 
-local ICON_HOLY_SITE      :string = "Faith";
-local ICON_PRESSURE_DOWN    :string = "PressureDown";
-local ICON_PRESSURE_UP      :string = "PressureUp";
-local MINIMUM_BANNER_WIDTH    :number = 186;
-local PLOT_HIDDEN       :number = 0;
-local PLOT_REVEALED       :number = 1;
-local PLOT_VISIBLE        :number = 2;
-local PRESSURE_THRESHOLD_HIGH :number = 400;
+local ICON_HOLY_SITE            :string = "Faith";
+local ICON_PRESSURE_DOWN        :string = "PressureDown";
+local ICON_PRESSURE_UP          :string = "PressureUp";
+local MINIMUM_BANNER_WIDTH      :number = 186;
+local PLOT_HIDDEN               :number = 0;
+local PLOT_REVEALED             :number = 1;
+local PLOT_VISIBLE              :number = 2;
+local PRESSURE_THRESHOLD_HIGH   :number = 400;
 local PRESSURE_THRESHOLD_MEDIUM :number = 200;
-local PADDING_FOLLOWERS_BG    :number = 0;
-local RELIGION_PRESSURE     :table = {
+local PADDING_FOLLOWERS_BG      :number = 0;
+local RELIGION_PRESSURE         :table = {
   NONE  = 0,
   LOW   = 1,
   MEDIUM  = 2,
   HIGH  = 3
 };
-local SIZE_HOLY_SITE_ICON   :number = 22;
+local SIZE_HOLY_SITE_ICON       :number = 22;
 local SIZE_RELIGION_ICON_LARGE  :number = 100;
 local SIZE_RELIGION_ICON_SMALL  :number = 22;
-local ALPHA_DIM         :number = 0.45;
+local ALPHA_DIM                 :number = 0.45;
 
-local YOFFSET_2DVIEW           :number = 26;
-local ZOFFSET_3DVIEW           :number = 36;
-local SIZEOFPOPANDPROD         :number = 80;	--The amount to add to the city banner to account for the size of the production icon and population number
-local SIZEOFPOPANDPRODMETERS   :number = 15;	--The amount to add to the city banner backing width to allow for the production and population meters to appear
+local YOFFSET_2DVIEW            :number = 26;
+local ZOFFSET_3DVIEW            :number = 36;
+local SIZEOFPOPANDPROD          :number = 80;    --The amount to add to the city banner to account for the size of the production icon and population number
+local SIZEOFPOPANDPRODMETERS    :number = 15;    --The amount to add to the city banner backing width to allow for the production and population meters to appear
 
 local BANNERSTYLE_LOCAL_TEAM    :number = 0;
 local BANNERSTYLE_OTHER_TEAM    :number = 1;
@@ -90,8 +90,8 @@ local m_isReligionLensActive    :boolean = false;
 local m_isLoyaltyLensActive     :boolean = false;
 local m_isTradeSelectionActive  :boolean = false;
 
-local m_refreshLocalPlayerRangeStrike:boolean = false;
-local m_refreshLocalPlayerProduction:boolean = false;
+local m_refreshLocalPlayerRangeStrike :boolean = false;
+local m_refreshLocalPlayerProduction  :boolean = false;
 
 local m_DelayedUpdate : table = {};
 
@@ -110,11 +110,11 @@ local m_TunnelBannerIM      :table = InstanceManager:new( "TunnelBanner",     "A
 local m_QhapaqNanBannerIM   :table = InstanceManager:new( "QhapaqNanBanner",  "Anchor", Controls.CityBanners );
 local m_HolySiteIconsIM     :table = InstanceManager:new( "HolySiteIcon",     "Anchor", Controls.CityDistrictIcons );
 
-local m_HexColoringReligion : number = UILens.CreateLensLayerHash("Hex_Coloring_Religion");
-local m_LoyaltyFreeCityWarning : number = UILens.CreateLensLayerHash("Loyalty_FreeCity_Warning");
-local m_CulturalIdentityLens : number = UILens.CreateLensLayerHash("Cultural_Identity_Lens");
-local m_CityDetailsLens : number = UILens.CreateLensLayerHash("City_Details");
-local m_EmpireDetailsLens : number = UILens.CreateLensLayerHash("Empire_Details");
+local m_HexColoringReligion    :number = UILens.CreateLensLayerHash("Hex_Coloring_Religion");
+local m_LoyaltyFreeCityWarning :number = UILens.CreateLensLayerHash("Loyalty_FreeCity_Warning");
+local m_CulturalIdentityLens   :number = UILens.CreateLensLayerHash("Cultural_Identity_Lens");
+local m_CityDetailsLens        :number = UILens.CreateLensLayerHash("City_Details");
+local m_EmpireDetailsLens      :number = UILens.CreateLensLayerHash("Empire_Details");
 
 -- ===========================================================================
 --  CQUI
@@ -128,25 +128,26 @@ local CQUI_HousingUpdated :table = {};
 local CQUI_ShowYieldsOnCityHover = false;
 local CQUI_PlotIM        :table = InstanceManager:new( "CQUI_WorkedPlotInstance", "Anchor", Controls.CQUI_WorkedPlotContainer );
 local CQUI_uiWorldMap    :table = {};
-local CQUI_yieldsOn    :boolean = false;
-local CQUI_Hovering :boolean = false;
+local CQUI_yieldsOn      :boolean = false;
+local CQUI_Hovering      :boolean = false;
 local CQUI_NextPlot4Away :number = nil;
 
-local CQUI_ShowCitizenIconsOnCityHover:boolean = false;
-local CQUI_ShowCityManageAreaOnCityHover:boolean = true;
-local CQUI_CityManageAreaShown:boolean = false;
-local CQUI_CityManageAreaShouldShow:boolean = false;
+local CQUI_ShowCitizenIconsOnCityHover   :boolean = false;
+local CQUI_ShowCityManageAreaOnCityHover :boolean = true;
+local CQUI_CityManageAreaShown           :boolean = false;
+local CQUI_CityManageAreaShouldShow      :boolean = false;
 
-local CQUI_WorkIconSize: number = 48;
-local CQUI_WorkIconAlpha = .60;
-local CQUI_SmartWorkIcon: boolean = true;
-local CQUI_SmartWorkIconSize: number = 64;
-local CQUI_SmartWorkIconAlpha = .45;
-local g_smartbanner = true;
+local CQUI_WorkIconSize      :number = 48;
+local CQUI_WorkIconAlpha              = 0.60;
+local CQUI_SmartWorkIcon     :boolean = true;
+local CQUI_SmartWorkIconSize :number  = 64;
+local CQUI_SmartWorkIconAlpha         = 0.45;
+local g_smartbanner                   = true;
 
-local CQUI_CityYields : number = UILens.CreateLensLayerHash("City_Yields");
-local CQUI_CitizenManagement : number = UILens.CreateLensLayerHash("Citizen_Management");
+local CQUI_CityYields        :number = UILens.CreateLensLayerHash("City_Yields");
+local CQUI_CitizenManagement :number = UILens.CreateLensLayerHash("Citizen_Management");
 
+-- ============================================================================
 function CQUI_OnSettingsInitialized()
   CQUI_ShowYieldsOnCityHover = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
   g_smartbanner = GameConfiguration.GetValue("CQUI_Smartbanner");
@@ -165,6 +166,7 @@ function CQUI_OnSettingsInitialized()
   CQUI_ShowCityManageAreaInScreen = GameConfiguration.GetValue("CQUI_ShowCityMangeAreaInScreen")
 end
 
+-- ============================================================================
 function CQUI_OnSettingsUpdate()
   CQUI_OnSettingsInitialized();
   Reload();
@@ -185,6 +187,7 @@ function GetCityBanner( playerID:number, cityID:number )
   if (CityBannerInstances[playerID] == nil) then
     return;
   end
+
   return CityBannerInstances[playerID][cityID];
 end
 -- ===========================================================================
@@ -192,6 +195,7 @@ function GetMiniBanner( playerID:number, districtID:number )
   if (MiniBannerInstances[playerID] == nil) then
     return;
   end
+
   return MiniBannerInstances[playerID][districtID];
 end
 
@@ -199,7 +203,6 @@ end
 -- Constructor
 -- ===========================================================================
 function CityBanner:new( playerID: number, cityID : number, districtID : number, bannerType : number, bannerStyle : number )
-
   if bannerStyle == nil then 
     UI.DataError("Missing bannerStyle: "..tostring(playerID)..", "..tostring(cityID)..", "..tostring(districtID)..", "..tostring(bannerType) ); 
   end
@@ -212,11 +215,13 @@ function CityBanner:new( playerID: number, cityID : number, districtID : number,
     if (CityBannerInstances[playerID] == nil) then
       CityBannerInstances[playerID] = {};
     end
+
     CityBannerInstances[playerID][cityID] = oNewCityBanner;
   else
     if (MiniBannerInstances[playerID] == nil) then
       MiniBannerInstances[playerID] = {};
     end
+
     MiniBannerInstances[playerID][districtID] = oNewCityBanner;
   end
 
@@ -233,27 +238,35 @@ function CityBanner:Uninitialize()
   if self.m_DetailStatusIM then
     self.m_DetailStatusIM:DestroyInstances();
   end
+
   if self.m_DetailEffectsIM then
     self.m_DetailEffectsIM:DestroyInstances();
   end
+
   if self.m_InfoIconIM then
     self.m_InfoIconIM:DestroyInstances();
   end
+
   if self.m_InfoConditionIM then
     self.m_InfoConditionIM:DestroyInstances();
   end
+
   if self.m_StatGovernorIM then
     self.m_StatGovernorIM:DestroyInstances();
   end
+
   if self.m_StatPopulationIM then
     self.m_StatPopulationIM:DestroyInstances();
   end
+
   if self.m_StatProductionIM then
     self.m_StatProductionIM:DestroyInstances();
   end
+
   if self.m_LoyaltyBreakdownIM then
     self.m_LoyaltyBreakdownIM:DestroyInstances();
   end
+
   if self.m_eLoyaltyWarningPlayer ~= -1 then
     local plot = Map.GetPlotIndex(self.m_PlotX, self.m_PlotY);
     UILens.ClearHex( m_LoyaltyFreeCityWarning, plot);
@@ -276,8 +289,7 @@ end
 -- CQUI -- When a banner is moused over, display the relevant yields and next culture plot
 function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
-  if(CQUI_ShowYieldsOnCityHover) then
-
+  if (CQUI_ShowYieldsOnCityHover) then
     CQUI_Hovering = true;
 
     -- Astog: Fix for lens being shown when other lenses are on.
@@ -292,7 +304,7 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
     local kPlayer = Players[playerID];
     local kCities = kPlayer:GetCities();
-    local kCity = kCities:FindID(cityID);
+    local kCity   = kCities:FindID(cityID);
 
     local tParameters :table = {};
     tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
@@ -305,20 +317,19 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
       return;
     end
 
-    local tPlots    :table = tResults[CityCommandResults.PLOTS];
-    local tUnits    :table = tResults[CityCommandResults.CITIZENS];
-    local tMaxUnits   :table = tResults[CityCommandResults.MAX_CITIZENS];
-    local tLockedUnits  :table = tResults[CityCommandResults.LOCKED_CITIZENS];
+    local tPlots       :table = tResults[CityCommandResults.PLOTS];
+    local tUnits       :table = tResults[CityCommandResults.CITIZENS];
+    local tMaxUnits    :table = tResults[CityCommandResults.MAX_CITIZENS];
+    local tLockedUnits :table = tResults[CityCommandResults.LOCKED_CITIZENS];
 
-    local pCityCulture          :table  = kCity:GetCulture();
-    local pNextPlotID           :number = pCityCulture:GetNextPlot();
-    local TurnsUntilExpansion   :number = pCityCulture:GetTurnsUntilExpansion();
+    local pCityCulture        :table  = kCity:GetCulture();
+    local pNextPlotID         :number = pCityCulture:GetNextPlot();
+    local TurnsUntilExpansion :number = pCityCulture:GetTurnsUntilExpansion();
 
-    local yields :table = {};
+    local yields      :table = {};
     local yieldsIndex :table = {};
 
-    if (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(CQUI_CitizenManagement) == false then
-
+    if (tPlots ~= nil and table.count(tPlots) ~= 0) and (UILens.IsLayerOn(CQUI_CitizenManagement) == false) then
       CQUI_yieldsOn = UserConfiguration.ShowMapYield();
 
       for i,plotId in pairs(tPlots) do
@@ -334,7 +345,7 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
           if workerCount > 0 and kPlot:IsCity() == false then
             pInstance.CitizenButton:SetHide(false);
             pInstance.CitizenButton:SetTextureOffsetVal(0, 256);
-            if(CQUI_SmartWorkIcon) then
+            if (CQUI_SmartWorkIcon) then
               pInstance.CitizenButton:SetSizeVal(CQUI_SmartWorkIconSize, CQUI_SmartWorkIconSize);
               pInstance.CitizenButton:SetAlpha(CQUI_SmartWorkIconAlpha);
             else
@@ -343,9 +354,9 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
             end
           end
 
-          if(tLockedUnits[i] > 0) then
+          if (tLockedUnits[i] > 0) then
             pInstance.LockedIcon:SetHide(false);
-            if(CQUI_SmartWorkIcon) then
+            if (CQUI_SmartWorkIcon) then
               pInstance.LockedIcon:SetAlpha(CQUI_SmartWorkIconAlpha);
             else
               pInstance.LockedIcon:SetAlpha(CQUI_WorkIconAlpha);
@@ -357,9 +368,7 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
         table.insert(yields, plotId);
         yieldsIndex[index] = plotId;
-
-      end
-
+      end -- for loop
     end
 
     tResults  = CityManager.GetCommandTargets( kCity, CityCommandTypes.PURCHASE, tParameters );
@@ -370,7 +379,6 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
     tPlots    = tResults[CityCommandResults.PLOTS];
 
     if (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(CQUI_CitizenManagement) == false then
-
       for i,plotId in pairs(tPlots) do
         local kPlot :table = Map.GetPlotByIndex(plotId);
         local index:number = kPlot:GetIndex();
@@ -383,7 +391,6 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
         table.insert(yields, plotId);
         yieldsIndex[index] = plotId;
-
       end
 
       local plotCount = Map.GetPlotCount();
@@ -399,15 +406,17 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
         pInstance.CQUI_NextPlotButton:SetHide( false );
         CQUI_NextPlot4Away = pNextPlotID;
       end
-    end
-  end
+    end --i if/else
+  end --if CQUI_ShowYieldsOnCityHover true
 end
 
 -- ===========================================================================
 -- CQUI -- When a banner is moused over, and the mouse leaves the banner, remove display of the relevant yields and next culture plot
 function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
 
-  if(not CQUI_Hovering) then return; end
+  if (not CQUI_Hovering) then
+    return;
+  end
 
   CQUI_yieldsOn = UserConfiguration.ShowMapYield();
 
@@ -417,7 +426,7 @@ function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
 
   local kPlayer = Players[playerID];
   local kCities = kPlayer:GetCities();
-  local kCity = kCities:FindID(cityID);
+  local kCity   = kCities:FindID(cityID);
 
   local tParameters :table = {};
   tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
@@ -437,36 +446,31 @@ function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
     CQUI_CityManageAreaShown = false;
   end
 
-  local tPlots    :table = tResults[CityCommandResults.PLOTS];
+  local tPlots :table = tResults[CityCommandResults.PLOTS];
 
   if (tPlots ~= nil and table.count(tPlots) ~= 0) then
-
     for i,plotId in pairs(tPlots) do
       local kPlot :table = Map.GetPlotByIndex(plotId);
       local index:number = kPlot:GetIndex();
       pInstance = CQUI_ReleaseInstanceAt(index);
     end
-
   end
 
   tResults  = CityManager.GetCommandTargets( kCity, CityCommandTypes.PURCHASE, tParameters );
   tPlots    = tResults[CityCommandResults.PLOTS];
 
   if (tPlots ~= nil and table.count(tPlots) ~= 0) then
-
     for i,plotId in pairs(tPlots) do
       local kPlot :table = Map.GetPlotByIndex(plotId);
       local index:number = kPlot:GetIndex();
       pInstance = CQUI_ReleaseInstanceAt(index);
     end
-
   end
 
   if (CQUI_NextPlot4Away ~= nil) then
     pInstance = CQUI_ReleaseInstanceAt(CQUI_NextPlot4Away);
     CQUI_NextPlot4Away = nil;
   end
-
 end
 
 -- CQUI taken from PlotInfo
@@ -477,6 +481,7 @@ end
 -- ===========================================================================
 function CQUI_GetInstanceAt( plotIndex:number )
   local pInstance:table = CQUI_uiWorldMap[plotIndex];
+
   if pInstance == nil then
     pInstance = CQUI_PlotIM:GetInstance();
     CQUI_uiWorldMap[plotIndex] = pInstance;
@@ -486,12 +491,14 @@ function CQUI_GetInstanceAt( plotIndex:number )
     pInstance.CitizenButton:SetConsumeMouseButton(false);
     pInstance.Anchor:SetHide( false );
   end
+
   return pInstance;
 end
 
 -- ===========================================================================
 function CQUI_ReleaseInstanceAt( plotIndex:number)
   local pInstance :table = CQUI_uiWorldMap[plotIndex];
+
   if pInstance ~= nil then
     pInstance.Anchor:SetHide( true );
     -- Return the button to normal so that it can be clicked again
@@ -503,22 +510,21 @@ end
 
 -- ===========================================================================
 function CityBanner:Initialize( playerID: number, cityID : number, districtID : number, bannerType : number, bannerStyle : number)
-
-  self.m_Player = Players[playerID];
+  self.m_Player     = Players[playerID];
   self.m_DistrictID = districtID;
-  self.m_CityID = cityID;
+  self.m_CityID     = cityID;
 
-  self.m_Type = bannerType;
-  self.m_Style = bannerStyle;
-  self.m_IsSelected = false;
-  self.m_IsCurrentlyVisible = false;
+  self.m_Type        = bannerType;
+  self.m_Style       = bannerStyle;
+  self.m_IsSelected  = false;
   self.m_IsForceHide = false;
-  self.m_IsDimmed = false;
+  self.m_IsDimmed    = false;
   self.m_OverrideDim = false;
-  self.m_FogState = 0;
+  self.m_FogState    = 0;
   self.m_UnitListEnabled = false;
+  self.m_IsCurrentlyVisible = false;
 
-  self.m_eMajorityReligion = -1;    -- Assign default values
+  self.m_eMajorityReligion     = -1;  -- Assign default values
   self.m_eLoyaltyWarningPlayer = -1;  -- which player the city might flip to within X turns (default 20)
 
   if (bannerType == BANNERTYPE_CITY_CENTER) then
@@ -536,18 +542,23 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
     if self.m_DetailStatusIM == nil then
       self.m_DetailStatusIM = InstanceManager:new( "CityDetailStatus", "Icon", self.m_Instance.CityDetailsStatus );
     end
+
     if self.m_DetailEffectsIM == nil then
       self.m_DetailEffectsIM = InstanceManager:new( "CityDetailEffect", "Button", self.m_Instance.CityDetailsEffects );
     end
+
     if self.m_InfoIconIM == nil then
       self.m_InfoIconIM = InstanceManager:new( "CityInfoType", "Button", self.m_Instance.CityInfoStack );
     end
+
     if self.m_InfoConditionIM == nil then
       self.m_InfoConditionIM = InstanceManager:new( "CityInfoCondition", "Button", self.m_Instance.CityInfoStack );
     end
+
     if self.m_StatGovernorIM == nil then
       self.m_StatGovernorIM = InstanceManager:new( "CityStatGovernor", "Button", self.m_Instance.CityStatusStack );
     end
+
     if self.m_StatProductionIM == nil then
       self.m_StatProductionIM = InstanceManager:new( "CityStatProduction", "Button", self.m_Instance.CityStatusStack );
     end
@@ -578,7 +589,7 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
 
     -- If we're not local player, show limited population info
     if self.m_StatPopulationIM == nil then
-      self.m_StatPopulationIM	= InstanceManager:new( "CityStatPopulationLimited", "BG", self.m_Instance.CityStatusStack );
+      self.m_StatPopulationIM   = InstanceManager:new( "CityStatPopulationLimited", "BG", self.m_Instance.CityStatusStack );
     end
 
     self:UpdateReligion();
@@ -590,6 +601,7 @@ function CityBanner:Initialize( playerID: number, cityID : number, districtID : 
         loyaltyInfo.CulturalIdentityExpandedButton:SetHide(not on);
       end
     end
+
     loyaltyInfo.CulturalIdentityButton:RegisterCallback( Mouse.eLClick, toggleLoyalty(true) );
     loyaltyInfo.CulturalIdentityExpandedButton:RegisterCallback( Mouse.eLClick, toggleLoyalty(false) );
 
@@ -636,7 +648,7 @@ function CityBanner:CreateAerodromeBanner()
   if (pDistrict ~= nil) then
     self.m_PlotX = pDistrict:GetX();
     self.m_PlotY = pDistrict:GetY();
-  else	-- it's an banner not associated with a district, so the districtID should be a plot index
+  else  -- it's an banner not associated with a district, so the districtID should be a plot index
     self.m_PlotX, self.m_PlotY = Map.GetPlotLocation(self.m_DistrictID);
     self.m_IsImprovementBanner = true;
   end
@@ -654,6 +666,7 @@ function CityBanner:UpdateAerodromeBanner()
     -- Update minibanner for aerodrome
     iAirCapacity = pDistrict:GetAirSlots();
     local bHasAirUnits, tAirUnits = pDistrict:GetAirUnits();
+
     if (bHasAirUnits and tAirUnits ~= nil) then
       -- Update unit instances in unit list
       for i,unit in ipairs(tAirUnits) do
@@ -687,10 +700,11 @@ function CityBanner:UpdateAerodromeBanner()
         end
       end
     end
-  else
+  else -- pDistrict is nil
     -- Update minibanner for airstrip
     local airstripPlot = Map.GetPlotByIndex(self.m_DistrictID);
     local tAirUnits = airstripPlot:GetAirUnits();
+
     if tAirUnits then
       local eImprovement = airstripPlot:GetImprovementType();
       if (eImprovement ~= -1) then
@@ -746,7 +760,6 @@ function CityBanner:UpdateAerodromeBanner()
   end
 
   self:SetFogState( self.m_FogState );
-
   self.m_Instance.UnitListPopup:CalculateInternals();
 
   -- Adjust the scroll panel offset so stack is centered whether scrollbar is visible or not
@@ -768,7 +781,6 @@ function CityBanner:CreateWMDBanner()
   -- Set the appropriate instance factory (mini banner one) for this flag...
   self.m_InstanceManager = m_WMDBannerIM;
   self.m_Instance = self.m_InstanceManager:GetInstance();
-
   self.m_IsImprovementBanner = false;
 
   local pDistrict = self:GetDistrict();
@@ -810,6 +822,7 @@ function CityBanner:UpdateWMDBanner()
   for entry in GameInfo.WMDs() do
     if (entry.WeaponType == "WMD_NUCLEAR_DEVICE") then
       local count = playerWMDs:GetWeaponCount(entry.Index);
+
       if (count > 0) then
         -- Player has nukes
         self.m_Instance.NukeCountLabel:SetText(count);
@@ -817,7 +830,7 @@ function CityBanner:UpdateWMDBanner()
 
         -- Check if we're able to fire
         local bSiloCanFire:boolean = false;
-        if( pCity ~= nil ) then
+        if (pCity ~= nil) then
           local tParameters = {};
           tParameters[CityCommandTypes.PARAM_WMD_TYPE] = entry.Index;
           tParameters[CityCommandTypes.PARAM_X0] = self.m_PlotX;
@@ -830,7 +843,7 @@ function CityBanner:UpdateWMDBanner()
         end
 
         -- Update button state and tooltip
-        if( bSiloCanFire) then
+        if (bSiloCanFire) then
           self.m_Instance.NukeBombButton:SetDisabled(false);
           self.m_Instance.NukeBombButton:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_NUCLEAR_STRIKE_CAPABLE"));
         else
@@ -851,7 +864,7 @@ function CityBanner:UpdateWMDBanner()
 
         -- Check if we're able to fire
         local bSiloCanFire:boolean = false;
-        if( pCity ~= nil ) then
+        if (pCity ~= nil) then
           local tParameters = {};
           tParameters[CityCommandTypes.PARAM_WMD_TYPE] = entry.Index;
           tParameters[CityCommandTypes.PARAM_X0] = self.m_PlotX;
@@ -864,7 +877,7 @@ function CityBanner:UpdateWMDBanner()
         end
 
         -- Update button state and tooltip
-        if( bSiloCanFire) then
+        if (bSiloCanFire) then
           self.m_Instance.ThermoNukeBombButton:SetDisabled(false);
           self.m_Instance.ThermoNukeBombButton:SetToolTipString(Locale.Lookup("LOC_CITY_BANNER_THERMONUCLEAR_STRIKE_CAPABLE"));
         else
@@ -1075,12 +1088,8 @@ function CityBanner:Resize()
       if (newBannerSize < MINIMUM_BANNER_WIDTH) then
         newBannerSize = MINIMUM_BANNER_WIDTH;
       end
-      self.m_Instance.Container:SetSizeX(newBannerSize);
 
-      -- Inside the city strength indicator (shield) - Recentering the characters that have odd leading
-      --if(self.m_Instance.DefenseNumber:GetText() == "4" or self.m_Instance.DefenseNumber:GetText() == "6" or self.m_Instance.DefenseNumber:GetText() == "8") then
-      --	self.m_Instance.DefenseNumber:SetOffsetX(-2);
-      --end
+      self.m_Instance.Container:SetSizeX(newBannerSize);
     end
   end
 end
@@ -1089,7 +1098,7 @@ end
 -- Assign player colors to the appropriate banner elements
 function CityBanner:UpdateColor()
 
-  local backColor, frontColor  = UI.GetPlayerColors( self.m_Player:GetID() );
+  local backColor, frontColor   = UI.GetPlayerColors( self.m_Player:GetID() );
   local darkerBackColor :number = UI.DarkenLightenColor(backColor,-85,238);
 
   if (self.m_Type == BANNERTYPE_CITY_CENTER) then
@@ -1145,11 +1154,11 @@ function CityBanner:SetHealthBarColor()
   end
 
   local percent = self.m_Instance.CityHealthBar:GetPercent();
-  if (percent > .8 ) then
+  if (percent > 0.80 ) then
     self.m_Instance.CityHealthBar:SetColor( COLOR_CITY_GREEN );
-  elseif ( percent > .4) then
+  elseif (percent > 0.40) then
     self.m_Instance.CityHealthBar:SetColor( COLOR_CITY_YELLOW );
-  elseif ( percent < .4) then
+  elseif (percent <= 0.40) then
     self.m_Instance.CityHealthBar:SetColor( COLOR_CITY_RED );
   end
 end
@@ -1176,40 +1185,40 @@ function CityBanner:UpdateProduction(pCity:table)
     productionInstance.Button:ClearCallback( Mouse.eLClick );
   end
 
-  local pBuildQueue		:table  = pCity:GetBuildQueue();
+  local pBuildQueue     :table  = pCity:GetBuildQueue();
   if (pBuildQueue ~= nil) then
-    local productionpct			:number = 0;
-    local currentProduction		:string;
+    local productionpct         :number = 0;
+    local currentProduction     :string;
     local currentProductionHash :number = pBuildQueue:GetCurrentProductionTypeHash();
-    local prodTurnsLeft			:number;
-    local progress				:number;
-    local prodTypeName			:string;
-    local pBuildingDef			:table;
-    local pDistrictDef			:table;
-    local pUnitDef				:table;
-    local pProjectDef			:table;
+    local prodTurnsLeft         :number;
+    local progress              :number;
+    local prodTypeName          :string;
+    local pBuildingDef          :table;
+    local pDistrictDef          :table;
+    local pUnitDef              :table;
+    local pProjectDef           :table;
 
     -- Attempt to obtain a hash for each item
     if currentProductionHash ~= 0 then
       pBuildingDef = GameInfo.Buildings[currentProductionHash];
       pDistrictDef = GameInfo.Districts[currentProductionHash];
-      pUnitDef	 = GameInfo.Units[currentProductionHash];
-      pProjectDef	 = GameInfo.Projects[currentProductionHash];
+      pUnitDef     = GameInfo.Units[currentProductionHash];
+      pProjectDef  = GameInfo.Projects[currentProductionHash];
     end
 
-    if( pBuildingDef ~= nil ) then
+    if (pBuildingDef ~= nil) then
       currentProduction = pBuildingDef.Name;
       prodTypeName = pBuildingDef.BuildingType;
       prodTurnsLeft = pBuildQueue:GetTurnsLeft(pBuildingDef.BuildingType);
       progress = pBuildQueue:GetBuildingProgress(pBuildingDef.Index);
       productionpct = progress / pBuildQueue:GetBuildingCost(pBuildingDef.Index);
-    elseif ( pDistrictDef ~= nil ) then
+    elseif (pDistrictDef ~= nil) then
       currentProduction = pDistrictDef.Name;
       prodTypeName = pDistrictDef.DistrictType;
       prodTurnsLeft = pBuildQueue:GetTurnsLeft(pDistrictDef.DistrictType);
       progress = pBuildQueue:GetDistrictProgress(pDistrictDef.Index);
       productionpct = progress / pBuildQueue:GetDistrictCost(pDistrictDef.Index);
-    elseif ( pUnitDef ~= nil ) then
+    elseif (pUnitDef ~= nil) then
       local eMilitaryFormationType = pBuildQueue:GetCurrentProductionTypeModifier();
       currentProduction = pUnitDef.Name;
       prodTypeName = pUnitDef.UnitType;
@@ -1257,7 +1266,7 @@ function CityBanner:UpdateProduction(pCity:table)
       productionInstance.IconMeter:SetHide(false);
       productionInstance.IconMeter:SetPercent(productionpct);
 
-      local productionTip				:string = Locale.Lookup("LOC_CITY_BANNER_PRODUCING", currentProduction);
+      local productionTip             :string = Locale.Lookup("LOC_CITY_BANNER_PRODUCING", currentProduction);
       local productionTurnsLeftString :string;
       if prodTurnsLeft <= 0 then
         productionInstance.TurnsLeft:SetText("-");
@@ -1266,11 +1275,12 @@ function CityBanner:UpdateProduction(pCity:table)
         productionTurnsLeftString = "  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_LEFT_UNTIL_COMPLETE", prodTurnsLeft);
         productionInstance.TurnsLeft:SetText(prodTurnsLeft);
       end
+
       productionTip = productionTip .. "[NEWLINE]" .. productionTurnsLeftString;
       productionInstance.Button:SetToolTipString(productionTip);
       productionInstance.Button:SetColor(UI.GetColorValue("COLOR_CLEAR"));
             
-      if(prodTypeName ~= nil) then
+      if (prodTypeName ~= nil) then
         productionInstance.Slot:SetHide(false);
         productionInstance.Icon:SetHide(false);
         productionInstance.Icon:SetIcon("ICON_"..prodTypeName);
@@ -1292,19 +1302,17 @@ end
 -- ===========================================================================
 -- Non-instance function so it can be overwritten by mods
 function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGrowth:table)
-
   self.m_StatPopulationIM:ResetInstances();
-
   local currentPopulation:number = pCity:GetPopulation();
   local populationInstance:table = self.m_StatPopulationIM:GetInstance();
 
   if isLocalPlayer then
-    local food				:number = pCityGrowth:GetFood();
-    local pCityData   :table  = GetCityData(pCity);
-    local isGrowing			:boolean= pCityGrowth:GetTurnsUntilGrowth() ~= -1;
-    local isStarving		:boolean= pCityGrowth:GetTurnsUntilStarvation() ~= -1;
-    local growthThreshold	:number = pCityGrowth:GetGrowthThreshold();
-    local foodpct			:number = Clamp( food / growthThreshold, 0.0, 1.0 );
+    local food              :number = pCityGrowth:GetFood();
+    local pCityData         :table  = GetCityData(pCity);
+    local isGrowing         :boolean= pCityGrowth:GetTurnsUntilGrowth() ~= -1;
+    local isStarving        :boolean= pCityGrowth:GetTurnsUntilStarvation() ~= -1;
+    local growthThreshold   :number = pCityGrowth:GetGrowthThreshold();
+    local foodpct           :number = Clamp( food / growthThreshold, 0.0, 1.0 );
 
     local iModifiedFood;
     local total :number;
@@ -1317,11 +1325,11 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
       total = pCityData.FoodSurplus;
     end
 
-    local turnsUntilGrowth:number = 0;	-- It is possible for zero... no growth and no starving.
+    local turnsUntilGrowth:number = 0;  -- It is possible for zero... no growth and no starving.
     if isGrowing then
       turnsUntilGrowth = pCityGrowth:GetTurnsUntilGrowth();
     elseif isStarving then
-      turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();	-- negative
+      turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();  -- negative
     end
 
     -- Get real housing from improvements value
@@ -1334,7 +1342,6 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
     local CQUI_housingLeftPopupText = ""
     -- CQUI : housing left
     if g_smartbanner and g_smartbanner_population then
-
       local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[localPlayerID][pCityID];    -- CQUI real housing from improvements value
       if CQUI_HousingFromImprovements ~= nil then    -- CQUI real housing from improvements fix to show correct values when waiting for the next turn
         local housingLeft = pCityGrowth:GetHousing() - pCityGrowth:GetHousingFromImprovements() + CQUI_HousingFromImprovements - currentPopulation; -- CQUI calculate real housing
@@ -1345,9 +1352,11 @@ function CityBanner:UpdatePopulation(isLocalPlayer:boolean, pCity:table, pCityGr
         elseif housingLeft <= 0.5 then
           housingLeftColor = "WarningMajor";
         end
+
         if housingLeft >= 0.5 then
           housingLeft = "+"..housingLeft
         end
+
         local housingText = "[COLOR:"..housingLeftColor.."]"..housingLeft.."[ENDCOLOR]";
         populationInstance.CQUI_CityHousing:SetText(housingText);
         populationInstance.CQUI_CityHousing:SetHide(false);
@@ -1400,6 +1409,7 @@ function OnGovernorIconClicked(playerID: number, cityID: number)
   else
     OnCityBannerLookAt(playerID, cityID);
   end
+
   LuaEvents.GovernorPanel_Toggle(playerID, cityID);
 end
 
@@ -1570,10 +1580,10 @@ function CityBanner:UpdateStats()
 
     if self.m_Type == BANNERTYPE_CITY_CENTER then
 
-      local pCity				:table = self:GetCity();
-      local iCityOwner		:number = pCity:GetOwner();
-      local pCityGrowth		:table  = pCity:GetGrowth();
-      local populationIM		:table;
+      local pCity        :table = self:GetCity();
+      local iCityOwner   :number = pCity:GetOwner();
+      local pCityGrowth  :table  = pCity:GetGrowth();
+      local populationIM :table;
 
       if (localPlayerID == iCityOwner) then
         self:UpdatePopulation(true, pCity, pCityGrowth);
@@ -1606,16 +1616,17 @@ function CityBanner:UpdateStats()
       end
 
       --- DEFENSE INFO ---
-      local districtHitpoints		:number = pDistrict:GetMaxDamage(DefenseTypes.DISTRICT_GARRISON);
+      local districtHitpoints     :number = pDistrict:GetMaxDamage(DefenseTypes.DISTRICT_GARRISON);
       local currentDistrictDamage :number = pDistrict:GetDamage(DefenseTypes.DISTRICT_GARRISON);
-      local wallHitpoints			:number = pDistrict:GetMaxDamage(DefenseTypes.DISTRICT_OUTER);
-      local currentWallDamage		:number = pDistrict:GetDamage(DefenseTypes.DISTRICT_OUTER);
-      local garrisonDefense		:number = math.floor(pDistrict:GetDefenseStrength() + 0.5);
+      local wallHitpoints         :number = pDistrict:GetMaxDamage(DefenseTypes.DISTRICT_OUTER);
+      local currentWallDamage     :number = pDistrict:GetDamage(DefenseTypes.DISTRICT_OUTER);
+      local garrisonDefense       :number = math.floor(pDistrict:GetDefenseStrength() + 0.5);
 
-      local garrisonDefString :string = Locale.Lookup("LOC_CITY_BANNER_GARRISON_DEFENSE_STRENGTH");
+      local garrisonDefString     :string = Locale.Lookup("LOC_CITY_BANNER_GARRISON_DEFENSE_STRENGTH");
       local defValue = garrisonDefense;
       local defTooltip = garrisonDefString .. ": " .. garrisonDefense;
       local healthTooltip :string = Locale.Lookup("LOC_CITY_BANNER_GARRISON_HITPOINTS", ((districtHitpoints-currentDistrictDamage) .. "/" .. districtHitpoints));
+
       if (wallHitpoints > 0) then
         self.m_Instance.DefenseIcon:SetHide(true);
         self.m_Instance.ShieldsIcon:SetHide(false);
@@ -1630,17 +1641,19 @@ function CityBanner:UpdateStats()
         self.m_Instance.CityDefenseBarBacking:SetHide(true);
         self.m_Instance.CityHealthBarBacking:SetHide(true);
       end
+
       self.m_Instance.DefenseNumber:SetText(defValue);
       self.m_Instance.DefenseNumber:SetToolTipString(defTooltip);
       self.m_Instance.CityHealthBarBacking:SetToolTipString(healthTooltip);
       self.m_Instance.CityHealthBarBacking:SetHide(false);
-      if(districtHitpoints > 0) then
+      if (districtHitpoints > 0) then
         self.m_Instance.CityHealthBar:SetPercent((districtHitpoints-currentDistrictDamage) / districtHitpoints);	
       else
         self.m_Instance.CityHealthBar:SetPercent(0);	
       end
+
       self:SetHealthBarColor();	
-      
+
       if (((districtHitpoints-currentDistrictDamage) / districtHitpoints) == 1 and wallHitpoints == 0) then
         self.m_Instance.CityHealthBar:SetHide(true);
         self.m_Instance.CityHealthBarBacking:SetHide(true);
@@ -1652,7 +1665,6 @@ function CityBanner:UpdateStats()
       self:UpdateDetails();
       --------------------------------------
     else -- it should be a miniBanner
-      
       if (self.m_Type == BANNERTYPE_ENCAMPMENT) then 
         self:UpdateEncampmentBanner();
       elseif (self.m_Type == BANNERTYPE_AERODROME) then
@@ -1660,9 +1672,7 @@ function CityBanner:UpdateStats()
       elseif (self.m_Type == BANNERTYPE_OTHER_DISTRICT) then
         self:UpdateDistrictBanner();
       end
-      
     end
-
   else  --it's a banner not associated with a district
     if (self.m_IsImprovementBanner) then
       local bannerPlot = Map.GetPlot(self.m_PlotX, self.m_PlotY);
@@ -1678,7 +1688,7 @@ function CityBanner:UpdateStats()
 end
 
 -- ===========================================================================
-function SetDetailIcon( instance:table, icon:string, tooltip:string )
+function SetDetailIcon(instance:table, icon:string, tooltip:string)
   instance.Icon:SetHide(icon == nil);
   if icon then instance.Icon:SetIcon(icon); end
   instance.Icon:SetToolTipString(tooltip and tooltip or "");
@@ -1691,7 +1701,6 @@ end
 
 -- ===========================================================================
 function CityBanner:UpdateDetails()
-  
   local pCity:table = self:GetCity();
   local pDistrict:table = self:GetDistrict();
   if pCity and pDistrict then
@@ -1760,12 +1769,13 @@ function CityBanner:UpdateDetails()
       end	
     end
 
-    local pCityPower:table = pCity:GetPower();
+    local pCityPower      :table = pCity:GetPower();
     local freePower       :number = pCityPower:GetFreePower();
     local temporaryPower  :number = pCityPower:GetTemporaryPower();
     local requiredPower   :number = pCityPower:GetRequiredPower();
     local powerTooltip    :string = "";
     local powerIconKey    :string = "PowerInsufficient";
+
     if (pCityPower:IsFullyPowered()) then
       powerIconKey = "Power";
       powerTooltip = Locale.Lookup("LOC_CITY_BANNER_POWERED_CITY", requiredPower, freePower, temporaryPower);
@@ -1775,6 +1785,7 @@ function CityBanner:UpdateDetails()
     else
       powerTooltip = Locale.Lookup("LOC_CITY_BANNER_UNPOWERED_CITY", requiredPower, freePower, temporaryPower);
     end
+
     if (freePower > 0 or temporaryPower > 0 or requiredPower > 0) then
       local kPowerDetailEffectInst:table = self.m_DetailEffectsIM:GetInstance();
       SetDetailIcon(kPowerDetailEffectInst, powerIconKey, powerTooltip);
@@ -1837,7 +1848,7 @@ function OnCityBannerClick( playerID:number, cityID:number )
     UI.SelectCity( pCity );
     UI.SetCycleAdvanceTimer(0);  -- Cancel any auto-advance timer
     UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-  elseif(localPlayerID == PlayerTypes.OBSERVER
+  elseif (localPlayerID == PlayerTypes.OBSERVER
       or localPlayerID == PlayerTypes.NONE
       or pPlayer:GetDiplomacy():HasMet(localPlayerID)) then
 
@@ -1859,7 +1870,6 @@ function OnCityBannerClick( playerID:number, cityID:number )
         LuaEvents.CityBannerManager_TalkToLeader( playerID );
       end
     end
-
   end
 end
 
@@ -1913,14 +1923,14 @@ end
 -- ===========================================================================
 function CityBanner:SetFogState( fogState : number )
 
-  if( fogState == PLOT_HIDDEN ) then
+  if (fogState == PLOT_HIDDEN) then
     self:SetHide( true );
   else
     self:SetHide( false );
 
     --If this is an Aerodrome we need to hide the numbers and dropdown if in FOW
-    if( self.m_Type == BANNERTYPE_AERODROME) then
-      if( fogState == PLOT_REVEALED ) then
+    if (self.m_Type == BANNERTYPE_AERODROME) then
+      if (fogState == PLOT_REVEALED) then
         self.m_Instance.AerodromeBase:SetHide(true);
         self.m_Instance.UnitListPopup:SetDisabled(true);
       else
@@ -1940,7 +1950,6 @@ end
 
 -- ===========================================================================
 function CityBanner:UpdateVisibility()
-
   local bVisible = self.m_IsCurrentlyVisible and not self.m_IsForceHide;
   self.m_Instance.Anchor:SetHide(not bVisible);
   self:UpdateLoyaltyWarning();
@@ -2051,16 +2060,15 @@ end
 
 -- ===========================================================================
 function CityBanner:UpdateInfo( pCity : table )
-  
   self.m_CivIconInstance = nil;
   self.m_InfoIconIM:ResetInstances();
   self.m_InfoConditionIM:ResetInstances();
 
   if pCity ~= nil then
-    local playerID		:number = pCity:GetOwner();
-    local cityID		:number = pCity:GetID();
-    local pPlayer		:table	= Players[playerID];
-    local pPlayerConfig	:table	= PlayerConfigurations[playerID];
+    local playerID      :number = pCity:GetOwner();
+    local cityID        :number = pCity:GetID();
+    local pPlayer       :table  = Players[playerID];
+    local pPlayerConfig :table  = PlayerConfigurations[playerID];
 
     -- CAPITAL ICON
     if pPlayer then
@@ -2076,6 +2084,7 @@ function CityBanner:UpdateInfo( pCity : table )
             -- Former original capital
             instance.Icon:SetIcon("ICON_FORMER_CAPITAL");
           end
+
           tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_ORIGINAL_CAPITAL_TT", pPlayerConfig:GetCivilizationShortDescription());
         elseif pCity:IsCapital() then
           -- New capital
@@ -2087,7 +2096,7 @@ function CityBanner:UpdateInfo( pCity : table )
           tooltip = tooltip .. Locale.Lookup("LOC_CITY_BANNER_OTHER_CITY_TT", pPlayerConfig:GetCivilizationShortDescription());
         end
 
-        if GameCapabilities.HasCapability("CAPABILITY_ESPIONAGE") then			
+        if GameCapabilities.HasCapability("CAPABILITY_ESPIONAGE") then
           if Game.GetLocalPlayer() == playerID or HasEspionageView(playerID, cityID) then
             tooltip = tooltip .. Locale.Lookup("LOC_ESPIONAGE_VIEW_ENABLED_TT");
           else
@@ -2212,7 +2221,7 @@ function CityBanner:UpdateInfo( pCity : table )
         if tPlots ~= nil and (table.count(tPlots) > 0) then
           for i,plotId in pairs(tPlots) do
             local kPlot :table = Map.GetPlotByIndex(plotId);
-            if(tMaxUnits[i] >= 1 and tUnits[i] >= 1 and tLockedUnits[i] <= 0) then
+            if (tMaxUnits[i] >= 1 and tUnits[i] >= 1 and tLockedUnits[i] <= 0) then
               local instance:table = self.m_InfoIconIM:GetInstance();
               instance.Icon:SetIcon("EXCLAMATION");
               instance.Icon:SetToolTipString(Locale.Lookup("LOC_CQUI_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP"));
@@ -2237,35 +2246,36 @@ end
 -- ===========================================================================
 function CityBanner:UpdateReligion()
 
-  local pCity				:table = self:GetCity();
-  local pCityReligion		:table = pCity:GetReligion();
-  local localPlayerID		:number = Game.GetLocalPlayer();
-  local eMajorityReligion	:number = pCityReligion:GetMajorityReligion();
+  local pCity               :table = self:GetCity();
+  local pCityReligion       :table = pCity:GetReligion();
+  local localPlayerID       :number = Game.GetLocalPlayer();
+  local eMajorityReligion   :number = pCityReligion:GetMajorityReligion();
 
   self.m_eMajorityReligion = eMajorityReligion;
   self:UpdateInfo(pCity);
 
-  local cityInst			:table = self.m_Instance;
-  local religionInfo		:table = cityInst.ReligionInfo;
-  local religionsInCity	:table = pCityReligion:GetReligionsInCity();
+  local cityInst        :table = self.m_Instance;
+  local religionInfo    :table = cityInst.ReligionInfo;
+  local religionsInCity :table = pCityReligion:GetReligionsInCity();
 
   -- Hide the meter and bail out if the religion lens isn't active
-  if(not m_isReligionLensActive or table.count(religionsInCity) == 0) then
+  if (not m_isReligionLensActive or table.count(religionsInCity) == 0) then
     if religionInfo then
       religionInfo.ReligionInfoContainer:SetHide(true);
     end
+
     return;
   end
 
   -- Update religion icon + religious pressure animation
   local majorityReligionColor:number = COLOR_RELIGION_DEFAULT;
-  if(eMajorityReligion >= 0) then
+  if (eMajorityReligion >= 0) then
     majorityReligionColor = UI.GetColorValue(GameInfo.Religions[eMajorityReligion].Color);
   end
   
   -- Preallocate total fill so we can stagger the meters
-  local totalFillPercent:number = 0;
-  local iCityPopulation:number = pCity:GetPopulation();
+  local totalFillPercent :number = 0;
+  local iCityPopulation  :number = pCity:GetPopulation();
 
   -- Get a list of religions present in this city
   local activeReligions:table = {};
@@ -2273,9 +2283,9 @@ function CityBanner:UpdateReligion()
   local pReligionsInCity:table = pCityReligion:GetReligionsInCity();
   for _, cityReligion in pairs(pReligionsInCity) do
     local religion:number = cityReligion.Religion;
-    if(religion >= 0) then
-      local followers:number = cityReligion.Followers;
-      local fillPercent:number = followers / iCityPopulation;
+    if (religion >= 0) then
+      local followers   :number = cityReligion.Followers;
+      local fillPercent :number = followers / iCityPopulation;
       totalFillPercent = totalFillPercent + fillPercent;
 
       table.insert(activeReligions, {
@@ -2300,31 +2310,33 @@ function CityBanner:UpdateReligion()
     religion.AccumulativeFillPercent = accumulativeFillPercent;
   end
 
-  if(table.count(activeReligions) > 0) then
-    local localPlayerVis:table = PlayersVisibility[localPlayerID];
+  if (table.count(activeReligions) > 0) then
+    local localPlayerVis :table = PlayersVisibility[localPlayerID];
     if (localPlayerVis ~= nil) then
       -- Holy sites get a different color and texture
-      local holySitePlotIDs:table = {};
-      local cityDistricts:table = pCity:GetDistricts();
-      local playerDistricts:table = self.m_Player:GetDistricts();
+      local holySitePlotIDs :table = {};
+      local cityDistricts   :table = pCity:GetDistricts();
+      local playerDistricts :table = self.m_Player:GetDistricts();
+
       for i, district in cityDistricts:Members() do
-        local districtType:string = GameInfo.Districts[district:GetType()].DistrictType;
-        if(districtType == "DISTRICT_HOLY_SITE") then
-          local locX:number = district:GetX();
-          local locY:number = district:GetY();
+        local districtType :string = GameInfo.Districts[district:GetType()].DistrictType;
+        if (districtType == "DISTRICT_HOLY_SITE") then
+          local locX :number = district:GetX();
+          local locY :number = district:GetY();
           if localPlayerVis:IsVisible(locX, locY) then
-            local plot:table  = Map.GetPlot(locX, locY);
+            local plot :table  = Map.GetPlot(locX, locY);
             local holySiteFaithYield:number = district:GetReligionHealRate();
             SpawnHolySiteIconAtLocation(locX, locY, "+" .. holySiteFaithYield);
             holySitePlotIDs[plot:GetIndex()] = true;
           end
+
           break;
         end
       end
 
       -- Color hexes in this city the same color as religion
       local plots:table = Map.GetCityPlots():GetPurchasedPlots(pCity);
-      if(table.count(plots) > 0) then
+      if (table.count(plots) > 0) then
         UILens.SetLayerHexesColoredArea( m_HexColoringReligion, localPlayerID, plots, majorityReligionColor );
       end
     end
@@ -2332,8 +2344,8 @@ function CityBanner:UpdateReligion()
 
   if religionInfo then
     -- Create or reset icon instance manager
-    local iconIM:table = cityInst[DATA_FIELD_RELIGION_ICONS_IM];
-    if(iconIM == nil) then
+    local iconIM :table = cityInst[DATA_FIELD_RELIGION_ICONS_IM];
+    if (iconIM == nil) then
       iconIM = InstanceManager:new("ReligionIconInstance", "ReligionIconButtonBacking", religionInfo.ReligionInfoIconStack);
       cityInst[DATA_FIELD_RELIGION_ICONS_IM] = iconIM;
     else
@@ -2341,8 +2353,8 @@ function CityBanner:UpdateReligion()
     end
 
     -- Create or reset follower list instance manager
-    local followerListIM:table = cityInst[DATA_FIELD_RELIGION_FOLLOWER_LIST_IM];
-    if(followerListIM == nil) then
+    local followerListIM :table = cityInst[DATA_FIELD_RELIGION_FOLLOWER_LIST_IM];
+    if (followerListIM == nil) then
       followerListIM = InstanceManager:new("ReligionFollowerListInstance", "ReligionFollowerListContainer", religionInfo.ReligionFollowerListStack);
       cityInst[DATA_FIELD_RELIGION_FOLLOWER_LIST_IM] = followerListIM;
     else
@@ -2350,15 +2362,15 @@ function CityBanner:UpdateReligion()
     end
 
     -- Create or reset pop chart instance manager
-    local popChartIM:table = cityInst[DATA_FIELD_RELIGION_POP_CHART_IM];
-    if(popChartIM == nil) then
+    local popChartIM :table = cityInst[DATA_FIELD_RELIGION_POP_CHART_IM];
+    if (popChartIM == nil) then
       popChartIM = InstanceManager:new("ReligionPopChartInstance", "PopChartMeter", religionInfo.ReligionPopChartContainer);
       cityInst[DATA_FIELD_RELIGION_POP_CHART_IM] = popChartIM;
     else
       popChartIM:ResetInstances();
     end
 
-    local populationChartTooltip:string = RELIGION_POP_CHART_TOOLTIP_HEADER;
+    local populationChartTooltip :string = RELIGION_POP_CHART_TOOLTIP_HEADER;
 
     -- Show what religion we will eventually turn into
     local nextReligion = pCityReligion:GetNextReligion();
@@ -2498,9 +2510,9 @@ end
 function SpawnHolySiteIconAtLocation( locX : number, locY:number, label:string )
   local iconInst:table = m_HolySiteIconsIM:GetInstance();
 
-  local xOffset:number = -4;	--offset to center UI element on tile
-  local yOffset:number = 4;	--offset to center UI element on tile
-  local zOffset:number = 10;	--offset for 3D world view
+  local xOffset:number = -4;  --offset to center UI element on tile
+  local yOffset:number = 4;   --offset to center UI element on tile
+  local zOffset:number = 10;  --offset for 3D world view
   if (UI.GetWorldRenderView() == WorldRenderView.VIEW_2D) then
     zOffset = 0;
   end
@@ -2668,6 +2680,7 @@ function CityBanner:UpdateLoyalty()
             instance.FreeCityTop:SetHide(false);
           end
         end
+
         self.m_Instance.LoyaltyInfo.MainStack:CalculateSize();
         local newSizeY = self.m_Instance.LoyaltyInfo.MainStack:GetSizeY();
         self.m_Instance.LoyaltyInfo.CulturalIdentityExpandedButton:SetSizeY(newSizeY + 10);
@@ -2859,6 +2872,7 @@ function OnCityStrikeButtonClick( playerID, cityID )
   if (pCity == nil) then
     return;
   end;
+
   -- AZURENCY : Enter the range city mode on click (not on hover of a button, the old workaround)
   LuaEvents.CQUI_Strike_Enter();
   -- AZURENCY : Allow to switch between different city range attack (clicking on the range button of one
@@ -2868,7 +2882,6 @@ function OnCityStrikeButtonClick( playerID, cityID )
   UI.DeselectAll();
   UI.SelectCity( pCity );
   UI.SetInterfaceMode(InterfaceModeTypes.CITY_RANGE_ATTACK);
-
 end
 
 LuaEvents.CQUI_CityRangeStrike.Add( OnCityStrikeButtonClick ); -- AZURENCY : to acces it in the actionpannel on the city range attack button
@@ -2891,9 +2904,7 @@ function OnDistrictRangeStrikeButtonClick( playerID, districtID )
   UI.LookAtPlot(pDistrict:GetX(), pDistrict:GetY());
   UI.SetInterfaceMode(InterfaceModeTypes.DISTRICT_RANGE_ATTACK);
 end
-
 LuaEvents.CQUI_DistrictRangeStrike.Add( OnDistrictRangeStrikeButtonClick ); -- AZURENCY : to acces it in the actionpannel on the district range attack button
-
 
 -- ===========================================================================
 function OnICBMStrikeButtonClick( iPlotID, eWMD )
@@ -2969,12 +2980,12 @@ function OnCityAddedToMap( playerID: number, cityID : number, cityX : number, ci
       CityBannerInstances[ playerID ][ cityID ] ~= nil) then
       return;
     end
+
   AddCityBannerToMap( playerID, cityID );
 end
 
 -- ===========================================================================
 function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :number, districtX : number, districtY : number, districtType:number, percentComplete:number )
-
   local locX = districtX;
   local locY = districtY;
   local type = districtType;
@@ -3040,6 +3051,7 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
                                 break;
                               end
                             end
+
                             break;
                           end
                         end
@@ -3064,19 +3076,17 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
                 end
               end
             end
-          else
+          else -- if minibanner == nil
             miniBanner:UpdateStats();
           end
-        end
-      end
-    end
-  end
-
+        end -- else not city center
+      end -- if pcity ~= nil
+    end -- if pdistrict ~= nil
+  end -- if pplayer ~= nil
 end
 
 -- ===========================================================================
 function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
-
   if eImprovementType == -1 then
     UI.DataError("Received -1 eImprovementType for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
     return;
@@ -3100,7 +3110,8 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
     end
   end
 
-  if ( improvementData.AirSlots == 0 and improvementData.WeaponSlots == 0 and improvementData.ImprovementType ~= "IMPROVEMENT_MOUNTAIN_TUNNEL" and improvementData.ImprovementType ~= "IMPROVEMENT_MOUNTAIN_ROAD" ) then
+  -- Right now we're only interested in the Airstrip improvement, or Mountain Tunnel/Road
+  if (improvementData.AirSlots == 0 and improvementData.WeaponSlots == 0 and improvementData.ImprovementType ~= "IMPROVEMENT_MOUNTAIN_TUNNEL" and improvementData.ImprovementType ~= "IMPROVEMENT_MOUNTAIN_ROAD" ) then
     return;
   end
 
@@ -3111,17 +3122,17 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
     if (plotID ~= nil) then
       local miniBanner = GetMiniBanner( eOwner, plotID );
       if (miniBanner == nil) then
-        if ( improvementData.AirSlots > 0 ) then
+        if (improvementData.AirSlots > 0) then
           --we're passing -1 as the cityID and the plotID as the districtID argument since Airstrips aren't associated with a city or a district
           AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_AERODROME );
-        elseif ( improvementData.WeaponSlots > 0 ) then
+        elseif (improvementData.WeaponSlots > 0) then
           local ownerCity = Cities.GetPlotPurchaseCity(locX, locY);
           local cityID = ownerCity:GetID();
           -- we're passing the plotID as the districtID argument because we need the location of the improvement
           AddMiniBannerToMap( eOwner, cityID, plotID, BANNERTYPE_MISSILE_SILO );
-        elseif ( improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_TUNNEL" ) then
+        elseif (improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_TUNNEL") then
           AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_MOUNTAIN_TUNNEL );
-        elseif ( improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_ROAD" ) then
+        elseif (improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_ROAD") then
           AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_QHAPAQ_NAN);
         end
       else
@@ -3197,7 +3208,7 @@ end
 
 -- ===========================================================================
 function OnImprovementVisibilityChanged( locX :number, locY :number, eImprovementType :number, eVisibility :number )
-  if ( eImprovementType == -1 ) then
+  if (eImprovementType == -1) then
     return;
   end
   local data:table = GameInfo.Improvements[eImprovementType];
@@ -3221,7 +3232,6 @@ end
 
 -- ===========================================================================
 function OnBuildingChanged( plotX:number, plotY:number, buildingIndex:number, playerID:number, cityID:number, iPercentComplete:number)
-  
   local pPlayer = Players[playerID];
   if (pPlayer ~= nil and pPlayer:GetCities() ~= nil) then
     
@@ -3245,7 +3255,6 @@ function OnBuildingChanged( plotX:number, plotY:number, buildingIndex:number, pl
       end
     end
   end
-
 end
 
 -- ===========================================================================
@@ -3255,7 +3264,6 @@ function OnCityNameChange( playerID: number, cityID : number)
   if (banner ~= nil ) then
     banner:UpdateName();   
   end
-
 end
 
 -- ===========================================================================
@@ -3273,7 +3281,6 @@ end
 
 -- ===========================================================================
 function OnCityReligionChanged( playerID: number, cityID : number, eVisibility : number, city)
-
   -- Ensure not in autoplay
   if Game.GetLocalPlayer() < 0 then
     return;
@@ -3287,7 +3294,6 @@ end
 
 -- ===========================================================================
 function OnQuestChanged( fromPlayerID:number, toPlayerID:number)
-
   -- Update the capital of the player the quest is from
   local pFromPlayer = Players[fromPlayerID];
   if (pFromPlayer ~= nil and pFromPlayer:GetCities() ~= nil) then
@@ -3321,7 +3327,7 @@ function OnDistrictCombatChanged(eventSubType, playerID, districtID)
         miniBanner:UpdateStats();
       end
     end
-    end
+  end
 end
 
 -- ===========================================================================
@@ -3373,7 +3379,6 @@ function OnDistrictDamageChanged( playerID:number, districtID:number, damageType
       local pLocalPlayerVis = PlayersVisibility[Game.GetLocalPlayer()];
       if (pLocalPlayerVis ~= nil) then
         if (pLocalPlayerVis:IsVisible(pDistrict:GetX(), pDistrict:GetY())) then
-
           local iDelta = newDamage - oldDamage;
           local szText;
 
@@ -3391,21 +3396,19 @@ function OnDistrictDamageChanged( playerID:number, districtID:number, damageType
             end
           end
 
-
           UI.AddWorldViewText(EventSubTypes.DAMAGE, szText, pDistrict:GetX(), pDistrict:GetY(), 0);
         end
       end
     end
   end
+
   -- print("A District has been damaged");
   -- print(playerID, districtID, outerDamage, garrisonDamage);
 end
 
 -- ===========================================================================
 function OnDistrictPillaged(playerID : number, districtID : number, cityID : number, x : number, y : number, district_type : number, percent_complete : number, is_pillaged : number)
-
   UpdateDistrictStats( playerID, districtID );
-
 end
 
 -- ===========================================================================
@@ -3489,7 +3492,7 @@ function OnCityProductionCompleted( playerID:number, cityID:number)
 end
 
 -- ===========================================================================
---	Refresh a banner at a location if it belongs to the supplied player
+--  Refresh a banner at a location if it belongs to the supplied player
 function RefreshPlayerBannerAt( playerID:number, iX : number, iY : number )
   local pCity = CityManager.GetCityAt(iX, iY);
   if pCity ~= nil then
@@ -3518,6 +3521,7 @@ function RefreshPlayerBanners( playerID:number )
     if (CityBannerInstances[ playerID ] == nil) then
       return;
     end
+
     local playerCityBannerInstances = CityBannerInstances[ playerID ];
     for id, banner in pairs(playerCityBannerInstances) do
       if (banner ~= nil) then
@@ -3529,6 +3533,7 @@ function RefreshPlayerBanners( playerID:number )
     if (MiniBannerInstances[ playerID ] == nil) then
       return;
     end
+
     local playerMiniBannerInstances = MiniBannerInstances[ playerID ];
     for id, banner in pairs(playerMiniBannerInstances) do
       if (banner ~= nil) then
@@ -3550,6 +3555,7 @@ function RefreshPlayerProduction( playerID:number )
     if (CityBannerInstances[ playerID ] == nil) then
       return;
     end
+
     local playerCityBannerInstances = CityBannerInstances[ playerID ];
     for id, banner in pairs(playerCityBannerInstances) do
       if (banner ~= nil) then
@@ -3569,6 +3575,7 @@ function RefreshPlayerRangeStrike( playerID:number )
     if (CityBannerInstances[ playerID ] == nil) then
       return;
     end
+
     local playerCityBannerInstances = CityBannerInstances[ playerID ];
     for id, banner in pairs(playerCityBannerInstances) do
       if (banner ~= nil) then
@@ -3579,6 +3586,7 @@ function RefreshPlayerRangeStrike( playerID:number )
     if (MiniBannerInstances[ playerID ] == nil) then
       return;
     end
+
     local playerMiniBannerInstances = MiniBannerInstances[ playerID ];
     for id, banner in pairs(playerMiniBannerInstances) do
       if (banner ~= nil) then
@@ -3777,7 +3785,7 @@ function Reload()
   if pLocalPlayerVis ~= nil then
     local players = Game.GetPlayers();
     for i, player in ipairs(players) do
-      local playerID    :number = player:GetID();
+      local playerID      :number = player:GetID();
       local pPlayerCities :table = players[i]:GetCities();
 
       for _, city in pPlayerCities:Members() do
@@ -3788,6 +3796,7 @@ function Reload()
         if (pLocalPlayerVis:IsVisible(locX, locY) == true) then
           OnCityVisibilityChanged(playerID, cityID, PLOT_VISIBLE);
         end
+
         RefreshBanner(playerID, cityID) -- CQUI : refresh the banner info
       end
 
@@ -3833,11 +3842,9 @@ function OnEventPlaybackComplete()
         if (banner ~= nil and banner:IsVisible()) then
           -- Always update the stats
           banner:UpdateStats();
-
           if bUpdateLoyalty == true then
             banner:UpdateLoyalty();
           end
-
         end
       end
     end
@@ -3852,13 +3859,11 @@ function OnEventPlaybackComplete()
   end
 
   m_DelayedUpdate = {};
-
   m_pDirtyCityComponents:Clear();
 end
 
 ----------------------------------------------------------------
 function OnLocalPlayerChanged( localPlayerID:number , prevLocalPlayerID:number )
-
   -- Hide all the flags, we will get updates later
   for _, playerBannerInstances in pairs(CityBannerInstances) do
     for id, banner in pairs(playerBannerInstances) do
@@ -3888,7 +3893,7 @@ function OnLocalPlayerChanged( localPlayerID:number , prevLocalPlayerID:number )
     for iMini,kMiniBanner in pairs(kMiniBanners) do
       local districtID:number = kMiniBanner.m_DistrictID;
       local typeID  :number = kMiniBanner.m_Type;
-      local cityID	:number = kMiniBanner.m_CityID;
+      local cityID  :number = kMiniBanner.m_CityID;
       kMiniBanner:destroy();
       AddMiniBannerToMap( iPlayer, cityID, districtID, typeID );
     end
@@ -3905,6 +3910,7 @@ function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
   end
 end
 
+-- ===========================================================================
 function OnPlayerTurnActivated(player, isFirstTimeThisTurn)
   -- PlayerTurnActivated is post DoTurn processing for the beginning of the turn.
   if (isFirstTimeThisTurn and Game.GetLocalPlayer() == player) then
@@ -3917,7 +3923,6 @@ end
 function OnObjectPairingChanged(eSubType, parentOwner, parentType, parentID, childOwner, childType, childID)
   local pPlayer = Players[ parentOwner ];
   if (pPlayer ~= nil) then
-
     local bannerInstance = GetCityBanner( parentOwner, parentID );
     if (bannerInstance ~= nil) then
       bannerInstance:UpdateStats( bannerInstance );
@@ -3927,7 +3932,6 @@ function OnObjectPairingChanged(eSubType, parentOwner, parentType, parentID, chi
     if (miniBannerInstance ~= nil) then
       miniBannerInstance:UpdateStats( miniBannerInstance );
     end
-
   end
 end
 
@@ -3940,7 +3944,6 @@ end
 
 -- ===========================================================================
 function RealizeReligion()
-  
   m_HolySiteIconsIM:ResetInstances();
   -- Only clear the religion lens if we're turning off lenses altogether, but not if switching to another modal lens. (Turning on another modal lens clears it already)
   if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS then
@@ -3955,7 +3958,6 @@ function RealizeReligion()
       end
     end
   end
-
 end
 
 -- ===========================================================================
@@ -4020,8 +4022,8 @@ function OnShutdown()
 end
 
 -- ===========================================================================
---	LUA Event
---	Set cached values back after a hotload.
+--  LUA Event
+--  Set cached values back after a hotload.
 -- ===========================================================================
 function OnGameDebugReturn( context:string, contextTable:table )
   if context == "CityBannerManager" then
@@ -4069,12 +4071,12 @@ function OnLensLayerOn( layerNum:number )
 end
 
 -- ===========================================================================
---	Gamecore Event
---	Called once per layer that is turned on when a new lens is deactivated,
---	or when a player explicitly turns off the layer from the "player" lens.
+--  Gamecore Event
+--  Called once per layer that is turned on when a new lens is deactivated,
+--  or when a player explicitly turns off the layer from the "player" lens.
 -- ===========================================================================
 function OnLensLayerOff( layerNum:number )
-  if	layerNum == m_HexColoringReligion then
+  if  layerNum == m_HexColoringReligion then
     m_isReligionLensActive = false;
     RealizeReligion();
   elseif layerNum == m_CulturalIdentityLens then
@@ -4110,6 +4112,7 @@ function CQUI_OnInfluenceGiven()
   end
 end
 
+-- ===========================================================================
 function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance )
   if bannerInstance == nil then
     return;
@@ -4126,7 +4129,7 @@ function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance )
       local suzerainTooltip = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_LIST") .. " ";
       if pPlayer:GetDiplomacy():HasMet(suzerainID) then
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_" .. leader);
-        if(suzerainID == Game.GetLocalPlayer()) then
+        if (suzerainID == Game.GetLocalPlayer()) then
           bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup("LOC_CITY_STATES_YOU"));
         else
           bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup(pPlayerConfig:GetPlayerName()));
@@ -4147,9 +4150,7 @@ end
 -- ===========================================================================
 function OnInterfaceModeChanged( oldMode:number, newMode:number )
   if newMode == InterfaceModeTypes.MAKE_TRADE_ROUTE or oldMode == InterfaceModeTypes.MAKE_TRADE_ROUTE then
-
     m_isTradeSelectionActive = newMode == InterfaceModeTypes.MAKE_TRADE_ROUTE;
-
     -- Show trading post icons on cities that contain a trading post with the local player
     for _, playerBannerInstances in pairs(CityBannerInstances) do
       for id, banner in pairs(playerBannerInstances) do
@@ -4226,7 +4227,7 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
   local kCityPlots :table = Map.GetCityPlots():GetPurchasedPlots(pCity);
   if kCityPlots ~= nil then
     for _, plotID in pairs(kCityPlots) do
-      local kPlot	:table = Map.GetPlotByIndex(plotID);
+      local kPlot :table = Map.GetPlotByIndex(plotID);
       if Map.GetPlotDistance( pCity:GetX(), pCity:GetY(), kPlot:GetX(), kPlot:GetY() ) <= 3 then
         local eImprovementType :number = kPlot:GetImprovementType();
         if eImprovementType ~= -1 then
@@ -4267,6 +4268,7 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
         end
       end
     end
+
     CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
     if CQUI_HousingFromImprovementsTable[PlayerID] == nil then
       CQUI_HousingFromImprovementsTable[PlayerID] = {};
@@ -4274,6 +4276,7 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
     if CQUI_HousingUpdated[PlayerID] == nil then
       CQUI_HousingUpdated[PlayerID] = {};
     end
+
     CQUI_HousingFromImprovementsTable[PlayerID][pCityID] = CQUI_HousingFromImprovements;
     CQUI_HousingUpdated[PlayerID][pCityID] = true;
     LuaEvents.CQUI_RealHousingFromImprovementsCalculated(pCityID, CQUI_HousingFromImprovements);
@@ -4321,89 +4324,87 @@ end
 
 -- ===========================================================================
 function Initialize()
-
   print("Initialize CQUI CityBanner Expansion 2")
-
   RegisterDirtyEvents();
 
   ContextPtr:SetInitHandler( OnContextInitialize );
   ContextPtr:SetShutdown( OnShutdown );
 
-  Events.BeginWonderReveal.Add(       OnBeginWonderReveal );
-  Events.BuildingChanged.Add(         OnBuildingChanged);
-  Events.CapitalCityChanged.Add(        OnCapitalCityChanged);
-  Events.CityAddedToMap.Add(          OnCityAddedToMap );
-  Events.CityDefenseStatusChanged.Add(    OnCityDefenseStatusChanged );
+  Events.BeginWonderReveal.Add( OnBeginWonderReveal );
+  Events.BuildingChanged.Add(   OnBuildingChanged);
+  Events.CapitalCityChanged.Add(OnCapitalCityChanged);
+  Events.CityAddedToMap.Add(    OnCityAddedToMap );
+  Events.CityDefenseStatusChanged.Add(OnCityDefenseStatusChanged );
   Events.CityFocusChanged.Add(        OnCityFocusChange );
   Events.CityNameChanged.Add(         OnCityNameChange );
-  Events.CityProductionQueueChanged.Add(OnCityProductionChanged);
-  Events.CityProductionUpdated.Add(     OnCityProductionUpdate);
-  Events.CityProductionChanged.Add(     OnCityProductionChanged); 
+  Events.CityProductionQueueChanged.Add(  OnCityProductionChanged);
+  Events.CityProductionUpdated.Add(       OnCityProductionUpdate);
+  Events.CityProductionChanged.Add(       OnCityProductionChanged);
   Events.CityProductionCompleted.Add(     OnCityProductionCompleted);
-  Events.CityReligionChanged.Add(       OnCityReligionChanged );
-  Events.CityReligionFollowersChanged.Add(  OnCityReligionChanged );
-  Events.CityRemovedFromMap.Add(        OnCityRemovedFromMap );
-  Events.CitySelectionChanged.Add(      OnSelectionChanged );
-  Events.CityUnitsChanged.Add(                OnCityUnitsChanged );
-  Events.CityVisibilityChanged.Add(     OnCityVisibilityChanged );
-  Events.CityOccupationChanged.Add(     OnCityOccupationChanged );
-  Events.CityPopulationChanged.Add(			OnCityPopulationChanged );
-  Events.DiplomacyDeclareWar.Add(       OnDiplomacyDeclareWar );
-  Events.DiplomacyMakePeace.Add(        OnDiplomacyMakePeace );
-  Events.DistrictAddedToMap.Add(        OnDistrictAddedToMap );
-  Events.DistrictBuildProgressChanged.Add(  OnDistrictAddedToMap);
+  Events.CityReligionChanged.Add(         OnCityReligionChanged );
+  Events.CityReligionFollowersChanged.Add(OnCityReligionChanged );
+  Events.CityRemovedFromMap.Add(   OnCityRemovedFromMap );
+  Events.CitySelectionChanged.Add( OnSelectionChanged );
+  Events.CityUnitsChanged.Add(     OnCityUnitsChanged );
+  Events.CityVisibilityChanged.Add(OnCityVisibilityChanged );
+  Events.CityOccupationChanged.Add(OnCityOccupationChanged );
+  Events.CityPopulationChanged.Add(OnCityPopulationChanged );
+  Events.DiplomacyDeclareWar.Add(  OnDiplomacyDeclareWar );
+  Events.DiplomacyMakePeace.Add(   OnDiplomacyMakePeace );
+  Events.DistrictAddedToMap.Add(   OnDistrictAddedToMap );
+  Events.DistrictBuildProgressChanged.Add( OnDistrictAddedToMap);
   --Events.DistrictBuildProgressChanged.Add(  OnDistrictProgressChanged);
-  Events.DistrictCombatChanged.Add(     OnDistrictCombatChanged );
-  Events.DistrictDamageChanged.Add(     OnDistrictDamageChanged );
-  Events.DistrictPillaged.Add(          OnDistrictPillaged );
-  Events.DistrictRemovedFromMap.Add(      OnDistrictRemovedFromMap );
-  Events.DistrictUnitsChanged.Add(      OnDistrictUnitsChanged );
-  Events.DistrictVisibilityChanged.Add(   OnDistrictVisibilityChanged );
-  Events.EndWonderReveal.Add(         OnEndWonderReveal );
-  Events.GameCoreEventPlaybackComplete.Add( OnEventPlaybackComplete);
-  Events.ImprovementAddedToMap.Add(     OnImprovementAddedToMap );
-  Events.ImprovementRemovedFromMap.Add(   OnImprovementRemovedFromMap );
-  Events.ImprovementVisibilityChanged.Add(  OnImprovementVisibilityChanged );
-  Events.InterfaceModeChanged.Add(      OnInterfaceModeChanged );
-  Events.LensLayerOff.Add(          OnLensLayerOff );
-  Events.LensLayerOn.Add(           OnLensLayerOn );
-  Events.LocalPlayerChanged.Add(        OnLocalPlayerChanged);
-  Events.PlayerTurnActivated.Add(       OnPlayerTurnActivated);
-  Events.ObjectPairing.Add(         OnObjectPairingChanged);
-  Events.QuestChanged.Add(          OnQuestChanged );
-  Events.UnitAddedToMap.Add(          OnUnitAddedToMap );
+  Events.DistrictCombatChanged.Add(        OnDistrictCombatChanged );
+  Events.DistrictDamageChanged.Add(        OnDistrictDamageChanged );
+  Events.DistrictPillaged.Add(             OnDistrictPillaged );
+  Events.DistrictRemovedFromMap.Add(       OnDistrictRemovedFromMap );
+  Events.DistrictUnitsChanged.Add(         OnDistrictUnitsChanged );
+  Events.DistrictVisibilityChanged.Add(    OnDistrictVisibilityChanged );
+  Events.EndWonderReveal.Add(              OnEndWonderReveal );
+  Events.GameCoreEventPlaybackComplete.Add(OnEventPlaybackComplete);
+  Events.ImprovementAddedToMap.Add(        OnImprovementAddedToMap );
+  Events.ImprovementRemovedFromMap.Add(    OnImprovementRemovedFromMap );
+  Events.ImprovementVisibilityChanged.Add( OnImprovementVisibilityChanged );
+  Events.InterfaceModeChanged.Add(OnInterfaceModeChanged );
+  Events.LensLayerOff.Add(        OnLensLayerOff );
+  Events.LensLayerOn.Add(         OnLensLayerOn );
+  Events.LocalPlayerChanged.Add(  OnLocalPlayerChanged);
+  Events.PlayerTurnActivated.Add( OnPlayerTurnActivated);
+  Events.ObjectPairing.Add(       OnObjectPairingChanged);
+  Events.QuestChanged.Add(        OnQuestChanged );
+  Events.UnitAddedToMap.Add(      OnUnitAddedToMap );
   Events.UnitMoved.Add(           OnUnitMoved );
-  Events.UnitRemovedFromMap.Add(        OnUnitRemovedFromMap );
+  Events.UnitRemovedFromMap.Add(  OnUnitRemovedFromMap );
   Events.UnitUpgraded.Add(          OnUnitUpgraded );
   Events.UnitVisibilityChanged.Add( OnUnitMoved );
-  Events.WorldRenderViewChanged.Add(      OnRefreshBannerPositions);
-  Events.WMDCountChanged.Add(         OnWMDCountChanged);
-  Events.GovernmentPolicyChanged.Add(         OnPolicyChanged );
-  Events.GovernmentPolicyObsoleted.Add(       OnPolicyChanged );
-  Events.SpyMissionCompleted.Add(				OnSpyMissionCompleted );
+  Events.WorldRenderViewChanged.Add(OnRefreshBannerPositions);
+  Events.WMDCountChanged.Add(       OnWMDCountChanged);
+  Events.GovernmentPolicyChanged.Add(  OnPolicyChanged );
+  Events.GovernmentPolicyObsoleted.Add(OnPolicyChanged );
+  Events.SpyMissionCompleted.Add(      OnSpyMissionCompleted );
   Events.PlayerAgeChanged.Add(         OnPlayerAgeChanged );
-  Events.PlayerDarkAgeChanged.Add(       OnPlayerAgeChanged );
-  Events.CitySiegeStatusChanged.Add(      OnSiegeStatusChanged);
-  Events.GameCoreEventPublishComplete.Add(	FlushChanges); --This event is raised directly after a series of gamecore events.
-  Events.CityWorkerChanged.Add(           OnCityWorkerChanged );
-
+  Events.PlayerDarkAgeChanged.Add(     OnPlayerAgeChanged );
+  Events.CitySiegeStatusChanged.Add(   OnSiegeStatusChanged);
+  Events.CityWorkerChanged.Add(        OnCityWorkerChanged );
+  Events.GameCoreEventPublishComplete.Add(FlushChanges); --This event is raised directly after a series of gamecore events.
+  
   -- Expansion1 related events
-  Events.GovernorChanged.Add(         OnGovernorChanged);
-  Events.GovernorAssigned.Add(        OnGovernorAssigned);
-  Events.GovernorPromoted.Add(        OnGovernorChanged);
-  Events.GovernorEjected.Add(         OnGovernorEjected);
-  Events.CityLoyaltyChanged.Add(      OnCityLoyaltyChanged);
+  Events.GovernorChanged.Add(   OnGovernorChanged);
+  Events.GovernorAssigned.Add(  OnGovernorAssigned);
+  Events.GovernorPromoted.Add(  OnGovernorChanged);
+  Events.GovernorEjected.Add(   OnGovernorEjected);
+  Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
   Events.CulturalIdentityConversionOutcomeChanged.Add( OnCulturalIdentityConversionOutcomeChanged);
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);
 
   -- CQUI related events
-  LuaEvents.CQUI_CityInfoUpdated.Add( CQUI_OnCityInfoUpdated );    -- CQUI update city's real housing from improvements
-  LuaEvents.CQUI_AllCitiesInfoUpdated.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
+  LuaEvents.CQUI_CityInfoUpdated.Add(           CQUI_OnCityInfoUpdated );    -- CQUI update city's real housing from improvements
+  LuaEvents.CQUI_AllCitiesInfoUpdated.Add(      CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
   LuaEvents.CQUI_CityLostTileToCultureBomb.Add( CQUI_OnCityLostTileToCultureBomb );    -- CQUI update close to a culture bomb cities data and real housing from improvements
-  Events.CityRemovedFromMap.Add( CQUI_OnCityRemovedFromMap );    -- CQUI erase real housing from improvements data everywhere when a city removed from map
-  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsInitialized );
-  Events.CitySelectionChanged.Add( CQUI_OnBannerMouseExit );
-  Events.InfluenceGiven.Add( CQUI_OnInfluenceGiven );
+  Events.CityRemovedFromMap.Add(                CQUI_OnCityRemovedFromMap );    -- CQUI erase real housing from improvements data everywhere when a city removed from map
+  LuaEvents.CQUI_SettingsInitialized.Add(       CQUI_OnSettingsInitialized );
+  Events.CitySelectionChanged.Add(              CQUI_OnBannerMouseExit );
+  Events.InfluenceGiven.Add(                    CQUI_OnInfluenceGiven );
 end
 Initialize();


### PR DESCRIPTION
**WHAT CHANGED**

- Fixed the CityBanners display for Rise and Fall.
- ~~CityBanners.xml from Exp1 now matches Exp2~~ Reverted this.  CityBannersInstances.xml is like the Exp1 unmodified version, plus the CQUI elements.
- Fixed minor issue in Exp2 version where if damage was exactly 40%, things would not display.  (Line 1161 in updated; all other changes are just tabs to spaces, or other space characters)
- Fixed up some formatting in both CityBanners.lua files in the Exp1 and Exp2 folders. (basically: so it'd be easier to make out the differences in the two files in the VSCode Diffing tool).

**TESTING**

- Tested in game.  Only mods enabled were Rise and Fall and CQUI.
- Verified City Banner shows districts, religion, loyalty.
- Verified Aerodome shows the airplane icon.
- Verified Encampment shows district strength and health bars