### PR TITLE
Calculate Maya housing correctly

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannermanager.lua
+++ b/Assets/Expansion1/CityBanners/citybannermanager.lua
@@ -9,6 +9,7 @@ include( "LoyaltySupport" );
 include( "Civ6Common" );
 include( "LuaClass" );
 include( "CitySupport" );
+include( "GameCapabilities" );
 
 -- ===========================================================================
 --  CONSTANTS
@@ -4281,9 +4282,12 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
         if eImprovementType ~= -1 then
           if not kPlot:IsImprovementPillaged() then
             local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
-  
             if kImprovementData == 1 then    -- farms, pastures etc.
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
+              if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_FARM" and HasTrait("TRAIT_CIVILIZATION_MAYAB", Game.GetLocalPlayer()) then
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+              else
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
+              end
             elseif kImprovementData == 2 then    -- stepwells, kampungs, mekewaps, golf courses
               if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_STEPWELL" then    -- stepwells
                 local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_SANITATION"].Index);    -- check if a player researched Sanitation

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -97,7 +97,7 @@ function GetUnitActionsTable( pUnit )
       if (actionsTable["BUILD"][i]["IconId"] == "ICON_IMPROVEMENT_FARM") then
         -- For some reason, Locale.Lookup("LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING") returns an empty string, so we need to do this manually
         -- Each of the strings below is the LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING value
-        -- Note: The Lua string matching requires that we use the escape character (the % sign) for the brackets and plus and other , otherwise the strings will not match
+        -- Note: The Lua string matching requires that we use the escape character (the % sign) for the brackets and plus and other lua special characters used in string matching, otherwise the strings will not match
         local curLang = Locale.GetCurrentLanguage();
         local housingStr = "";
         if curLang.Type == "en_US" then

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -1,8 +1,14 @@
+include("GameCapabilities");
+
 -- ===========================================================================
 -- Cached Base Functions
 -- ===========================================================================
 BASE_CQUI_VIEW = View;
 BASE_CQUI_Refresh = Refresh;
+BASE_CQUI_GetUnitActionsTable = GetUnitActionsTable;
+
+-- temp global
+actionsTable = nil;
 
 -- ===========================================================================
 -- CQUI Members
@@ -64,4 +70,92 @@ function Refresh(player, unitId)
       end
     end
   end
