### PR TITLE
Fix for Panels not appearing in Multiplayer

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -184,28 +184,30 @@ function CQUI_OnInterfaceModeChanged( eOldMode:number, eNewMode:number )
             if g_pCity == nil then
                 UI.GetHeadSelectedCity();
             end
-            if g_pCity == nil then
+
+            if g_pCity ~= nil then
+                local newGrowthPlot:number = g_pCity:GetCulture():GetNextPlot();  --show the growth tile if the district or wonder can be placed there
+                if (newGrowthPlot ~= -1) then
+                    if (eNewMode == InterfaceModeTypes.DISTRICT_PLACEMENT) then
+                        local districtHash:number = UI.GetInterfaceModeParameter(CityOperationTypes.PARAM_DISTRICT_TYPE);
+                        local district:table      = GameInfo.Districts[districtHash];
+                        local kPlot   :table      = Map.GetPlotByIndex(newGrowthPlot);
+                        if kPlot:CanHaveDistrict(district.Index, m_pPlayer, g_pCity:GetID()) then
+                            DisplayGrowthTile();
+                        end
+                    elseif (eNewMode == InterfaceModeTypes.BUILDING_PLACEMENT) then
+                        local buildingHash :number = UI.GetInterfaceModeParameter(CityOperationTypes.PARAM_BUILDING_TYPE);
+                        local building = GameInfo.Buildings[buildingHash];
+                        local kPlot       :table          = Map.GetPlotByIndex(newGrowthPlot);
+                        if kPlot:CanHaveWonder(building.Index, m_pPlayer, g_pCity:GetID()) then
+                            DisplayGrowthTile();
+                        end
+                    end
+                end
+            else
                 print("-- CQUI CityPanel.lua: g_pCity is nil");
             end
 
-            local newGrowthPlot:number = g_pCity:GetCulture():GetNextPlot();  --show the growth tile if the district or wonder can be placed there
-            if (newGrowthPlot ~= -1) then
-                if (eNewMode == InterfaceModeTypes.DISTRICT_PLACEMENT) then
-                    local districtHash:number = UI.GetInterfaceModeParameter(CityOperationTypes.PARAM_DISTRICT_TYPE);
-                    local district:table      = GameInfo.Districts[districtHash];
-                    local kPlot   :table      = Map.GetPlotByIndex(newGrowthPlot);
-                    if kPlot:CanHaveDistrict(district.Index, m_pPlayer, g_pCity:GetID()) then
-                        DisplayGrowthTile();
-                    end
-                elseif (eNewMode == InterfaceModeTypes.BUILDING_PLACEMENT) then
-                    local buildingHash :number = UI.GetInterfaceModeParameter(CityOperationTypes.PARAM_BUILDING_TYPE);
-                    local building = GameInfo.Buildings[buildingHash];
-                    local kPlot       :table          = Map.GetPlotByIndex(newGrowthPlot);
-                    if kPlot:CanHaveWonder(building.Index, m_pPlayer, g_pCity:GetID()) then
-                        DisplayGrowthTile();
-                    end
-                end
-            end
         elseif (eNewMode ~= InterfaceModeTypes.CITY_MANAGEMENT) then
             if (CQUI_wonderMode) then
                 LuaEvents.CQUI_CityviewEnable();

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -173,6 +173,7 @@ LuaEvents.CQUI_CityviewHide.Add(CQUI_HideCityInterface);
 LuaEvents.CQUI_Strike_Enter.Add (function() CQUI_usingStrikeButton = true; end)
 LuaEvents.CQUI_Strike_Exit.Add (function() CQUI_usingStrikeButton = false; end)
 
+-- ===========================================================================
 function CQUI_OnInterfaceModeChanged( eOldMode:number, eNewMode:number )
     if (eNewMode == InterfaceModeTypes.CITY_RANGE_ATTACK or eNewMode == InterfaceModeTypes.DISTRICT_RANGE_ATTACK or CQUI_usingStrikeButton) then
         LuaEvents.CQUI_CityviewHide(); -- AZURENCY : always hide the cityview if new mode is CITY_RANGE_ATTACK
@@ -205,9 +206,8 @@ function CQUI_OnInterfaceModeChanged( eOldMode:number, eNewMode:number )
                     end
                 end
             else
