### PR TITLE
Remove Obsolete settings; Restore Culture value to City Banner (expansions)

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -108,7 +108,7 @@
       <TextureBar ID="FillMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="XP1_GovernorsCityBannerFill32">
         <Image ID="UnknownGovernor" Anchor="C,C" Size="32,32" Texture="XP1_Governors_Unknown32"/>
         <TextureBar ID="SlotMeter" Anchor="C,C" Size="32,32" Direction="Down" Speed="0" Texture="XP1_GovernorsCityBannerSlot32"/>
-        <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+        <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-3" Style="StrongSmall2"/>
         <Label ID="NumOfAmbassadors" Anchor="C,C" Offset="0,0" Style="FontFlair20"/>
       </TextureBar>
     </Button>
@@ -121,7 +121,7 @@
         <Image ID="Icon" Anchor="C,C" Size="32,32" Texture="Buildings32" Color="145,145,145,255"/>
         <TextureBar ID="FillMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="XP1_Banner_MeterFillProduction"/>
         <TextureBar ID="IconMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="Buildings32"/>
-        <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+        <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-5" Style="StrongSmall2"/>
       </Image>
     </Button>
   </Instance>
@@ -131,8 +131,9 @@
       <TextureBar ID="FillMeter" Anchor="C,C" Size="28,28" Direction="Up" Speed="0" Texture="XP1_Banner_MeterFill">
         <TextureBar ID="SlotMeter" Anchor="C,C" Size="28,28" Direction="Down" Speed="0" Texture="XP1_Banner_MeterSlot"/>
         <Label ID="CityPopulation" Anchor="C,C" String="999" Style="FontFlair20" FontStyle="stroke" Color0="225,225,225,255" Color1="35,35,35,178" />
-        <Label ID="CityPopTurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
-        <Label ID="CQUI_CityHousing" Anchor="R,B" Offset="0,-5" Style="FontNormal10" FontStyle="stroke" Hidden="1"/>
+        <Label ID="CityPopTurnsLeft" Anchor="C,T" Offset="12,-5" Style="StrongSmall2" FontStyle="stroke" />
+        <Label ID="CQUI_CityHousing" Anchor="C,B" Offset="12,-5" Style="StrongSmall2" FontStyle="stroke" Hidden="1"/>
+        <Label ID="CityCultureTurnsLeft" Anchor="C,B" Offset="-12,-5" Style="StrongSmall2" FontStyle="stroke" Color="204,109,197,255" Hidden="1"/>
       </TextureBar>
     </Button>
   </Instance>

--- a/Assets/Expansion2/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion2/CityBanners/citybannerinstances.xml
@@ -109,7 +109,7 @@
             <TextureBar ID="FillMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="XP1_GovernorsCityBannerFill32">
                 <Image ID="UnknownGovernor" Anchor="C,C" Size="32,32" Texture="XP1_Governors_Unknown32"/>
                 <TextureBar ID="SlotMeter" Anchor="C,C" Size="32,32" Direction="Down" Speed="0" Texture="XP1_GovernorsCityBannerSlot32"/>
-                <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+                <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-3" Style="StrongSmall2"/>
                 <Label ID="NumOfAmbassadors" Anchor="C,C" Offset="0,0" Style="FontFlair20"/>
             </TextureBar>
         </Button>
@@ -122,7 +122,7 @@
                 <Image ID="Icon" Anchor="C,C" Size="32,32" Texture="Buildings32" Color="145,145,145,255"/>
                 <TextureBar ID="FillMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="XP1_Banner_MeterFillProduction"/>
                 <TextureBar ID="IconMeter" Anchor="C,C" Size="32,32" Direction="Up" Speed="0" Texture="Buildings32"/>
-                <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+                <Label ID="TurnsLeft" Anchor="C,T" Offset="10,-5" Style="StrongSmall2"/>
             </Image>
         </Button>
     </Instance>