+end
+
+-- ===========================================================================
+--  CQUI modified Refresh functiton : GetUnitActionsTable
+--  Update the Housing tool tip to show Farm Provides 1 Housing when Plaeyr is Maya
+--  This is fixing a bug in the unmodified game, as it still shows 0.5 Housing on the tool tip
+-- ===========================================================================
+function GetUnitActionsTable( pUnit )
+  print("** Hooked GetUnitActionsTable called 2");
+  actionsTable = BASE_CQUI_GetUnitActionsTable(pUnit);
+
+  --[[
+    Powershell Script to Pull the two lines from the text file:
+  
+    $xmlfiles = Get-ChildItem -Filter *.xml
+    $pat = 'LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING'
+    foreach ($xml in $xmlfiles)
+    {
+        $fn = $xml.Name
+        Get-Content $fn | Select-String -Pattern 'LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING' -Context 0,1
+    }
+  --]]
+
+  -- Update the Farm Tool Tip to show 1 Housing if the player is Maya
+  if HasTrait("TRAIT_CIVILIZATION_MAYAB", Game.GetLocalPlayer()) then
+    local iconCount = #actionsTable["BUILD"];
+    for i = 1, iconCount do
+      if (actionsTable["BUILD"][i]["IconId"] == "ICON_IMPROVEMENT_FARM") then
+        -- For some reason, Locale.Lookup("LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING") returns an empty string, so we need to do this manually
+        -- Each of the strings below is the LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING value
+        -- Note: The Lua string matching requires that we use the escape character (the % sign) for the brackets and plus and other , otherwise the strings will not match
+        local curLang = Locale.GetCurrentLanguage();
+        local housingStr = "";
+        if curLang.Type == "en_US" then
+          housingStr = "Provides {1_Amount:number #.#} %[ICON_Housing%] Housing";
+        elseif curLang.Type == "de_DE" then
+          housingStr = "Gewährt {1_Amount:number #.#} %[ICON_Housing%] Wohnraum";
+        elseif curLang.Type == "es_ES" then
+          housingStr = "Proporciona {1_Amount:number #.#} a Alojamiento %[ICON_Housing%]";
+        elseif curLang.Type == "fr_FR" then
+          housingStr = "%[ICON_Housing%] Habitations %+{1_Amount:number #.#}.";
+        elseif curLang.Type == "it_IT" then
+          housingStr = "Fornisce {1_Amount:number #.#} %[ICON_Housing%] Abitazioni";
+        elseif curLang.Type == "ja_JP" then
+          housingStr = "%[ICON_Housing%] 住宅%+{1_Amount:number #.#}";
+        elseif curLang.Type == "ko_KR" then
+          housingStr = "%[ICON_Housing%] 주거공간 {1_Amount:number #.#} 제공";
+        elseif curLang.Type == "pl_PL" then
+          housingStr = "Daje następującą liczbę %[ICON_Housing%] obszarów mieszkalnych: {1_Amount:number #.#}";
+        elseif curLang.Type == "pt_BR" then
+          housingStr = "Concede {1_Amount:number #.#} de %[ICON_Housing%] habitação";
+        elseif curLang.Type == "ru_RU" then
+          housingStr = "Предоставляет {1_Amount:number #.#} %[ICON_Housing%] жилья";
+        elseif curLang.Type == "zh_Hans_CN" then
+          housingStr = "提供{1_Amount:number #.#} %[ICON_Housing%] 住房";
+        elseif curLang.Type == "zh_Hant_HK" then
+          housingStr = "提供 {1_Amount:number #.#} %[ICON_Housing%] 住房";
+        else
+          print("Unknown language type: "..tostring(curLang.Type));
+        end
+
+        -- temp
+        print("housingStr is: "..housingStr);
+
+        if housingStr ~= "" then
+          local chunkToUpdate = "{1_Amount:number #.#}";
+          local housingStrBefore = housingStr:gsub(chunkToUpdate, tostring(Locale.ToNumber("0.5")));
+          local housingStrAfter = housingStr:gsub(chunkToUpdate, "1");
+
+          print("housingStrBefore is: "..housingStrBefore);
+          print("housingStrAfter is: "..housingStrAfter);
+
+
+          local updatedHelpString, replacedCount = actionsTable["BUILD"][i]["helpString"]:gsub(housingStrBefore, housingStrAfter);
+          print("updatedHelpString is: "..updatedHelpString);
+          print("replacedCount is: "..tostring(replacedCount));
+
+          if replacedCount == 1 then
+            actionsTable["BUILD"][i]["helpString"] = updatedHelpString;
+          end
+        end
+
+        break -- Only one farm icon, break from the for loop
+      end
+    end
+  end
+
+  return actionsTable;
 end

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -7,9 +7,6 @@ BASE_CQUI_VIEW = View;
 BASE_CQUI_Refresh = Refresh;
 BASE_CQUI_GetUnitActionsTable = GetUnitActionsTable;
 
--- temp global
-actionsTable = nil;
-
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
@@ -79,7 +76,7 @@ end
 -- ===========================================================================
 function GetUnitActionsTable( pUnit )
   print_debug("CQUI: GetUnitActionsTable Hook Called")