-                print("-- CQUI CityPanel.lua: g_pCity is nil");
+                print("-- CQUI CityPanel.lua CQUI_OnInterfaceModeChanged: g_pCity is nil");
             end
-
         elseif (eNewMode ~= InterfaceModeTypes.CITY_MANAGEMENT) then
             if (CQUI_wonderMode) then
                 LuaEvents.CQUI_CityviewEnable();

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -115,15 +115,25 @@ function SetDesiredLens(desiredLens)
     if UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT or UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT then
         return;
     end
+
     m_desiredLens = desiredLens;
     if m_isShowingPanel then
         if m_desiredLens == "CityManagement" then
-            UILens.SetActive("Default");
-            LuaEvents.CQUI_RefreshCitizenManagement(m_pCity:GetID());
-            UILens.SetActive("Appeal");
+            if (m_pCity == nil) then
+                Refresh();
+            end
+
+            if (m_pCity ~= nil) then
+                UILens.SetActive("Default");
+                LuaEvents.CQUI_RefreshCitizenManagement(m_pCity:GetID());
+                UILens.SetActive("Appeal");
+            else
+                print("CQUI: CityPanelOverview SetDesiredLens m_pCity is nil!");
+            end
         else
             UILens.SetActive(m_desiredLens);
         end
+
         ContextPtr:SetUpdate(EnsureDesiredLens);
     else
         UILens.SetActive(m_desiredLens);

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -246,13 +246,13 @@ function OnCityBannerClick( playerID, cityID )
     if (pPlayer:GetID() == localPlayerID) then
         UI.SelectCity( pCity );
         UI.SetCycleAdvanceTimer(0);     -- Cancel any auto-advance timer