@@ -132,8 +132,9 @@
             <TextureBar ID="FillMeter" Anchor="C,C" Size="28,28" Direction="Up" Speed="0" Texture="XP1_Banner_MeterFill">
                 <TextureBar ID="SlotMeter" Anchor="C,C" Size="28,28" Direction="Down" Speed="0" Texture="XP1_Banner_MeterSlot"/>
                 <Label ID="CityPopulation" Anchor="C,C" String="999" Style="FontFlair20" FontStyle="stroke" Color0="225,225,225,255" Color1="35,35,35,178" />
-                <Label ID="CityPopTurnsLeft" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
-                <Label ID="CQUI_CityHousing" Anchor="R,B" Offset="0,-5" Style="FontNormal10" FontStyle="stroke" Hidden="1"/>
+                <Label ID="CityPopTurnsLeft" Anchor="C,T" Offset="12,-5" Style="StrongSmall2" FontStyle="stroke"/>
+                <Label ID="CQUI_CityHousing" Anchor="C,B" Offset="12,-5" Style="StrongSmall2" FontStyle="stroke" Hidden="1"/>
+                <Label ID="CityCultureTurnsLeft" Anchor="C,B" Offset="-12,-5" Style="StrongSmall2" FontStyle="stroke" Color="204,109,197,255" Hidden="1"/>
             </TextureBar>
         </Button>
     </Instance>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="en_US">
       <Text>City View</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="en_US">
-      <Text>Block end turn for city attack</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="en_US">
-      <Text>Enable this if you want "End Turn" to be block if a city can attack.</Text>
-    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="en_US">
       <Text>Relocate City Strike button</Text>
     </Row>
@@ -41,9 +35,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="en_US">
       <Text>Enable this to relocate the Encampment Strike button above health and defense bars</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="en_US">
-      <Text>Production item height</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="en_US">
       <Text>Enable production queue</Text>
@@ -71,12 +62,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="en_US">
       <Text>Shows citizen managament area when hovering over city banner</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="en_US">
-      <Text>Show city management area in screen</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="en_US">
-      <Text>Shows citizen managament area when in city screen</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="en_US">
       <Text>Smartbanners</Text>
@@ -167,18 +152,6 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="en_US">
       <Text>Autoapply scout lens</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="en_US">
-      <Text>Show nothing to do in builder lens</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="en_US">
-      <Text>Shows nothing to do hexes (red tiles) when in builder lens</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="en_US">
-      <Text>Show generic in builder lens</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="en_US">
-      <Text>Shows generic hexes (white tiles) when in builder lens</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="en_US">
       <Text>Popups</Text>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="de_DE">
       <Text>Stadtansicht</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="de_DE">
-      <Text>Erzwinge Stadtverteid. für Rundenende</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="de_DE">
-      <Text>Der "Nächste Runde"-Button ist blockiert, solange eine Stadtverteidigung möglich ist.</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="de_DE">
       <Text>City Strike-Schaltfläche verschieben</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="de_DE">
       <Text>Aktivieren Sie diese Option, um die Schaltfläche "Streik des Lagers" über den Gesundheits- und Verteidigungsbalken zu verschieben</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="de_DE">
-      <Text>Zeilenhöhe i.d. Produktwahlliste</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="de_DE">
       <Text>Produktionsliste einschalten</Text>
@@ -72,12 +63,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="de_DE">
       <Text>Zeige die Gebiete, an denen Einwohner arbeiten, wenn die Maus über dem Stadtbanner steht.</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="de_DE">
-      <Text>Zeige Stadtgebiet im Stadtbildschirm</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="de_DE">
-      <Text>Zeige Stadtgebiet, wenn der Stadtbildschirm geöffnet wird.</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="de_DE">
       <Text>Smartbanner</Text>
@@ -168,18 +153,6 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="de_DE">
       <Text>Automat. Späher-Linse</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="de_DE">
