### PR TITLE
Fixed sizing issue with Great People popup

### DIFF
--- a/Assets/UI/Popups/greatpeoplepopup.lua
+++ b/Assets/UI/Popups/greatpeoplepopup.lua
@@ -163,8 +163,16 @@ function ViewCurrent( data:table )
 
     local kInstanceToShow:table = nil;
 
-    local CQUI_preferedRecruitScrollSize = 0;
-    local CQUI_isPreferedRecruitScrollSizeComputed:boolean = false;
+    -- 63px from top of container "RecruitProgressBox" to top of scrollpanel "RecruitScroll"
+    -- 84px from bottom of scrollpanel "RecruitScroll" to bottom of the container "PopupContainer"
+    local CQUI_lowerPanelAdditionalHeight = 147;
+    -- When fit to a full screen, the Great Person panel instance is 122px shorter than the "PopupContainer"
+    local CQUI_instanceMargin = 127;
+    local CQUI_preferredRecruitScrollSize = 0;
+    local CQUI_preferredEffectsScrollSize = 240; -- Value defined in the XML
+    local CQUI_preferredInstanceSize = 0;
+    local CQUI_isPreferredRecruitScrollSizeComputed:boolean = false;
+    local CQUI_isPreferredHeightsComputed:boolean = false;
 
     for i, kPerson:table in ipairs(data.Timeline) do
         local instance  :table = m_greatPersonPanelIM:GetInstance();
@@ -269,7 +277,7 @@ function ViewCurrent( data:table )
                 instance.GoldButton:SetHide(true);
             end
 
-        -- Buy via Faith
+            -- Buy via Faith
             if (HasCapability("CAPABILITY_GREAT_PEOPLE_RECRUIT_WITH_FAITH") and (not kPerson.CanRecruit and not kPerson.CanReject and kPerson.PatronizeWithFaithCost ~= nil and kPerson.PatronizeWithFaithCost < 1000000)) then
                 if ((kPerson.CanPatronizeWithFaith) and not IsReadOnly()) then
                     instance.FaithButton:SetText("[COLOR_Faith]" .. kPerson.PatronizeWithFaithCost .. "[ENDCOLOR][ICON_Faith]");
@@ -287,14 +295,14 @@ function ViewCurrent( data:table )
                 instance.FaithButton:SetHide(true);
             end
 
-        -- Recruiting 
+            -- Recruiting 
             if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_RECRUIT") and kPerson.CanRecruit and kPerson.RecruitCost ~= nil) then
                 instance.RecruitButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_RECRUIT_DETAILS", kPerson.RecruitCost) );
                 instance.RecruitButton:SetVoid1(kPerson.IndividualID);
                 instance.RecruitButton:RegisterCallback(Mouse.eLClick, OnRecruitButtonClick);
                 instance.RecruitButton:SetHide(false);
 
-            -- Auto scroll to first recruitable person.
+              -- Auto scroll to first recruitable person.
                 if kInstanceToShow==nil then
                     kInstanceToShow = instance;
                 end
@@ -302,7 +310,7 @@ function ViewCurrent( data:table )
                 instance.RecruitButton:SetHide(true);
             end
 
-        -- Rejecting
+            -- Rejecting
             if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_REJECT") and kPerson.CanReject and kPerson.RejectCost ~= nil) then
                 instance.RejectButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_PASS_DETAILS", kPerson.RejectCost ) );
                 instance.RejectButton:SetVoid1(kPerson.IndividualID);
@@ -312,16 +320,16 @@ function ViewCurrent( data:table )
                 instance.RejectButton:SetHide(true);
             end
 
