### PR TITLE
Fix casing for DiploAction and Ribbon references

### DIFF
--- a/Assets/Expansion1/Replacements/diplomacyactionview_CQUI_expansion1.lua
+++ b/Assets/Expansion1/Replacements/diplomacyactionview_CQUI_expansion1.lua
@@ -3,4 +3,4 @@
 -- ===========================================================================
 include("DiplomacyActionView_Expansion1.lua");
 
-include("DiplomacyActionView_CQUI.lua");
+include("diplomacyactionview_CQUI.lua");

--- a/Assets/Expansion1/Replacements/diplomacyribbon_CQUI_expansion1.lua
+++ b/Assets/Expansion1/Replacements/diplomacyribbon_CQUI_expansion1.lua
@@ -3,4 +3,4 @@
 -- ===========================================================================
 include("DiplomacyRibbon_Expansion1.lua");
 
-include("DiplomacyRibbon_CQUI.lua");
+include("diplomacyribbon_CQUI.lua");

--- a/Assets/Expansion2/Replacements/diplomacyactionview_CQUI_expansion2.lua
+++ b/Assets/Expansion2/Replacements/diplomacyactionview_CQUI_expansion2.lua
@@ -3,4 +3,4 @@
 -- ===========================================================================
 include("DiplomacyActionView_Expansion2.lua");
 
-include("DiplomacyActionView_CQUI.lua");
+include("diplomacyactionview_CQUI.lua");

--- a/Assets/Expansion2/Replacements/diplomacydealview_CQUI_expansion2.lua
+++ b/Assets/Expansion2/Replacements/diplomacydealview_CQUI_expansion2.lua
@@ -11,7 +11,7 @@ BASE_CQUI_LateInitialize = LateInitialize;
 -- ===========================================================================
 -- CQUI File
 -- ===========================================================================
-include("DiplomacyDealView_CQUI.lua");
+include("diplomacydealview_CQUI.lua");
 
 -- ===========================================================================
 function LateInitialize()

--- a/Assets/UI/diplomacyactionview_CQUI_basegame.lua
+++ b/Assets/UI/diplomacyactionview_CQUI_basegame.lua
@@ -3,4 +3,4 @@
 -- ===========================================================================
 include("DiplomacyActionView");
 
-include("DiplomacyActionView_CQUI.lua");
+include("diplomacyactionview_CQUI.lua");

--- a/Assets/UI/diplomacydealview_CQUI_basegame.lua
+++ b/Assets/UI/diplomacydealview_CQUI_basegame.lua
@@ -2,7 +2,7 @@
 -- Base File
 -- ===========================================================================
 include("DiplomacyDealView");
-include("DiplomacyDealView_CQUI.lua");
+include("diplomacydealview_CQUI.lua");
 
 g_LocalPlayer = nil;
 g_OtherPlayer = nil;

--- a/Assets/UI/diplomacyribbon_CQUI_basegame.lua
+++ b/Assets/UI/diplomacyribbon_CQUI_basegame.lua
@@ -3,4 +3,4 @@
 -- ===========================================================================
 include("DiplomacyRibbon");
 
-include("DiplomacyRibbon_CQUI.lua");
+include("diplomacyribbon_CQUI.lua");


### PR DESCRIPTION
Turns out all three (basegame, exp1, exp2) used incorrect casing for the references to the diplomacyribbon_CQUI.lua and diplomacydealview_CQUI.lua files.  Fix for #68, possible fix for #36 

I checked the modinfo and things looked okay there, though I took the opportunity to take out a commented line that should have been removed in a previous change

Tested with saves from Exp2, Exp1, and Vanilla.  All diploscreens and ribbon appeared ok.