-      <Text>Zeigt untätige in Handwerker-Linse</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="de_DE">
-      <Text>Zeigt untätige Hex-Felder (rot) in Handwerker-Linse</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="de_DE">
-      <Text>Normale Anzeige in Handwerker-Linse</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="de_DE">
-      <Text>Zeige normale Felder (weiß) in Handwerker-Linse</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="de_DE">
       <Text>Popups</Text>

--- a/Assets/Text/cqui_text_settings_es.xml
+++ b/Assets/Text/cqui_text_settings_es.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="es_ES">
       <Text>Vista de ciudad</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="es_ES">
-      <Text>Bloquea turno para ataques de ciudad</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="es_ES">
-      <Text>Activar para bloquear "Finalizar Turno" si una ciudad puede atacar.</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="es_ES">
       <Text>Botón Reubicar City Strike</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="es_ES">
       <Text>Habilite esto para reubicar el botón de Golpe de campamento sobre las barras de salud y defensa</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="es_ES">
-      <Text>Altura de elementos de producción</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="es_ES">
       <Text>Activa cola de producción</Text>

--- a/Assets/Text/cqui_text_settings_fr.xml
+++ b/Assets/Text/cqui_text_settings_fr.xml
@@ -40,10 +40,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="fr_FR">
       <Text>Activez cette option pour déplacer le bouton Encampment Strike au-dessus des barres de santé et de défense</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="fr_FR">
-      <!-- TODO -->
-      <Text>Production item height</Text>
-    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="fr_FR">
       <Text>Activer la queue de production</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_it.xml
+++ b/Assets/Text/cqui_text_settings_it.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="it_IT">
       <Text>Vista Cittadina</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="it_IT">
-      <Text>Blocca fine turno per attacchi cittadini</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="it_IT">
-      <Text>Abilita se vuoi che il pulsante "Fine Turno" sia bloccato se una città può attaccare.</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="it_IT">
       <Text>Riposiziona il pulsante City Strike</Text>
@@ -43,9 +37,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="it_IT">
       <Text>Abilita questo per riposizionare il pulsante Colpo Encampment sopra le barre di salute e difesa</Text>
     </Row>    
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="it_IT">
-      <Text>Altezza elemento da produrre</Text>
-    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="it_IT">
       <Text>Abilita coda di produzione</Text>
     </Row>
@@ -72,12 +63,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="it_IT">
       <Text>Mostra l'area di gestione dei cittadini al passaggio del mouse sul banner della città</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="it_IT">
-      <Text>Area gestione cittadini nella vista della città</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="it_IT">
-      <Text>Mostra l'area di gestione dei cittadini nella vista della città</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="it_IT">
       <Text>Banner Smart</Text>
@@ -168,18 +153,6 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="it_IT">
       <Text>Lente Scout in automatico</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="it_IT">
-      <Text>Mostra nessuna azione nella Lente Costruttore</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="it_IT">
-      <Text>Mostra gli esagoni su cui non c'è niente da migliorare (caselle rosse) nella Lente Costruttore</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="it_IT">
-      <Text>Mostra generici nella Lente Costruttore</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="it_IT">
-      <Text>Mostra gli esagoni generici (caselle bianche) nella Lente Costruttore</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="it_IT">
       <Text>Popup</Text>

--- a/Assets/Text/cqui_text_settings_ja.xml
+++ b/Assets/Text/cqui_text_settings_ja.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="ja_JP">
       <Text>都市画面</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="ja_JP">
-      <Text>都市砲撃が可能な場合はターン終了不可</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="ja_JP">
-      <Text>都市砲撃できる場合はターンを終了できなくする。</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="ja_JP">
       <Text>City Strikeボタンを再配置する</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ja_JP">
       <Text>これを有効にして、エンキャンプメントストライクボタンをヘルスバーと防御バーの上に再配置します</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ja_JP">
-      <Text>生産アイテムの縦幅</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="ja_JP">
       <Text>生産キューを有効化</Text>
@@ -72,12 +63,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="ja_JP">
       <Text>都市バナーのマウスオーバーで市民管理エリアを表示する</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="ja_JP">
