### PR TITLE
Relocate the City/Encampment Strike Buttons

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -30,6 +30,18 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="en_US">
       <Text>Enable this if you want "End Turn" to be block if a city can attack.</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="en_US">
+      <Text>Relocate City Strike button</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="en_US">
+      <Text>Enable this to relocate the City Strike button above health and defense bars</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="en_US">
+      <Text>Relocate Encampment Strike button</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="en_US">
+      <Text>Enable this to relocate the Encampment Strike button above health and defense bars</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="en_US">
       <Text>Production item height</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="de_DE">
       <Text>Der "Nächste Runde"-Button ist blockiert, solange eine Stadtverteidigung möglich ist.</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="de_DE">
+      <Text>City Strike-Schaltfläche verschieben</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="de_DE">
+      <Text>Aktivieren Sie diese Option, um den City Strike-Button über den Gesundheits- und Verteidigungsbalken zu verschieben</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="de_DE">
+      <Text>Verschieben Sie die Schaltfläche "Streik im Lager"</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="de_DE">
+      <Text>Aktivieren Sie diese Option, um die Schaltfläche "Streik des Lagers" über den Gesundheits- und Verteidigungsbalken zu verschieben</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="de_DE">
       <Text>Zeilenhöhe i.d. Produktwahlliste</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_es.xml
+++ b/Assets/Text/cqui_text_settings_es.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="es_ES">
       <Text>Activar para bloquear "Finalizar Turno" si una ciudad puede atacar.</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="es_ES">
+      <Text>Botón Reubicar City Strike</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="es_ES">
+      <Text>Habilite esto para reubicar el botón City Strike sobre las barras de salud y defensa</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="es_ES">
+      <Text>Botón Reubicar Golpe de campamento</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="es_ES">
+      <Text>Habilite esto para reubicar el botón de Golpe de campamento sobre las barras de salud y defensa</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="es_ES">
       <Text>Altura de elementos de producción</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_fr.xml
+++ b/Assets/Text/cqui_text_settings_fr.xml
@@ -27,6 +27,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="fr_FR">
       <Text>Vue des Villes</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="fr_FR">
+      <Text>Déplacer le bouton City Strike</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="fr_FR">
+      <Text>Activez cette option pour déplacer le bouton City Strike au-dessus des barres de santé et de défense</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="fr_FR">
+      <Text>Bouton Déplacer la grève du campement</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="fr_FR">
+      <Text>Activez cette option pour déplacer le bouton Encampment Strike au-dessus des barres de santé et de défense</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="fr_FR">
       <!-- TODO -->
       <Text>Production item height</Text>

--- a/Assets/Text/cqui_text_settings_it.xml
+++ b/Assets/Text/cqui_text_settings_it.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="it_IT">
       <Text>Abilita se vuoi che il pulsante "Fine Turno" sia bloccato se una città può attaccare.</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="it_IT">
+      <Text>Riposiziona il pulsante City Strike</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="it_IT">
+      <Text>Abilita questo per riposizionare il pulsante City Strike sopra le barre di salute e difesa</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="it_IT">
+      <Text>Riposizionare il pulsante Colpo Encampment</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="it_IT">
+      <Text>Abilita questo per riposizionare il pulsante Colpo Encampment sopra le barre di salute e difesa</Text>
+    </Row>    
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="it_IT">
       <Text>Altezza elemento da produrre</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_ja.xml
+++ b/Assets/Text/cqui_text_settings_ja.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="ja_JP">
       <Text>都市砲撃できる場合はターンを終了できなくする。</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="ja_JP">
+      <Text>City Strikeボタンを再配置する</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="ja_JP">
+      <Text>これを有効にして、シティストライクボタンをヘルスバーと防御バーの上に再配置します。</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="ja_JP">
+      <Text>陣営攻撃ボタンを再配置</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ja_JP">
+      <Text>これを有効にして、エンキャンプメントストライクボタンをヘルスバーと防御バーの上に再配置します</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ja_JP">
       <Text>生産アイテムの縦幅</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_ko.xml
+++ b/Assets/Text/cqui_text_settings_ko.xml
@@ -24,6 +24,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="ko_KR">
       <Text>도시 화면</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="ko_KR">
+      <Text>도시 스트라이크 버튼 재배치</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="ko_KR">
+      <Text>이 옵션을 사용하면 체력 및 방어 막대 위의 City Strike 버튼을 재배치합니다</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="ko_KR">
+      <Text>야영 스트라이크 재배치 버튼</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ko_KR">
+      <Text>이 옵션을 사용하면 상태 및 방어 막대 위의 야영지 스트라이크 버튼을 재배치하십시오.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ko_KR">
       <Text>도시 생산창 아이템 항목 높이</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="pl_PL">
       <Text>Włącz tę opcję jeśli chcesz by "Zakończ Turę" było zablokowane gdy miasto może atakować.</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="pl_PL">