-        -- If Recruit or Reject buttons are shown hide the minimized recruit stack
-        -- CQUI: Do not hide the "Minimized Recruit" Stack (which lists the progress of all of the civs for that Great Person)
-            -- if not instance.RejectButton:IsHidden() or not instance.RecruitButton:IsHidden() then
+            -- If Recruit or Reject buttons are shown hide the minimized recruit stack
+            -- CQUI: Do not hide the "Minimized Recruit" Stack (which lists the progress of all of the civs for that Great Person)
+                -- if not instance.RejectButton:IsHidden() or not instance.RecruitButton:IsHidden() then
             --    instance.RecruitMinimizedStack:SetHide(true);
             -- else
             --    instance.RecruitMinimizedStack:SetHide(false);
             -- end
             
-        -- Recruiting standings
-        -- Let's sort the table first by points total, then by the lower player id (to push yours toward the top of the list for readability)
+            -- Recruiting standings
+            -- Let's sort the table first by points total, then by the lower player id (to push yours toward the top of the list for readability)
             local recruitTable: table = {};
             for i, kPlayerPoints in ipairs(data.PointsByClass[kPerson.ClassID]) do
                 table.insert(recruitTable,kPlayerPoints);
@@ -341,8 +349,8 @@ function ViewCurrent( data:table )
                 else
                     local recruitInst:table = instance["m_RecruitIM"]:GetInstance();
                     FillRecruitInstance(recruitInst, kPlayerPoints, kPerson, classData);
-                    if not CQUI_isPreferedRecruitScrollSizeComputed then
-                        CQUI_preferedRecruitScrollSize = CQUI_preferedRecruitScrollSize + recruitInst.Top:GetSizeY() + 5; -- AZURENCY : 5 is the padding
+                    if not CQUI_isPreferredRecruitScrollSizeComputed then
+                        CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + recruitInst.Top:GetSizeY() + 5; -- AZURENCY : 5 is the padding
                     end
                 end
 
@@ -350,8 +358,8 @@ function ViewCurrent( data:table )
                 FillRecruitInstance(recruitExtendedInst, kPlayerPoints, kPerson, classData);
             end
 
-            if not CQUI_isPreferedRecruitScrollSizeComputed then
-                CQUI_isPreferedRecruitScrollSizeComputed = true;
+            if not CQUI_isPreferredRecruitScrollSizeComputed then
+                CQUI_isPreferredRecruitScrollSizeComputed = true;
             end
 
             if (kPerson.EarnConditions ~= nil and kPerson.EarnConditions ~= "") then
@@ -367,13 +375,13 @@ function ViewCurrent( data:table )
 
         
         if kPerson.IndividualID ~= nil then
-        -- Set the biography buttons
+            -- Set the biography buttons
             instance.BiographyBackButton:SetVoid1( kPerson.IndividualID );
             instance.BiographyBackButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
             instance.BiographyOpenButton:SetVoid1( kPerson.IndividualID );
             instance.BiographyOpenButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
             
-        -- Setup extended recruit info buttons
+            -- Setup extended recruit info buttons
             instance.RecruitInfoOpenButton:SetVoid1( kPerson.IndividualID );
             instance.RecruitInfoOpenButton:RegisterCallback( Mouse.eLClick, OnRecruitInfoClick );
             instance.RecruitInfoBackButton:SetVoid1( kPerson.IndividualID );
@@ -394,26 +402,48 @@ function ViewCurrent( data:table )
         instance.RecruitInfoArea:SetHide( true );
         instance.FadedBackground:SetHide( true );
         instance.BiographyOpenButton:SetHide( noneAvailable );
-        
         instance.EffectStack:CalculateSize();
         instance.EffectStackScroller:CalculateSize();
 