-      <Text>都市画面に市民管理エリアを表示</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="ja_JP">
-      <Text>都市画面に市民管理エリアを表示する</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="ja_JP">
       <Text>都市バナー</Text>
@@ -168,18 +153,6 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="ja_JP">
       <Text>斥候レンズを自動適用</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="ja_JP">
-      <Text>改善できないタイルを表示する</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="ja_JP">
-      <Text>労働者レンズを選択したとき、改善できないタイルを赤色で表示する</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="ja_JP">
-      <Text>一般的なタイルを表示する</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="ja_JP">
-      <Text>労働者レンズを選択したとき、一般的なタイルを白色で表示する</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="ja_JP">
       <Text>ポップアップ</Text>

--- a/Assets/Text/cqui_text_settings_ko.xml
+++ b/Assets/Text/cqui_text_settings_ko.xml
@@ -37,9 +37,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ko_KR">
       <Text>이 옵션을 사용하면 상태 및 방어 막대 위의 야영지 스트라이크 버튼을 재배치하십시오.</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ko_KR">
-      <Text>도시 생산창 아이템 항목 높이</Text>
-    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="ko_KR">
       <Text>생산 대기열 활성화</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="pl_PL">
       <Text>Widok miasta</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="pl_PL">
-      <Text>Zablokuj koniec tury dla ataku miasta</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="pl_PL">
-      <Text>Włącz tę opcję jeśli chcesz by "Zakończ Turę" było zablokowane gdy miasto może atakować.</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="pl_PL">
       <Text>Zmień położenie przycisku City Strike</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="pl_PL">
       <Text>Włącz tę opcję, aby przenieść przycisk Obozowisko powyżej pasków zdrowia i obrony</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="pl_PL">
-      <Text>Wysokość elementu produkcji</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="pl_PL">
       <Text>Włącz kolejkę budowania</Text>
@@ -67,7 +58,7 @@
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER" Language="pl_PL">
       <Text>Włącz inteligentne banery</Text>
     </Row>
-  <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP" Language="pl_PL">
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP" Language="pl_PL">
       <Text>Wyświetla nowe ikony i informacje w banerze miasta.</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP" Language="pl_PL">

--- a/Assets/Text/cqui_text_settings_pt.xml
+++ b/Assets/Text/cqui_text_settings_pt.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="pt_BR">
       <Text>Visão da Cidade</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="pt_BR">
-      <Text>Bloquear final de turno para ataque da cidade</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="pt_BR">
-      <Text>Habilite isso se você quer bloquear "Final de Turno" se uma cidade pode atacar.</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="pt_BR">
       <Text>Reposicionar botão Strike City</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="pt_BR">
       <Text>Habilite isso para realocar o botão Ataque ao acampamento acima das barras de saúde e defesa</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="pt_BR">
-      <Text>Altura dos itens de produção</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="pt_BR">
       <Text>Habilidar fila de produção</Text>
@@ -72,12 +63,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="pt_BR">
       <Text>Exibe a área de gerenciamento de cidadãos quando passar o mouse sobre o banner da cidade</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="pt_BR">
-      <Text>Exibe área de gerenciamento da cidade na tela</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="pt_BR">
-      <Text>Exibe a área de gerenciamento de cidadãos na tela da cidade</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="pt_BR">
       <Text>Insígnias Inteligentes</Text>
@@ -168,18 +153,6 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="pt_BR">
       <Text>Lente de Batedor aplicada automaticamente</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="pt_BR">
-      <Text>Não mostre nada para fazer nas lentes de construtor</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="pt_BR">
-      <Text>Não mostrar nada para fazer nos hexágonos (lotes vermelhos) quando nas lentes de construtor</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="pt_BR">
-      <Text>Mostrar genéricos nas lentes de construtores</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="pt_BR">
-      <Text>Mostra hexágonos genéricos (lotes brancos) quando em lentes de construtor</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="pt_BR">
       <Text>Popups</Text>

