### PR TITLE
Fix minor XML typos #77

### DIFF
--- a/Assets/Expansion2/Replacements/diplomacyactionview.xml
+++ b/Assets/Expansion2/Replacements/diplomacyactionview.xml
@@ -515,7 +515,7 @@
 
   <Instance		Name="TextInfoInstance">
     <Stack		ID="Top"					StackGrowth="Bottom" StackPadding="4">
-      <Label	ID="Header"				Style="FontFlair14"		WrapWidth="350" SmallCapsType="EveryWord" SmallCaps="20" String="$Header$"/>y
+      <Label	ID="Header"				Style="FontFlair14"		WrapWidth="350" SmallCapsType="EveryWord" SmallCaps="20" String="$Header$"/>
       <Label	ID="Description"	Style="DawnText"	WrapWidth="350" String="$Description$"/>
     </Stack>
   </Instance>

--- a/Assets/UI/Panels/citypanel.xml
+++ b/Assets/UI/Panels/citypanel.xml
@@ -186,7 +186,7 @@
             <Label        ID="PopulationNumber"       Anchor="C,C" Style="CityPanelNumLarge" WrapWidth="70" String="999" Align="Center" KerningAdjustment="-1" Offset="-1,0"/>
           </Image>
         </Button>
-      </Grid>
+      </GridButton>
     </SlideAnim>
   </AlphaAnim>
 </Context>

--- a/Assets/UI/Panels/citypaneloverview.xml
+++ b/Assets/UI/Panels/citypaneloverview.xml
@@ -279,7 +279,7 @@
                   <Stack                              StackGrowth="Right">
                     <Image  ID="DominantReligionSymbol"       Anchor="L,T" Offset="0,0" Size="22,22"  Hidden="1" />
                     <Label  ID="DominantReligionName"         Anchor="L,T" Offset="2,7"                 Style="CityPanelText"     String="Other Religion Instance" />
-                  </Stack>                                                               >
+                  </Stack>
                 </Grid>
                 <Stack	ID="ReligionBeliefsStack"		Anchor="R,T" Offset="0,42" StackPadding="2"/>
               </Grid>

--- a/Assets/UI/diplomacyactionview.xml
+++ b/Assets/UI/diplomacyactionview.xml
@@ -551,7 +551,7 @@
 
   <Instance		Name="TextInfoInstance">
     <Stack		ID="Top"					StackGrowth="Bottom" StackPadding="4">
-      <Label	ID="Header"				Style="FontFlair14"		WrapWidth="350" SmallCapsType="EveryWord" SmallCaps="20" String="$Header$"/>y
+      <Label	ID="Header"				Style="FontFlair14"		WrapWidth="350" SmallCapsType="EveryWord" SmallCaps="20" String="$Header$"/>
       <Label	ID="Description"	Style="DawnText"	WrapWidth="350" String="$Description$"/>
     </Stack>
   </Instance>

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -30,16 +30,16 @@ local boolean_options = {
 local ProductionItemHeightConverter = {
   ToSteps = function(value)
       local out = value - 24;
-      if(out < 0) then
+      if (out < 0) then
         out = 0;
-      elseif(out > 104) then
+      elseif (out > 104) then
         out = 104;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = steps + 24;
-      if(out > 128) then
+      if (out > 128) then
         out = 128;
       end
       return out;
@@ -50,14 +50,14 @@ local ProductionItemHeightConverter = {
 local WorkIconSizeConverter = {
   ToSteps = function(value)
       local out = math.floor((value - 48) / 8);
-      if(out < 0) then
+      if (out < 0) then
         out = 0;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = (steps) * 8 + 48;
-      if(out > 128) then
+      if (out > 128) then
         out = 128;
       end
       return out;
@@ -68,14 +68,14 @@ local WorkIconSizeConverter = {
 local WorkIconAlphaConverter = {
     ToSteps = function(value)
       local out = value;
-      if(out < 0) then
+      if (out < 0) then
         out = 0;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = steps;
-      if(out > 100) then
+      if (out > 100) then
         out = 100;
       end
       return out;

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -30,16 +30,16 @@ local boolean_options = {
 local ProductionItemHeightConverter = {
   ToSteps = function(value)
       local out = value - 24;
-      if (out < 0) then
+      if(out < 0) then
         out = 0;
-      elseif (out > 104) then
+      elseif(out > 104) then
         out = 104;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = steps + 24;
-      if (out > 128) then
+      if(out > 128) then
         out = 128;
       end
       return out;
@@ -50,14 +50,14 @@ local ProductionItemHeightConverter = {
 local WorkIconSizeConverter = {
   ToSteps = function(value)
       local out = math.floor((value - 48) / 8);
-      if (out < 0) then
+      if(out < 0) then
         out = 0;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = (steps) * 8 + 48;
-      if (out > 128) then
+      if(out > 128) then
         out = 128;
       end
       return out;
@@ -68,14 +68,14 @@ local WorkIconSizeConverter = {
 local WorkIconAlphaConverter = {
     ToSteps = function(value)
       local out = value;
-      if (out < 0) then
+      if(out < 0) then
         out = 0;
       end
       return out;
     end,
   ToValue = function(steps)
       local out = steps;
-      if (out > 100) then
+      if(out > 100) then
         out = 100;
       end
       return out;


### PR DESCRIPTION
As documented in issue #77 - takes care of three issues in the XML files that I happened across when doing the four-spaces fixes.  Two are from the basegame unmodified files, one is from a change Azurency made about 2 years ago.

Quick tests showed no issues with a vanilla game and expansion 2 game.
