### PR TITLE
Auto-focus on Search bar in Civilopedia

### DIFF
--- a/Assets/UI/Civilopedia/civilopediascreen.lua
+++ b/Assets/UI/Civilopedia/civilopediascreen.lua
@@ -1,0 +1,21 @@
+-- ===========================================================================
+--	CQUI CivilopediaScreen.lua replacement
+--  This file matches the Firaxis version of CivilopediaScreen.lua, save for the lines referencing CQUI
+-- ===========================================================================
+
+-- Include all of the base civilopedia logic
+include("CivilopediaSupport");
+
+-- Include the CQUI extension
+include("civilopediasupport_CQUI.lua");
+
+-- Now that all of the utility functions have been defined and all of the scaffolding in place...
+-- Load all of the Civilopedia pages.
+-- These individual files will define the page layouts referenced in the database.
+-- By keeping the pages separated from each other and the base logic, modders can quickly add new page layouts
+-- or replace existing ones.
+include("CivilopediaPage_", true);
+
+
+-- Initialize the pedia!
+Initialize();

--- a/Assets/UI/Civilopedia/civilopediasupport_CQUI.lua
+++ b/Assets/UI/Civilopedia/civilopediasupport_CQUI.lua
@@ -1,0 +1,12 @@
+-- ===========================================================================
+-- Cached Base Functions
+-- ===========================================================================
+BASE_CQUI_OnOpenCivilopedia = OnOpenCivilopedia;
+
+-- ===========================================================================
+--  CQUI Functions
+-- ===========================================================================
+function OnOpenCivilopedia(sectionId_or_search, pageId)
+    BASE_CQUI_OnOpenCivilopedia(sectionId_or_search, pageId);
+    Controls.SearchEditBox:TakeFocus();
+end

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -145,6 +145,8 @@
                 <File>Assets/UI/worldviewiconsmanager_CQUI.lua</File>
                 <File>Assets/UI/Choosers/civicschooser.lua</File>
                 <File>Assets/UI/Choosers/researchchooser.lua</File>
+                <File>Assets/UI/Civilopedia/civilopediasupport_CQUI.lua</File>
+                <File>Assets/UI/Civilopedia/civilopediascreen.lua</File>
                 <File>Assets/UI/Panels/citypanel.lua</File>
                 <File>Assets/UI/Panels/citypanel.xml</File>
                 <File>Assets/UI/Panels/citypaneloverview.lua</File>
@@ -998,6 +1000,8 @@
         <File>Assets/UI/worldviewiconsmanager_CQUI.lua</File>
         <File>Assets/UI/Choosers/civicschooser.lua</File>
         <File>Assets/UI/Choosers/researchchooser.lua</File>
+        <File>Assets/UI/Civilopedia/civilopediasupport_CQUI.lua</File>
+        <File>Assets/UI/Civilopedia/civilopediascreen.lua</File>
         <File>Assets/UI/Panels/citypanel.lua</File>
         <File>Assets/UI/Panels/citypanel.xml</File>
         <File>Assets/UI/Panels/citypaneloverview.lua</File>


### PR DESCRIPTION
Minimal set of changes, though not exactly what I wanted.  I couldn't figure out a way to just extend CivilopediaSupport without doing the full file replace, and I'd rather avoid doing full file replace on the big files if we can help it, so I think this workaround should work.

I tested this with and without Infixo's Better Civilopedia mod.  In related news, I discovered Infixo's Better Civilopedia mod and intend to keep using it, it's very nice!

This shouldn't conflict with the other PR that is open.