--- a/Assets/Text/cqui_text_settings_ru.xml
+++ b/Assets/Text/cqui_text_settings_ru.xml
@@ -24,12 +24,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="ru_RU">
       <Text>Обзор города</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="ru_RU">
-      <Text>Не завершать ход, когда город атакован</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="ru_RU">
-      <Text>Предотвращает завершение хода, когда город может атаковать</Text>
-    </Row>
     <!-- Relocate City Strike and Encampment Strike button translations done via Google Translate -->
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" Language="ru_RU">
       <Text>Кнопка Смена места жительства Attack Город</Text>
@@ -42,9 +36,6 @@
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="ru_RU">
       <Text>Включите это, чтобы переместить кнопку Удар по лагерю над панелями здоровья и защиты</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="ru_RU">
-      <Text>Высота строки элемента производства</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="ru_RU">
       <Text>Очередь производства</Text>

--- a/Assets/Text/cqui_text_settings_zh.xml
+++ b/Assets/Text/cqui_text_settings_zh.xml
@@ -37,9 +37,6 @@
     <Row Tag="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP" Language="zh_Hans_CN">
       <Text>启用此选项可将“营地攻击”按钮移至健康和防御栏上方。</Text>
     </Row>
-    <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="zh_Hans_CN">
-      <Text>生产项目横幅的高度</Text>
-    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" Language="zh_Hans_CN">
       <Text>启用生产队列</Text>
     </Row>

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -89,7 +89,6 @@ function CQUI_OnSettingsInitialized()
 
     CQUI_ShowCitizenIconsOnCityHover   = GameConfiguration.GetValue("CQUI_ShowCitizenIconsOnCityHover");
     CQUI_ShowCityManageAreaOnCityHover = GameConfiguration.GetValue("CQUI_ShowCityManageAreaOnCityHover");
-    CQUI_ShowCityManageAreaInScreen    = GameConfiguration.GetValue("CQUI_ShowCityMangeAreaInScreen");
     CQUI_RelocateCityStrike            = GameConfiguration.GetValue("CQUI_RelocateCityStrike");
     CQUI_RelocateEncampmentStrike      = GameConfiguration.GetValue("CQUI_RelocateEncampmentStrike");
 end