-         UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-    elseif(localPlayerID == PlayerTypes.OBSERVER 
+        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
+    elseif (localPlayerID == PlayerTypes.OBSERVER 
             or localPlayerID == PlayerTypes.NONE 
             or pPlayer:GetDiplomacy():HasMet(localPlayerID)) then
         LuaEvents.CQUI_CityviewDisable(); -- Make sure the cityview is disable
-        local pPlayerConfig :table      = PlayerConfigurations[playerID];
-        local isMinorCiv    :boolean    = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
+        local pPlayerConfig :table   = PlayerConfigurations[playerID];
+        local isMinorCiv    :boolean = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
         --print("clicked player " .. playerID .. " city.  IsMinor?: ",isMinorCiv);
 
         if UI.GetInterfaceMode() == InterfaceModeTypes.MAKE_TRADE_ROUTE then
@@ -272,10 +272,10 @@ function OnCityBannerClick( playerID, cityID )
     end
 end
 
-
+-- ===========================================================================
 function CityBanner.SetHealthBarColor( self )
     -- The basegame file has a minor bug where if percent is exactly 0.40, then no color is set.
-    print_debug("CityBannerManager_CQUI: CityBanner.SetHealthBarColor ENTRY");
+    -- print_debug("CityBannerManager_CQUI: CityBanner.SetHealthBarColor ENTRY");
     if (self.m_Instance.CityHealthBar == nil) then
         -- This normal behaviour in the case of missile silo and aerodrome minibanners
         return;
@@ -471,7 +471,7 @@ end
 -- CQUI Custom Functions (Common to basegame and expansions)
 -- ===========================================================================
 function CQUI_GetHousingString(pCity, cqui_HousingFromImprovementsCalc)
-    print_debug("CityBannerManager_CQUI: CQUI_GetHousingString ENTRY");
+    -- print_debug("CityBannerManager_CQUI: CQUI_GetHousingString ENTRY");
     -- TODO: Consider unifying what this looks like on the basegame and the expansions
     --       Basegame puts Turns left until Pop increase on left with housing value in brackets next to it
     local pCityGrowth   :table  = pCity:GetGrowth();
@@ -505,7 +505,7 @@ end
 -- ===========================================================================
 -- CQUI calculate real housing from improvements
 function CQUI_GetRealHousingFromImprovementsValue(pCity, localPlayerID)
-    print_debug("CityBannerManager_CQUI: CQUI_GetRealHousingFromImprovementsValue ENTRY  pCity:"..tostring(pCity).." localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_GetRealHousingFromImprovementsValue ENTRY  pCity:"..tostring(pCity).." localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
     local pCityID :number = pCity:GetID();
     if (CQUI_HousingUpdated[localPlayerID] == nil or CQUI_HousingUpdated[localPlayerID][pCityID] ~= true) then
         CQUI_RealHousingFromImprovements(pCity, localPlayerID, pCityID);
@@ -554,7 +554,7 @@ function CQUI_RealHousingFromImprovements(pCity, localPlayerID, pCityID)
     --       The basegame function doesn't include the half-value (e.g. as Non-Maya, 3 farms is 1.5, but basegame returns only 1).
     --       Basegame also appears to consider the Maya as +1 Housing in addition to the 0.5 for each farm (so, 1.5 for each Mayan farm)
     --       In basegame, when Maya have 2 farms, pCity:GetGrowth():GetHousingFromImprovements() will return a value of 3
-    print_debug("CityBannerManager_CQUI: CQUI_RealHousingFromImprovements ENTRY  pCity:"..tostring(pCity).." localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_RealHousingFromImprovements ENTRY  pCity:"..tostring(pCity).." localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
 
     local cityX:number, cityY:number = pCity:GetX(), pCity:GetY();
     local iNumHousing:number = 0; 
@@ -618,7 +618,7 @@ end
 -- ===========================================================================
 -- When a banner is moused over, display the relevant yields and next culture plot
 function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
-    print_debug("CityBannerManager_CQUI: CQUI_OnBannerMouseOver ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnBannerMouseOver ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
     if (CQUI_ShowYieldsOnCityHover == false) then
         return;
     end
@@ -742,7 +742,7 @@ end
 -- ===========================================================================
 -- When a banner is moused over, and the mouse leaves the banner, remove display of the relevant yields and next culture plot
 function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
-    print_debug("CityBannerManager_CQUI: CQUI_OnBannerMouseExit ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnBannerMouseExit ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
     if (not CQUI_Hovering) then
         return;
     end
@@ -908,7 +908,7 @@ end
 
 -- ===========================================================================
 function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance )
-    print_debug("CityBannerManager_CQUI: CQUI_UpdateSuzerainIcon ENTRY");
+    -- print_debug("CityBannerManager_CQUI: CQUI_UpdateSuzerainIcon ENTRY");
     if (bannerInstance == nil) then
         return;
     end

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -8,7 +8,6 @@ include( "CQUICommon.lua" );
 -- ===========================================================================
 -- Cached Base Functions
 -- ===========================================================================
-BASE_CQUI_OnCityBannerClick = OnCityBannerClick;
 BASE_CQUI_OnGameDebugReturn = OnGameDebugReturn;
 BASE_CQUI_OnInterfaceModeChanged = OnInterfaceModeChanged;
 BASE_CQUI_OnShutdown = OnShutdown;


### PR DESCRIPTION
As documented in #85 - there was a definite bug in OnCityBannerClick that apparently was causing a cascading failure that eventually resulted in the City Panels looking like the screen shots I will paste below.
**This change:**
- Implements a full "replacement" function for OnCityBannerClick, instead of extending it
  - The replacement function adds a few additional lines over the unmodified version from expansion 1/2:
    - Adds a check to determine if the Expansions are running and if so, handles the logic for clicking on a FreeCity banner
    - Adds 2 calls referring to the City view in the larger if/elseif statement
- Adds better handling logic for g_pCity nil in CQUI_OnInterfaceModeChanged
  - I still don't see _how_ we were getting into this code path based on the if statements protecting it, but we were, and it appears when doing so Ui.GetHeadSelectedCity() would usually return nil anyway (as no city was actually selected)
- Adds protection for m_pCity nil in SetDesiredLens
  - Again, still not sure how we got into that state based on the if statements preceding the line that was throwing the error (LuaEvents.CQUI_RefreshCitizenManagement(m_pCity:GetID())

HerpBrownstainz provided logs and screenshots via Discord, and said he and his friends used this version of the code last night and things appeared to be resolved.

This was apparently the most common issue - the various panels would not be updated when clicking on a City Banner (note it is not showing the city that was clicked on):
![image](https://user-images.githubusercontent.com/8787640/87074059-30d8db80-c1d3-11ea-9bf5-76bcaa9e3c40.png)

Occasionally this fun times would occur:
![image](https://user-images.githubusercontent.com/8787640/87074093-3b937080-c1d3-11ea-8ed9-838906b2e325.png)