-    --CQUI_preferedRecruitScrollSize = 1000;
-        if (CQUI_preferedRecruitScrollSize > (CQUI_screenHeight/4)) then
-            CQUI_preferedRecruitScrollSize = (CQUI_screenHeight/4);
+        if (CQUI_isPreferredHeightsComputed == false) then
+            --CQUI_preferredRecruitScrollSize = 1000;  -- for quick testing
+            if (CQUI_preferredRecruitScrollSize > (CQUI_screenHeight / 4)) then
+                CQUI_preferredRecruitScrollSize = (CQUI_screenHeight / 4);
+            end
+
+            -- 670 is the default Instance size in the XML... 86 is a number that represents some undocumented thing
+            CQUI_preferredInstanceSize =  670 - 86 + CQUI_preferredRecruitScrollSize;
+            -- CQUI_preferredInstanceSize = 3000 -- for quick testing
+            if (CQUI_preferredInstanceSize > (CQUI_screenHeight - CQUI_instanceMargin)) then
+                -- The instance area cannot be bigger than the screen height minus CQUI_instanceMargin:
+                -- When the Gold/Faith (or Recruit/Pass) buttons are 5px above the PeopleScroller horizontal scroll, 
+                -- the PanelInstance is CQUI_instanceMargin pixels less in height than the PeopleContainer, which is defined as 768 in the XML.
+                -- These adjustments are necessary to properly fit the screen
+                local prevPreferredInstanceSize = CQUI_preferredInstanceSize;
+                CQUI_preferredInstanceSize = CQUI_screenHeight - CQUI_instanceMargin;
+
+                -- Instead of shrinking the recruit scroll size, instead shrink the EffectsStackScroller, as there's typically room to spare in that section
+                -- 240 is the value defined in the XML.  We cannot do a GetSizeY here because subsequent calls to this function
+                -- would update the smaller value, eventually shrinking the control to less than zero.
+                local effectStackScrollerAdjustment = prevPreferredInstanceSize - CQUI_preferredInstanceSize;
+                CQUI_preferredEffectsScrollSize = 240 - effectStackScrollerAdjustment;
+            end
+
+            CQUI_isPreferredHeightsComputed = true;
         end
 
-    -- CQUI : change size
-    -- CQUI DEBUG TEST : 
-    -- CQUI_preferedRecruitScrollSize = 300;
-        instance.RecruitScroll:SetSizeY(CQUI_preferedRecruitScrollSize);
-    -- CQUI : change size
-        instance.Content:SetSizeY( 670 - 86 + CQUI_preferedRecruitScrollSize); -- CQUI : 86 scroll default
+        -- CQUI : change size
+        -- CQUI DEBUG TEST :
+        -- CQUI_preferredRecruitScrollSize = 300;
+        instance.Content:SetSizeY(CQUI_preferredInstanceSize);
+        instance.EffectStackScroller:SetSizeY(CQUI_preferredEffectsScrollSize);
+        instance.RecruitScroll:SetSizeY(CQUI_preferredRecruitScrollSize);
     end
 
     -- CQUI : change size
-    --CQUI_preferedRecruitScrollSize = CQUI_preferedRecruitScrollSize + 32 + 28 + 48 + 28 ; -- CQUI : 22 our LocalPlayerRecruitInstance, 28 Recruit progress title, 48 buttons, 28 arbitrary padding set to Content
-    Controls.CQUI_RecruitWoodPaneling:SetSizeY(CQUI_preferedRecruitScrollSize + 32 + 28 + 48 + 28 + 46); 
+    --CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + 32 + 28 + 48 + 28 ;
+    -- CQUI : 22 our LocalPlayerRecruitInstance, 28 Recruit progress title, 48 buttons, 28 distance from scroll bar to edge of PeopleScroller control
+    Controls.CQUI_RecruitWoodPaneling:SetSizeY(CQUI_preferredRecruitScrollSize + CQUI_lowerPanelAdditionalHeight); 
 
     Controls.PeopleStack:CalculateSize();
     Controls.PeopleScroller:CalculateSize();
@@ -434,8 +464,8 @@ function ViewCurrent( data:table )
     Controls.PopupContainer:SetSizeX( m_screenWidth );
     Controls.ModalFrame:SetSizeX( m_screenWidth );
     -- CQUI : change size