--- a/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
@@ -171,6 +171,21 @@ function CityBanner.UpdatePopulation(self, isLocalPlayer:boolean, pCity:table, p
     else
         populationInstance.CQUI_CityHousing:SetHide(true);
     end
+
+    if (IsCQUI_SmartBanner_CulturalEnabled()) then
+        -- Show the turns left until border expansion to the left of the population
+        local pCityCulture = pCity:GetCulture();
+        local turnsUntilBorderGrowth = pCityCulture:GetTurnsUntilExpansion();
+        populationInstance.CityCultureTurnsLeft:SetText(turnsUntilBorderGrowth);
+        populationInstance.CityCultureTurnsLeft:SetHide(false);
+
+        local popTooltip = populationInstance.FillMeter:GetToolTipString();
+        -- The Locale.Lookup for Border Growth requires the value be included... but doesn't then put that value in the string itself, apparently.
+        popTooltip = popTooltip .. "[NEWLINE] [ICON_Culture]" ..tostring(turnsUntilBorderGrowth).. " " .. Locale.Lookup("LOC_HUD_CITY_TURNS_UNTIL_BORDER_GROWTH", turnsUntilBorderGrowth);
+        populationInstance.FillMeter:SetToolTipString(popTooltip);
+    else
+        populationInstance.CityCultureTurnsLeft:SetHide(true);
+    end
 end
 
 -- ============================================================================

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -32,10 +32,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ("CQUI_AutoapplyArchaeologistLens", 1), -- Automatically activates the archaeologist lens when selecting a archaeologist
         ("CQUI_AutoapplyBuilderLens", 1), -- Automatically activates the builder lens when selecting a builder
         ("CQUI_AutoapplyScoutLens", 1), -- Automatically activates the scout lens when selecting a scout
-        ("CQUI_ShowNothingToDoBuilderLens", 1), -- Shows nothing to do hexes (red tiles) when in builder lens
-        ("CQUI_ShowGenericBuilderLens", 1), -- Shows generic hexes (white tiles) when in builder lens
         ("CQUI_AutoExpandUnitActions", 1), -- Automatically reveals the secondary unit actions normally hidden inside an expando
-        ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
         ("CQUI_RelocateCityStrike", 1), -- Relocate the City Strike button to above the city health and defense bars
         ("CQUI_RelocateEncampmentStrike", 0), -- Relocate the Encampment Strike button to above the encampment health and defense bars
         ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
@@ -57,7 +54,6 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
         ('CQUI_ShowCitizenIconsOnCityHover', 0), -- Shows citizen icons when hovering over city banner
         ('CQUI_ShowCityManageAreaOnCityHover', 1), -- Shows citizen management area when hovering over city banner
-        ('CQUI_ShowCityMangeAreaInScreen', 1), -- Shows citizen management area when in city screen
         ('CQUI_TraderAddDivider', 1), -- Adds a divider between groups in TradeOverview panel
         ('CQUI_TraderShowSortOrder', 0), -- Adds a divider between groups in TradeOverview panel
         ('CQUI_ShowProductionRecommendations', 0), -- Shows the advisor recommendation in the city produciton panel
@@ -90,8 +86,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
 */
 
 INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
-    VALUES  ("CQUI_ProductionItemHeight", 32), -- Height used for individual items in the production queue. Recommended values fall between 24 and 128, though any positive could work
-        ("CQUI_SmartWorkIconSize", 64), -- Size used for "smart" work icons. This size is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
+    VALUES  ("CQUI_SmartWorkIconSize", 64), -- Size used for "smart" work icons. This size is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
         ("CQUI_SmartWorkIconAlpha", 40), -- Transparency percent used for "smart" work icons. This alpha is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 10 and 100, though any value between 0 and 100 could work
         ("CQUI_WorkIconSize", 64), -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
         ("CQUI_WorkIconAlpha", 80); -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 10 and 100, though any value between 0 and 100 could work

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -354,7 +354,6 @@ function Initialize()
     PopulateCheckBox(Controls.SmartbannerPopulationCheckbox, "CQUI_Smartbanner_Population", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP"));
     PopulateCheckBox(Controls.SmartbannerCulturalCheckbox, "CQUI_Smartbanner_Cultural", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP"));
     PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
-    PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateCityStrikeCheckbox, "CQUI_RelocateCityStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateEncampmentStrikeCheckbox, "CQUI_RelocateEncampmentStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
@@ -367,20 +366,15 @@ function Initialize()
     PopulateCheckBox(Controls.AutoapplyArchaeologistLensCheckbox, "CQUI_AutoapplyArchaeologistLens");
     PopulateCheckBox(Controls.AutoapplyBuilderLensCheckbox, "CQUI_AutoapplyBuilderLens");
     PopulateCheckBox(Controls.AutoapplyScoutLensCheckbox, "CQUI_AutoapplyScoutLens");
-    -- TODO (2020-05): These items were commented prior to May 2020 patch
-    -- PopulateCheckBox(Controls.ShowNothingToDoInBuilderLens, "CQUI_ShowNothingToDoBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP"));
-    -- PopulateCheckBox(Controls.ShowGenericInBuilderLens, "CQUI_ShowGenericBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP"));
 
     PopulateCheckBox(Controls.ShowYieldsOnCityHoverCheckbox, "CQUI_ShowYieldsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER_TOOLTIP"));
     PopulateCheckBox(Controls.ShowCitizenIconsOnHoverCheckbox, "CQUI_ShowCitizenIconsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER_TOOLTIP"));
     PopulateCheckBox(Controls.ShowCityManageAreaOnHoverCheckbox, "CQUI_ShowCityManageAreaOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP"));