-  actionsTable = BASE_CQUI_GetUnitActionsTable(pUnit);
+  local actionsTable = BASE_CQUI_GetUnitActionsTable(pUnit);
 
   --[[
     Powershell Script to Pull the two lines from the text file:

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -78,7 +78,7 @@ end
 --  This is fixing a bug in the unmodified game, as it still shows 0.5 Housing on the tool tip
 -- ===========================================================================
 function GetUnitActionsTable( pUnit )
-  print("** Hooked GetUnitActionsTable called 2");
+  print_debug("CQUI: GetUnitActionsTable Hook Called")
   actionsTable = BASE_CQUI_GetUnitActionsTable(pUnit);
 
   --[[
@@ -131,28 +131,25 @@ function GetUnitActionsTable( pUnit )
           print("Unknown language type: "..tostring(curLang.Type));
         end
 
-        -- temp
-        print("housingStr is: "..housingStr);
-
         if housingStr ~= "" then
           local chunkToUpdate = "{1_Amount:number #.#}";
           local housingStrBefore = housingStr:gsub(chunkToUpdate, tostring(Locale.ToNumber("0.5")));
           local housingStrAfter = housingStr:gsub(chunkToUpdate, "1");
 
-          print("housingStrBefore is: "..housingStrBefore);
-          print("housingStrAfter is: "..housingStrAfter);
-
+          print_debug("housingStr is: "..housingStr);
+          print_debug("housingStrBefore is: "..housingStrBefore);
+          print_debug("housingStrAfter is: "..housingStrAfter);
 
           local updatedHelpString, replacedCount = actionsTable["BUILD"][i]["helpString"]:gsub(housingStrBefore, housingStrAfter);
-          print("updatedHelpString is: "..updatedHelpString);
-          print("replacedCount is: "..tostring(replacedCount));
+          print_debug("updatedHelpString is: "..updatedHelpString);
+          print_debug("replacedCount is: "..tostring(replacedCount));
 
           if replacedCount == 1 then
             actionsTable["BUILD"][i]["helpString"] = updatedHelpString;
           end
         end
 
-        break -- Only one farm icon, break from the for loop
+        break -- Only the farm icon needs updating, break from the for loop
       end
     end
   end

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -71,7 +71,7 @@ end
 
 -- ===========================================================================
 --  CQUI modified Refresh functiton : GetUnitActionsTable
---  Update the Housing tool tip to show Farm Provides 1 Housing when Plaeyr is Maya
+--  Update the Housing tool tip to show Farm Provides 1 Housing when Player is Maya
 --  This is fixing a bug in the unmodified game, as it still shows 0.5 Housing on the tool tip
 -- ===========================================================================
 function GetUnitActionsTable( pUnit )

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -75,7 +75,6 @@ end
 --  This is fixing a bug in the unmodified game, as it still shows 0.5 Housing on the tool tip
 -- ===========================================================================
 function GetUnitActionsTable( pUnit )
-  print_debug("CQUI: GetUnitActionsTable Hook Called")
   local actionsTable = BASE_CQUI_GetUnitActionsTable(pUnit);
 
   -- Update the Farm Tool Tip to show 1 Housing if the player is Maya
@@ -85,7 +84,8 @@ function GetUnitActionsTable( pUnit )
       if (actionsTable["BUILD"][i]["IconId"] == "ICON_IMPROVEMENT_FARM") then
         if housingStr ~= "" then
           local housingStrBefore = Locale.Lookup("LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING", 0.5);
-          print("housingStrBefore is (before adding escape chars): "..housingStrBefore);
+          -- print_debug isn't working in this file, so for now just comment out the print statements
+          -- print("housingStrBefore is (before adding escape chars): "..housingStrBefore);
           -- Lua parses characters that are found in regex ([],+, etc) so we need to escape those in our string we're looking to replace
           -- Using gsub("%p", "%%%1") will replace all of the punctuation characters (which includes [], +, )
           -- See https://www.lua.org/pil/20.2.html
@@ -93,10 +93,10 @@ function GetUnitActionsTable( pUnit )
           local housingStrAfter = Locale.Lookup("LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING", 1);
           local updatedHelpString, replacedCount = actionsTable["BUILD"][i]["helpString"]:gsub(housingStrBefore, housingStrAfter);
 
-          print("housingStrBefore is (after adding escape chars): "..housingStrBefore);
-          print("housingStrAfter is: "..housingStrAfter);
-          print("updatedHelpString is: "..updatedHelpString);
-          print("replacedCount is: "..tostring(replacedCount));
+          -- print("housingStrBefore is (after adding escape chars): "..housingStrBefore);
+          -- print("housingStrAfter is: "..housingStrAfter);
+          -- print("updatedHelpString is: "..updatedHelpString);
+          -- print("replacedCount is: "..tostring(replacedCount));
 
           if replacedCount == 1 then
             actionsTable["BUILD"][i]["helpString"] = updatedHelpString;

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -7,6 +7,7 @@ include( "SupportFunctions" );
 include( "Civ6Common" );
 include( "Colors" );
 include( "CitySupport" );
+include( "GameCapabilities" );
 
 -- ===========================================================================
 --  CONSTANTS
@@ -3522,7 +3523,11 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
           if not kPlot:IsImprovementPillaged() then
             local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
             if kImprovementData == 1 then    -- farms, pastures etc.
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
+              if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_FARM" and HasTrait("TRAIT_CIVILIZATION_MAYAB", Game.GetLocalPlayer()) then
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+              else
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
+              end
             elseif kImprovementData == 2 then    -- stepwells, kampungs
               if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_STEPWELL" then    -- stepwells
                 local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_SANITATION"].Index);    -- check if a player researched Sanitation
@@ -3544,13 +3549,16 @@ function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
         end
       end
     end
+
     CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
     if CQUI_HousingFromImprovementsTable[PlayerID] == nil then
       CQUI_HousingFromImprovementsTable[PlayerID] = {};
     end
+
     if CQUI_HousingUpdated[PlayerID] == nil then
       CQUI_HousingUpdated[PlayerID] = {};
     end
+
     CQUI_HousingFromImprovementsTable[PlayerID][pCityID] = CQUI_HousingFromImprovements;
     CQUI_HousingUpdated[PlayerID][pCityID] = true;
     LuaEvents.CQUI_RealHousingFromImprovementsCalculated(pCityID, CQUI_HousingFromImprovements);

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Mod id="1d44b5e7-753e-405b-af24-5ee634ec8a01" version="2.01">
+<Mod id="1d44b5e7-753e-405b-af24-5ee634ec8a01" version="2.1">
   <!-- ==============================  Basic Mod Information ============================== -->
   <Properties>
     <AffectsSavedGames>0</AffectsSavedGames>
     <Name>Community Quick User Interface</Name>
     <Teaser>CQUI</Teaser>
     <Description>The Community Quick User Interface MOD, CivFanatics Version: Updated May 2020.</Description>
-    <CompatibleVersions>2.0</CompatibleVersions>
+    <CompatibleVersions>2.0,2.01</CompatibleVersions>
   </Properties>
 
   <!--============================== Incompatible mods ============================== -->


### PR DESCRIPTION
NOTE: This does NOT include the changes to fix the CityBanners in Expansion 1... this is a different branch off of master.  We should complete that one first, though I don't think they'll have any merge issues.

**WHAT THIS IS**
- Housing calculation now correctly accounts for Maya +1 housing on Farms
- Tooltip on the Farming Icon shows +1 Housing if player is Maya
  - this accounts for a bug in the game without ANY mods -- it shows 0.5 Housing on the tooltip!

**TESTING**
- Verified housing and tooltip showed correctly as Maya
- Verified housing and tooltip showed correctly as not-Maya with Gathering Storm loaded (was India)
- Verified housing and tooltip showed correctly with no Expansions loaded
- Verified housing and tooltip showed correctly as Maya with fr-FR (french) as my display language
- Verified housing and tooltip showed correctly as not-Maya with fr-FR (french) as my display language

I did not test any other languages... it's way to late at night right now.

**OPEN QUESTION**
Is there some secret to Locale.Lookup that I am missing?  I could use it in the UnitPanel context to get plenty of strings, but not for LOC_OPERATION_BUILD_IMPROVEMENT_HOUSING or many of the LOC_OPERATION strings.
Wherever the tooltip is actually built is hidden away somewhere, so this string replace will do.