-    Controls.ModalFrame:SetSizeY( CQUI_ModalFrameBaseSize + CQUI_preferedRecruitScrollSize - 20);    -- CQUI
-    Controls.PopupContainer:SetSizeY( CQUI_PopupContainerBaseSize + CQUI_preferedRecruitScrollSize - 20); -- CQUI
+    Controls.ModalFrame:SetSizeY( CQUI_preferredInstanceSize + CQUI_instanceMargin -6 );    -- CQUI: 6px less for the 3px outer border
+    Controls.PopupContainer:SetSizeY( CQUI_preferredInstanceSize + CQUI_instanceMargin ); -- CQUI
 
     -- Has an instance been set to auto scroll to?
     Controls.PeopleScroller:SetScrollValue( 0 );            -- Either way reset scroll first (mostly for hot seat)
@@ -450,6 +480,7 @@ function ViewCurrent( data:table )
     end
 end
 
+-- ===========================================================================
 function FillRecruitInstance(instance:table, playerPoints:table, personData:table, classData:table)
     instance.Country:SetText( playerPoints.PlayerName );
     

--- a/Assets/UI/Popups/greatpeoplepopup.xml
+++ b/Assets/UI/Popups/greatpeoplepopup.xml
@@ -9,9 +9,12 @@
             <!-- CQUI : new textures that adapt the height -->
             <Image ID="CQUI_ContentWoodPaneling" Size="214,parent" Texture="CQUI_GreatPeople_Background_Repeat_Top.dds" StretchMode="Tile"/>
             <Image ID="WoodPaneling" Size="214,547" Texture="CQUI_GreatPeople_Background_Top.dds" StretchMode="TileX"/>
-            <!-- CQUI : Size should be se programmaticly (Offet : 78 peoplestack + 42 buttons) -->
+            <!-- This is the darker "paneling", which is actually just the vertical lines as BottomWoodPaneling sits on top of it -->
+            <!-- Size should be set programmatically (OffsetY : 78 peoplestack + 42 buttons) -->
             <Image ID="CQUI_RecruitWoodPaneling" Anchor="L,B" Offset="0,0" Size="214,parent" Texture="CQUI_GreatPeople_Background_Repeat_Bottom.dds" StretchMode="Tile"/>
-            <Image ID="CQUI_BottomWoodPaneling" Size="214,80" Texture="CQUI_GreatPeople_Background_Bottom.dds" StretchMode="TileX" Anchor="L,B" />
+            <!-- This image is the bottom of the paneling outline (curved corner and horizontal line) -->
+            <!-- At 40px tall, it has 5px gap between the bottom horizontal line and the PeopleScroller scroll bar, must be at least 40px in height -->
+            <Image ID="CQUI_BottomWoodPaneling" Size="214,40" Texture="CQUI_GreatPeople_Background_Bottom.dds" StretchMode="TileX" Anchor="L,B" />
 
 
 


### PR DESCRIPTION
I wanted this to be more dynamic, but getting the correct size of controls when there's offsets involved seems really crazy.  This solution works and so far I have tested on a 1024x768 and 1920x1200 screen size.

The previous version of things would take the standard "modal frame" size, add the preferred size of the control with all of the civs listed, and then subtract 20.  On screens with 768 or 800px on the Y-axis this was a bad calculation.

This code also shrinks the "Effects" section instead of the Civ recruits section when it needs to compensate for screen size.  Its easy enough to instead take that size from the list of civs, but on the 768-size screen for example, that meant the scroll box contained 3 visible civs only.

14 player game, with the changes in this PR:

1024x768:
![image](https://user-images.githubusercontent.com/8787640/90118387-023bac80-dd0d-11ea-8290-e6e951da911a.png)

1920x1200:
![image](https://user-images.githubusercontent.com/8787640/90118165-affa8b80-dd0c-11ea-9e19-792efc7fa19f.png)
