### PR TITLE
Quick fix for compatibility with Extended Diplomacy Ribbon

### DIFF
--- a/Assets/Expansion1/Replacements/leadericon.lua
+++ b/Assets/Expansion1/Replacements/leadericon.lua
@@ -162,15 +162,17 @@ function LeaderIcon:UpdateTeamAndRelationship( playerID: number)
   self.Controls.Relationship:SetHide( not isValid );
 
   -- CQUI Additions
-  local gameEras:table = Game.GetEras();
-  if gameEras:HasHeroicGoldenAge(playerID) then
-    self.Controls.CQUI_Era:SetText("[ICON_GLORY_SUPER_GOLDEN_AGE]");
-  elseif gameEras:HasGoldenAge(playerID) then
-    self.Controls.CQUI_Era:SetText("[ICON_GLORY_GOLDEN_AGE]");
-  elseif gameEras:HasDarkAge(playerID) then
-    self.Controls.CQUI_Era:SetText("[ICON_GLORY_DARK_AGE]");
-  else
-    self.Controls.CQUI_Era:SetText("[ICON_GLORY_NORMAL_AGE]");
+  if (self.Controls.CQUI_Era ~= nil) then
+    local gameEras:table = Game.GetEras();
+    if gameEras:HasHeroicGoldenAge(playerID) then
+      self.Controls.CQUI_Era:SetText("[ICON_GLORY_SUPER_GOLDEN_AGE]");
+    elseif gameEras:HasGoldenAge(playerID) then
+      self.Controls.CQUI_Era:SetText("[ICON_GLORY_GOLDEN_AGE]");
+    elseif gameEras:HasDarkAge(playerID) then
+      self.Controls.CQUI_Era:SetText("[ICON_GLORY_DARK_AGE]");
+    else
+      self.Controls.CQUI_Era:SetText("[ICON_GLORY_NORMAL_AGE]");
+    end
   end
   -- CQUI Additions
 

--- a/Assets/UI/diplomacyactionview_CQUI.lua
+++ b/Assets/UI/diplomacyactionview_CQUI.lua
@@ -110,6 +110,16 @@ end
 function OnActivateIntelRelationshipPanel(relationshipInstance : table)
   local intelSubPanel = relationshipInstance;
 
+  -- Check to make sure the XML wasn't overwritten by another mod
+  local cquiXmlActive:boolean = true;
+  cquiXmlActive = cquiXmlActive and (intelSubPanel.RelationshipScore ~= nil);
+  cquiXmlActive = cquiXmlActive and (intelSubPanel.RelationshipReasonsTotal ~= nil);
+  cquiXmlActive = cquiXmlActive and (intelSubPanel.RelationshipReasonsTotalScorePerTurn ~= nil);
+  if not cquiXmlActive then
+    BASE_OnActivateIntelRelationshipPanel(intelSubPanel);
+    return
+  end
+
   -- Get the selected player's Diplomactic AI
   local selectedPlayerDiplomaticAI = ms_SelectedPlayer:GetDiplomaticAI();
   -- What do they think of us?

--- a/Assets/UI/diplomacydealview_CQUI.lua
+++ b/Assets/UI/diplomacydealview_CQUI.lua
@@ -389,12 +389,22 @@ end
 function UpdateOtherPlayerText(otherPlayerSays)
   BASE_CQUI_UpdateOtherPlayerText(otherPlayerSays);
 
-  CQUI_IconOnlyIM:ResetInstances();
-  CQUI_IconAndTextForCitiesIM:ResetInstances();
-  CQUI_IconAndTextForGreatWorkIM:ResetInstances();
+  local isCquiXmlActive : boolean = true;
+  isCquiXmlActive = isCquiXmlActive and (Controls.PlayerCivIcon ~= nil);
+  isCquiXmlActive = isCquiXmlActive and (Controls.PlayerLeaderName ~= nil);
+  isCquiXmlActive = isCquiXmlActive and (Controls.PlayerCivName ~= nil);
+  isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerCivIcon ~= nil);
+  isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerLeaderName ~= nil);
+  isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerCivName ~= nil);
 
-  PopulateSignatureArea(g_LocalPlayer, Controls.PlayerCivIcon, Controls.PlayerLeaderName, Controls.PlayerCivName);  -- Expansion 2 added global variable for local and other player
-  PopulateSignatureArea(g_OtherPlayer, Controls.OtherPlayerCivIcon, Controls.OtherPlayerLeaderName, Controls.OtherPlayerCivName);
+  if isCquiXmlActive then
+    CQUI_IconOnlyIM:ResetInstances();
+    CQUI_IconAndTextForCitiesIM:ResetInstances();
+    CQUI_IconAndTextForGreatWorkIM:ResetInstances();
+
+    PopulateSignatureArea(g_LocalPlayer, Controls.PlayerCivIcon, Controls.PlayerLeaderName, Controls.PlayerCivName);  -- Expansion 2 added global variable for local and other player
+    PopulateSignatureArea(g_OtherPlayer, Controls.OtherPlayerCivIcon, Controls.OtherPlayerLeaderName, Controls.OtherPlayerCivName);
+  end
 end
 
 


### PR DESCRIPTION
Fixes #17 Fixes #30 
Quick fix to allow usage of EDR mod with CQUI. Done by allowing EDR to override whatever it needs to and then adding nil check in CQUI. A better more extensive fix would be to communicate with Aristos and incorporate what Aristos did in EDR and update his old code in CQUI. Right now keeping both enabled will override the trade deal screen with the EDR version.

Test conditions tried:
No Expansion, RF only, RF and GS
CQUI only, CQUI and EDR

1. Start new game
2. Play until meeting a player
3. Check the diplomacy banner tooltips
4. Check trade deal screen
5. Check diplomacy screen which shows the details of relationship