### PR TITLE
Fixes #62

### DIFF
--- a/Assets/Text/cqui_text_general.xml
+++ b/Assets/Text/cqui_text_general.xml
@@ -75,6 +75,14 @@
     <Row Tag="LOC_CQUI_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP" Language="en_US">
       <Text>There are unlocked citizens being automatically assigned by the AI city governor.</Text>
     </Row>
+    
+    <!-- #62 Infixo original owner tooltip -->
+    <Row Tag="LOC_CQUI_CITY_BANNER_ORIGINAL_CAPITAL_TT" Language="en_US">
+        <Text>[NEWLINE][ICON_Bullet]Original capital of {1_OriginalOwner}</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITY_BANNER_ORIGINAL_CITY_TT" Language="en_US">
+        <Text>[NEWLINE][ICON_Bullet]Original city of {1_OriginalOwner}</Text>
+    </Row>
 
   </LocalizedText>
 </GameData>

--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -3,6 +3,16 @@
 ------------------------------------------------------------------------------
 
 -- ===========================================================================
+-- Expansions check
+-- ===========================================================================
+
+-- these are global variables, will be visible in the entire context
+-- please note that Modding object is only available in the UI context
+-- in the Gameplay context a different method must be used as those variables will be nil
+g_bIsRiseAndFall    = Modding and Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9"); -- Rise & Fall
+g_bIsGatheringStorm = Modding and Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
+
+-- ===========================================================================
 --  VARIABLES
 -- ===========================================================================
 CQUI_ShowDebugPrint = false;


### PR DESCRIPTION
#62: info about the original owner in the tooltip
It is only implemented for expansions, base game doesn't have the "owner info" functionality in the first place, so there is nothing to work on.
I also added an expansion check that can be reused. It was needed here because an extra feature was added in XP2 only.