-    PopulateCheckBox(Controls.ShowCityManageAreaInScreenCheckbox, "CQUI_ShowCityMangeAreaInScreen", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP"));
     PopulateCheckBox(Controls.ShowUnitPathsCheckbox, "CQUI_ShowUnitPaths");
     PopulateCheckBox(Controls.AutoExpandUnitActionsCheckbox, "CQUI_AutoExpandUnitActions");
     PopulateCheckBox(Controls.AlwaysOpenTechTreesCheckbox, "CQUI_AlwaysOpenTechTrees");
     PopulateCheckBox(Controls.SmartWorkIconCheckbox, "CQUI_SmartWorkIcon", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTWORKICON_TOOLTIP"));
     PopulateCheckBox(Controls.ShowPolicyReminderCheckbox, "CQUI_ShowPolicyReminder", Locale.Lookup("LOC_CQUI_GENERAL_SHOWPRD_TOOLTIP"));
-    PopulateSlider(Controls.ProductionItemHeightSlider, Controls.ProductionItemHeightText, "CQUI_ProductionItemHeight", ProductionItemHeightConverter);
     PopulateSlider(Controls.WorkIconSizeSlider, Controls.WorkIconSizeText, "CQUI_WorkIconSize", WorkIconSizeConverter);
     PopulateSlider(Controls.SmartWorkIconSizeSlider, Controls.SmartWorkIconSizeText, "CQUI_SmartWorkIconSize", WorkIconSizeConverter);
     PopulateSlider(Controls.WorkIconAlphaSlider, Controls.WorkIconAlphaText, "CQUI_WorkIconAlpha", WorkIconAlphaConverter);

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -72,13 +72,6 @@
                                 <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="ProductionQueueCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" />
                                 </Stack>
-                                <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
-                                    <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="ProductionItemHeightText" Offset="3,0" />
-                                    <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_ITEMHEIGHT"/>
-                                </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                    <Slider Style="SliderControl" Anchor="R,C" Size="300,13" Offset="5,0" SpaceForScroll="0" ID="ProductionItemHeightSlider" Steps="104" />
-                                </Stack>
                                 <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="ShowCultureGrowthCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH" />
                                 </Stack>
@@ -90,12 +83,6 @@
                                 </Stack>
                                 <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="ShowCityManageAreaOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER" />
-                                </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                    <GridButton ID="ShowCityManageAreaInScreenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" />
-                                </Stack>
-                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-                                    <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
                                 </Stack>
                                 <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="RelocateCityStrikeCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON" />
@@ -408,12 +395,6 @@
                             <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                 <GridButton ID="AutoapplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS"/>
                             </Stack>
-                            <!--<Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <GridButton ID="ShowNothingToDoInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER"/>
-          </Stack>
-          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <GridButton ID="ShowGenericInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER"/>
-          </Stack>-->
                         </Stack>
                     </Container>
                     <Container ID="TraderScreenOption" Size="parent,parent" Hidden="1">


### PR DESCRIPTION
- Remove the settings from the menu that no longer do anything
- Add the "Borders expand from culture" to the City Banner for Expansions (like is available with Vanilla)
  - This is the the "Cultural" Smartbanner
- Slight adjustment in placement of the various numbers showing turns until things for better clarity (including aligning the _turns until_ value for the Governors)
- Using the same font for the various numbers (it bothered me they didn't match AND the one that didn't match was very small)

NOTE:
- Not all of the strings were in all of the localization files.  That's why, for example, you only see one string definition deleted from the french text, while others will have 5 different delete spots

From Exp1 game: 
![image](https://user-images.githubusercontent.com/8787640/87019350-5a6c1580-c187-11ea-8383-0da8c13050ec.png)

Closeup (Exp2 game) - showing the alignment with the Governor counter: 
![image](https://user-images.githubusercontent.com/8787640/87019287-458f8200-c187-11ea-9b3a-bea5ff448056.png)

Settings menu with the obsolete options removed:
![image](https://user-images.githubusercontent.com/8787640/87019425-740d5d00-c187-11ea-940c-b0012aed8417.png)


