### PR TITLE
Fix issues with Great People screen

### DIFF
--- a/Assets/UI/Popups/greatpeoplepopup.xml
+++ b/Assets/UI/Popups/greatpeoplepopup.xml
@@ -97,7 +97,6 @@
 
                 <!-- CQUI : changed sizeY to auto -->
                 <Container ID="RecruitProgressBox" Anchor="C,B" Offset="-1,30" Size="parent,auto">
-
                     <Stack Anchor="C,T" StackGrowth="Down" StackPadding="3">
                         <Box Anchor="C,T" Size="parent-8,2" Color="199,187,157,90" />
                         <Stack Anchor="C,T" StackGrowth="Right" StackPadding="2" Offset="0,4">
@@ -117,17 +116,18 @@
                     </Stack>
 
                     <!-- CQUI :changes the Offset -->
-                    <Label ID="RecruitInfo" Anchor="C,B" Offset="0,-30" Style="GreatPeopleText" String="LOC_GREAT_PEOPLE_OR_RECRUIT_WITH_PATRONAGE" />
+                    <Label ID="RecruitInfo" Anchor="C,B" Offset="0,-31" Style="FontNormal16" String="LOC_GREAT_PEOPLE_OR_RECRUIT_WITH_PATRONAGE" />
 
+                    <!-- CQUI: Recruit and Reject button moved to same location as Gold/Faith buttons, so all of the Civs in the Recruit list can be shown -->
                     <Stack ID="RecruitButtonStack" Anchor="C,B" Offset="0,6" StackGrowth="Down">
-                        <GridButton ID="RecruitButton" Anchor="C,B" Size="190,41" Style="ButtonConfirm" Hidden="1" String="LOC_GREAT_PEOPLE_RECRUIT" />
-                        <GridButton ID="RejectButton" Anchor="C,B" Size="190,41" Style="MainButton" Hidden="1" String="LOC_GREAT_PEOPLE_PASS" />
                     </Stack>
                 </Container>
 
-                <Stack Anchor="C,B" Offset="0,-10" StackGrowth="Right" StackPadding="10">
-                    <GridButton ID="GoldButton" Size="80,32" SliceCorner="12,12" SliceSize="1,1" SliceTextureSize="24,24" Texture="Controls_ButtonControl_Brown" TextColor="126,123,120" Style="FontNormal18" StateOffsetIncrement="0,24" String="999" />
-                    <GridButton ID="FaithButton" Size="80,32" SliceCorner="12,12" SliceSize="1,1" SliceTextureSize="24,24" Texture="Controls_ButtonControl_Brown" TextColor="126,123,120" Style="FontNormal18" StateOffsetIncrement="0,24" String="999" />
+                <Stack Anchor="C,B" Offset="0,-10" StackGrowth="Right" StackPadding="8">
+                    <GridButton ID="RecruitButton"  Hidden="1" Size="88,32" Style="ButtonConfirmSmall"  Style="FontNormal16" String="LOC_GREAT_PEOPLE_RECRUIT" />
+                    <GridButton ID="RejectButton"  Hidden="1" Size="88,32" Style="MainButtonSmall"  Style="FontNormal16" String="LOC_GREAT_PEOPLE_PASS" />
+                    <GridButton ID="GoldButton" Size="88,32" SliceCorner="12,12" SliceSize="1,1" SliceTextureSize="24,24" Texture="Controls_ButtonControl_Brown" Style="FontNormal18" StateOffsetIncrement="0,24" String="999" />
+                    <GridButton ID="FaithButton" Size="88,32" SliceCorner="12,12" SliceSize="1,1" SliceTextureSize="24,24" Texture="Controls_ButtonControl_Brown" Style="FontNormal18" StateOffsetIncrement="0,24" String="999" />
                 </Stack>
             </Container>
 


### PR DESCRIPTION
Addresses the issue opened by @phielp in #129, and I think @PriestSexist in #136, unless "see bug" is something besides every icon being a Great Admiral icon

**WHAT THIS DOES**
- Recruit progress (self and other civs) no longer obscured by the Recruit/Pass buttons
  - Entire list is shown when Recruit/Pass is available
- Correctly displays the no-longer-available message when there are no more Great Prophets
- Correctly shows the various Great-Person icons 
- Recruit/Pass buttons smaller, relocated to the same spots the Gold/Faith buttons live (as those buttons were not visible anyway when Recruit/Pass was available)
- Gold/Faith buttons now show lighter/darker text depending on whether they're enabled or disabled
- Gold/Faith buttons slightly larger to match size of Recruit/Pass buttons
- Slightly larger font for the "Cannot Recruit" message
- Updates Greatpeoplepopup.lua with changes to the Firaxis code that hadn't yet been imported into CQUI (minor, but explains at least 1 variable renaming)

**A PICTURE WITH ALL THE CHANGES**
![image](https://user-images.githubusercontent.com/8787640/89725998-b3b7a680-d9ca-11ea-98a8-2725b87c6990.png)