+      <Text>Zmień położenie przycisku City Strike</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="pl_PL">
+      <Text>Włącz tę opcję, aby przenieść przycisk Strajku Miasta powyżej pasków zdrowia i obrony</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="pl_PL">
+      <Text>Zmień położenie przycisku obozowania obozowiska</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="pl_PL">
+      <Text>Włącz tę opcję, aby przenieść przycisk Obozowisko powyżej pasków zdrowia i obrony</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="pl_PL">
       <Text>Wysokość elementu produkcji</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_pt.xml
+++ b/Assets/Text/cqui_text_settings_pt.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="pt_BR">
       <Text>Habilite isso se você quer bloquear "Final de Turno" se uma cidade pode atacar.</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="pt_BR">
+      <Text>Reposicionar botão Strike City</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="pt_BR">
+      <Text>Habilite isso para realocar o botão City Strike acima das barras de saúde e defesa</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="pt_BR">
+      <Text>Reposicionar botão de ataque de acampamento</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="pt_BR">
+      <Text>Habilite isso para realocar o botão Ataque ao acampamento acima das barras de saúde e defesa</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="pt_BR">
       <Text>Altura dos itens de produção</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_ru.xml
+++ b/Assets/Text/cqui_text_settings_ru.xml
@@ -30,6 +30,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="ru_RU">
       <Text>Предотвращает завершение хода, когда город может атаковать</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="ru_RU">
+      <Text>Кнопка Смена места жительства Attack Город</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="ru_RU">
+      <Text>Включите это, чтобы переместить кнопку City Attack поверх панелей здоровья и защиты.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="ru_RU">
+      <Text>Переместить кнопку атаки Лагерь</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ru_RU">
+      <Text>Включите это, чтобы переместить кнопку Удар по лагерю над панелями здоровья и защиты</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ru_RU">
       <Text>Высота строки элемента производства</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_zh.xml
+++ b/Assets/Text/cqui_text_settings_zh.xml
@@ -24,6 +24,19 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="zh_Hans_CN">
       <Text>城市视图</Text>
     </Row>
+    <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="zh_Hans_CN">
+      <Text>移居城市攻击图标</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP" Language="zh_Hans_CN">
+      <Text>启用此选项可将“城市攻击”按钮移到健康和防御面板上方</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" Language="zh_Hans_CN">
+      <Text>移居营地攻击图标</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="zh_Hans_CN">
+      <Text>启用此选项可将“营地攻击”按钮移至健康和防御栏上方。</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="zh_Hans_CN">
       <Text>生产项目横幅的高度</Text>
     </Row>

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -3,7 +3,6 @@
 -- This is what should go in the citybannermanager_CQUI file, the specific-to-basegame things go the _basegame file
 -- ===========================================================================
 include( "CityBannerManager" );
-include( "Civ6Common" ); -- IsExpansion1Active/IsExpansion2Active
 include( "CQUICommon.lua" );
 
 -- ===========================================================================
@@ -916,7 +915,7 @@ end
 -- ===========================================================================
 function CQUI_SetCityStrikeButtonLocation(cityBannerInstance, rotate, offsetY, anchor)
     cityStrikeImage = nil;
-    if (IsExpansion1Active() or IsExpansion2Active()) then
+    if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
         cityStrikeImage = cityBannerInstance.CityStrike;
     else
         -- Basegame calls this CityAttackContainer

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -819,6 +819,7 @@ function CQUI_OnCityRangeStrikeButtonClick( playerID, cityID )
         LuaEvents.CQUI_Strike_Exit();
         return;
     end
+
     -- Enter the range city mode on click (not on hover of a button, the old workaround)
     LuaEvents.CQUI_Strike_Enter();
     -- Allow to switch between different city range attack (clicking on the range button of one

--- a/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
@@ -19,7 +19,6 @@ BASE_CQUI_CityBanner_Initialize = CityBanner.Initialize;
 BASE_CQUI_CityBanner_Uninitialize = CityBanner.Uninitialize;
 BASE_CQUI_CityBanner_UpdateInfo = CityBanner.UpdateInfo;
 BASE_CQUI_CityBanner_UpdatePopulation = CityBanner.UpdatePopulation;
-BASE_CQUI_CityBanner_UpdateRangeStrike = CityBanner.UpdateRangeStrike;
 BASE_CQUI_CityBanner_UpdateStats = CityBanner.UpdateStats;
 
 -- ============================================================================

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -36,6 +36,8 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ("CQUI_ShowGenericBuilderLens", 1), -- Shows generic hexes (white tiles) when in builder lens
         ("CQUI_AutoExpandUnitActions", 1), -- Automatically reveals the secondary unit actions normally hidden inside an expando
         ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
+        ("CQUI_RelocateCityStrike", 1), -- Relocate the City Strike button to above the city health and defense bars
+        ("CQUI_RelocateEncampmentStrike", 0), -- Relocate the Encampment Strike button to above the encampment health and defense bars
         ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
         ("CQUI_ShowCultureGrowth", 1), -- Shows cultural growth overlay in cityview
         ("CQUI_ShowPolicyReminder", 1),

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -355,6 +355,8 @@ function Initialize()
     PopulateCheckBox(Controls.SmartbannerCulturalCheckbox, "CQUI_Smartbanner_Cultural", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP"));
     PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
     PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP"));
+    PopulateCheckBox(Controls.RelocateCityStrikeCheckbox, "CQUI_RelocateCityStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP"));
+    PopulateCheckBox(Controls.RelocateEncampmentStrikeCheckbox, "CQUI_RelocateEncampmentStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
     PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
     PopulateCheckBox(Controls.WonderBuiltVisualCheckbox, "CQUI_WonderBuiltPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTVISUAL_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -66,86 +66,95 @@
                         </Stack>
                     </Container>
                     <Container ID="CityviewOptions" Size="parent,parent" Hidden="1">
-                        <Stack ID="CityViewStack" Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ProductionQueueCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" />
-                            </Stack>
-                            <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
-                                <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="ProductionItemHeightText" Offset="3,0" />
-                                <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_ITEMHEIGHT"/>
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <Slider Style="SliderControl" Anchor="R,C" Size="300,13" Offset="5,0" SpaceForScroll="0" ID="ProductionItemHeightSlider" Steps="104" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ShowCultureGrowthCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ShowYieldsOnCityHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ShowCitizenIconsOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ShowCityManageAreaOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="ShowCityManageAreaInScreenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" />
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
-                            </Stack>
-                            <Stack Anchor="C,C" StackGrowth="Left">
-                                <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
-                            </Stack>
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />
-                            </Stack>
-                            <Stack ID="SmartbannerCheckboxes" Anchor="R,T" StackGrowth="Down">
-                                <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
-                                <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-                                    <GridButton ID="SmartbannerUnlockedCitizenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_HUD_CITY_UNASSIGNED_CITIZENS" />
+                        <ScrollPanel Anchor="C,T" Style="ListingScrollPanel" Offset="0,10" Size="parent-20,parent-5" Vertical="1">
+                            <ScrollBar Style="ScrollVerticalBar" Offset="-20,-5" Length="420" Anchor="R,C" AnchorSide="O,I" />
+                            <Stack ID="CityViewStack" Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ProductionQueueCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" />
                                 </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-                                    <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_DISTRICTS_TITLE" />
+                                <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="ProductionItemHeightText" Offset="3,0" />
+                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_ITEMHEIGHT"/>
                                 </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-                                    <GridButton ID="SmartbannerPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CIVINFO_POPULATION" />
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <Slider Style="SliderControl" Anchor="R,C" Size="300,13" Offset="5,0" SpaceForScroll="0" ID="ProductionItemHeightSlider" Steps="104" />
                                 </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-                                    <GridButton ID="SmartbannerCulturalCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_CITYSTATES_PAGEGROUP_CULTURAL_NAME" />
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowCultureGrowthCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH" />
                                 </Stack>
-                            </Stack>
-                            <Stack Anchor="C,C" StackGrowth="Left">
-                                <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONS_HEADER" Offset="0,10"/>
-                            </Stack>
-                            <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
-                                <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONSIZE"/>
-                                <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="WorkIconSizeText" Offset="3,0" />
-                            </Stack>
-                            <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconSizeSlider" Steps="10" />
-                            <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
-                                <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONALPHA"/>
-                                <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="WorkIconAlphaText" Offset="3,0" />
-                            </Stack>
-                            <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconAlphaSlider" Steps="101" />
-                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                <GridButton ID="SmartWorkIconCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTWORKICON" />
-                            </Stack>
-                            <Stack ID="SmartWorkIconSettings" Anchor="R,T" StackGrowth="Down">
-                                <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowYieldsOnCityHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowCitizenIconsOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowCityManageAreaOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowCityManageAreaInScreenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="RelocateCityStrikeCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" />
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="RelocateEncampmentStrikeCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" />
+                                </Stack>
+                                <Stack Anchor="C,C" StackGrowth="Left">
+                                    <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
+                                </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />
+                                </Stack>
+                                <Stack ID="SmartbannerCheckboxes" Anchor="R,T" StackGrowth="Down">
+                                    <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
+                                    <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+                                        <GridButton ID="SmartbannerUnlockedCitizenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_HUD_CITY_UNASSIGNED_CITIZENS" />
+                                    </Stack>
+                                    <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+                                        <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_DISTRICTS_TITLE" />
+                                    </Stack>
+                                    <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+                                        <GridButton ID="SmartbannerPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CIVINFO_POPULATION" />
+                                    </Stack>
+                                    <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+                                        <GridButton ID="SmartbannerCulturalCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_CITYSTATES_PAGEGROUP_CULTURAL_NAME" />
+                                    </Stack>
+                                </Stack>
+                                <Stack Anchor="C,C" StackGrowth="Left">
+                                    <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONS_HEADER" Offset="0,10"/>
+                                </Stack>
                                 <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
-                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTWORKICONSIZE"/>
-                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="SmartWorkIconSizeText" Offset="3,0" />
+                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONSIZE"/>
+                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="WorkIconSizeText" Offset="3,0" />
                                 </Stack>
-                                <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconSizeSlider" Steps="10" />
+                                <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconSizeSlider" Steps="10" />
                                 <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
-                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTWORKICONALPHA"/>
-                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="SmartWorkIconAlphaText" Offset="3,0" />
+                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONALPHA"/>
+                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="WorkIconAlphaText" Offset="3,0" />
                                 </Stack>
-                                <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconAlphaSlider" Steps="101" />
+                                <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconAlphaSlider" Steps="101" />
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="SmartWorkIconCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTWORKICON" />
+                                </Stack>
+                                <Stack ID="SmartWorkIconSettings" Anchor="R,T" StackGrowth="Down">
+                                    <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
+                                    <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
+                                        <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTWORKICONSIZE"/>
+                                        <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="SmartWorkIconSizeText" Offset="3,0" />
+                                    </Stack>
+                                    <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconSizeSlider" Steps="10" />
+                                    <Stack Anchor="C,T" StackGrowth="Right" Padding="5">
+                                        <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTWORKICONALPHA"/>
+                                        <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="SmartWorkIconAlphaText" Offset="3,0" />
+                                    </Stack>
+                                    <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconAlphaSlider" Steps="101" />
+                                </Stack>
                             </Stack>
-                        </Stack>
+                        </ScrollPanel>
                     </Container>
                     <Container ID="UnitsOptions" Size="parent,parent" Hidden="1">
                         <Stack Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">


### PR DESCRIPTION
As mentioned in issue #55.  I had done this in the XML and then ultimately decided I wanted to make it configurable, which brought be back to the lua.

This does the following to the City View CQUI options menu:
- Add Relocate City Strike Button to top of City Banner (enabled by default)
- Add Relocate Encampment Strike Button to top of Encampment banner (disabled by default)
- Put that whole menu in a scrolling panel

The diff for the XML is all goofy because of adding the elements for the scroll panel have it going nuts because of indenting changes, I guess.  There were 7 lines added to cqui_settingselement.xml in total - I highlighted those 7 below.

I am debating if the relocated button on the Encampment banner should be slightly higher or not - it mostly looks okay, but will provide close ups below for thought.  Tested on base, exp1, and exp2 games.

Also do not have any language strings besides English.  I suppose I can update by hitting google translate or something?

Up position:
![image](https://user-images.githubusercontent.com/8787640/86737075-d8de8100-bfe8-11ea-815f-c1b54cb96f02.png)

Items disabled (the "down" position for city and  barely visible through the menu).  This is the default position from the game (and what is defined in the XML).
![image](https://user-images.githubusercontent.com/8787640/86737237-fb709a00-bfe8-11ea-8e14-967cb70a6d8d.png)

Encampment Banner super closeup with offset heights (the way-off one was like, 32, I just wanted to see the top of the banner)
![image](https://user-images.githubusercontent.com/8787640/86737866-75088800-bfe9-11ea-8701-953ab9b28161.png)

Same for the City banner:
![image](https://user-images.githubusercontent.com/8787640/86738023-95384700-bfe9-11ea-838c-cfd23b0cddb2.png)


