### PR TITLE
Fix Category Collapsing buttons in DiplomacyDealView

### DIFF
--- a/Assets/UI/diplomacydealview_CQUI.lua
+++ b/Assets/UI/diplomacydealview_CQUI.lua
@@ -18,7 +18,7 @@ local CQUI_MinimizedSectionIM = InstanceManager:new( "MinimizedSection", "Minimi
 local CQUI_SIZE_SLOT_TYPE_ICON = 20;
 
 -- ===========================================================================
---  CQUI PopulateSignatureArea functiton
+--  CQUI PopulateSignatureArea function
 --  Populate the icon and leader name for the given player
 -- ===========================================================================
 function PopulateSignatureArea(player:table, iconControl, leaderControl, civControl)
@@ -64,7 +64,7 @@ function PopulateSignatureArea(player:table, iconControl, leaderControl, civCont
 end
 
 -- ===========================================================================
---  CQUI GetImportedResources functiton
+--  CQUI GetImportedResources function
 --  from the Improved Deal Screen by Mironos
 -- ===========================================================================
 function CQUI_GetImportedResources(playerID)
@@ -182,7 +182,7 @@ function CQUI_GetImportedResources(playerID)
 end
 
 -- ===========================================================================
---  CQUI MatchesPartnerResource functiton
+--  CQUI MatchesPartnerResource function
 --  from the Improved Deal Screen by Mironos
 -- ===========================================================================
 function MatchesPartnerResource(partnerResourceTable, targetResourceType)
@@ -197,7 +197,7 @@ function MatchesPartnerResource(partnerResourceTable, targetResourceType)
 end
 
 -- ===========================================================================
---  CQUI CQUI_RenderResourceButton functiton
+--  CQUI CQUI_RenderResourceButton function
 --  Render the correct resource button
 -- ===========================================================================
 function CQUI_RenderResourceButton(resource, resourceCategory, iconList, howAcquired)
@@ -264,7 +264,7 @@ function CQUI_RenderResourceButton(resource, resourceCategory, iconList, howAcqu
 end
 
 -- ===========================================================================
---  CQUI CQUI_RenderCityButton functiton
+--  CQUI CQUI_RenderCityButton function
 --  Render the city button with all the details
 -- ===========================================================================
 function CQUI_RenderCityButton(pCity : table, player : table, targetContainer : table)
@@ -398,7 +398,7 @@ function CQUI_MakeCityToolTip(pCity:table, player:table)
 end
 
 -- ===========================================================================
---  CQUI modified UpdateOtherPlayerText functiton
+--  CQUI modified UpdateOtherPlayerText function
 --  Small Hack, because modifing OnShow is not called, this function is called first after player variable are set and only in the original OnShow()
 --  Populate the signature of each civilization in the trade screen
 -- ===========================================================================
@@ -425,7 +425,7 @@ function UpdateOtherPlayerText(otherPlayerSays)
 end
 
 -- ===========================================================================
---  CQUI modified PopulateAvailableResources functiton
+--  CQUI modified PopulateAvailableResources function
 --  Resources are sorted by quantity
 -- ===========================================================================
 function PopulateAvailableResources(player : table, iconList : table, className : string)
@@ -518,7 +518,7 @@ function PopulateAvailableResources(player : table, iconList : table, className 
 end
 
 -- ===========================================================================
---  CQUI modified PopulateAvailableCities functiton
+--  CQUI modified PopulateAvailableCities function
 -- ===========================================================================
 function PopulateAvailableCities(player : table, iconList : table)
     local iAvailableItemCount = 0;
@@ -616,7 +616,7 @@ function PopulateAvailableCities(player : table, iconList : table)
 end
 
 -- ===========================================================================
---  CQUI modified PopulateAvailableGreatWorks functiton
+--  CQUI modified PopulateAvailableGreatWorks function
 -- ===========================================================================
 function PopulateAvailableGreatWorks(player : table, iconList : table)
     local iAvailableItemCount = 0;

--- a/Assets/UI/diplomacydealview_CQUI.lua
+++ b/Assets/UI/diplomacydealview_CQUI.lua
@@ -417,6 +417,7 @@ function UpdateOtherPlayerText(otherPlayerSays)
         CQUI_IconOnlyIM:ResetInstances();
         CQUI_IconAndTextForCitiesIM:ResetInstances();
         CQUI_IconAndTextForGreatWorkIM:ResetInstances();
+        CQUI_MinimizedSectionIM:ResetInstances();
 
         PopulateSignatureArea(g_LocalPlayer, Controls.PlayerCivIcon, Controls.PlayerLeaderName, Controls.PlayerCivName);  -- Expansion 2 added global variable for local and other player
         PopulateSignatureArea(g_OtherPlayer, Controls.OtherPlayerCivIcon, Controls.OtherPlayerLeaderName, Controls.OtherPlayerCivName);
@@ -524,11 +525,13 @@ function PopulateAvailableCities(player : table, iconList : table)
     local pForDeal = DealManager.GetWorkingDeal(DealDirection.OUTGOING, g_LocalPlayer:GetID(), g_OtherPlayer:GetID());
     -- Note: damanged cities do not appear in this list
     local possibleItems = DealManager.GetPossibleDealItems(player:GetID(), GetOtherPlayer(player):GetID(), DealItemTypes.CITIES, pForDeal);
-    local uiMinimizedSection:table = CQUI_MinimizedSectionIM:GetInstance(iconList.List);
 
     if (pForDeal ~= nil) then
         CQUI_IconAndTextForCitiesIM:ReleaseInstanceByParent(iconList.ListStack);
+        CQUI_MinimizedSectionIM:ReleaseInstanceByParent(iconList.List);
     end
+
+    local uiMinimizedSection:table = CQUI_MinimizedSectionIM:GetInstance(iconList.List);
 
     -- Todo: Possible to show the untradable (damaged) cities?
     if (possibleItems ~= nil) then
@@ -581,7 +584,7 @@ function PopulateAvailableCities(player : table, iconList : table)
 
             -- pCity should never be nil here, if it is print a warning so the scenario can be reproduced
             if pCity ~= nil then
-                local icon = CQUI_RenderCityButton(pCity, player, iconList.ListStack)
+                local icon = CQUI_RenderCityButton(pCity, player, iconList.ListStack);
                 local uiMinimizedIcon = CQUI_IconOnlyIM:GetInstance(uiMinimizedSection.MinimizedSectionStack);
                 SetIconToSize(uiMinimizedIcon.Icon, "ICON_BUILDINGS", 45);
                 uiMinimizedIcon.AmountText:SetHide(true);
@@ -619,11 +622,13 @@ function PopulateAvailableGreatWorks(player : table, iconList : table)
     local iAvailableItemCount = 0;
     local pForDeal = DealManager.GetWorkingDeal(DealDirection.OUTGOING, g_LocalPlayer:GetID(), g_OtherPlayer:GetID());
     local possibleItems = DealManager.GetPossibleDealItems(player:GetID(), GetOtherPlayer(player):GetID(), DealItemTypes.GREATWORK, pForDeal);
-    local uiMinimizedSection : table = CQUI_MinimizedSectionIM:GetInstance(iconList.List);
 
     if (pForDeal ~= nil) then
         CQUI_IconAndTextForGreatWorkIM:ReleaseInstanceByParent(iconList.ListStack);
+        CQUI_MinimizedSectionIM:ReleaseInstanceByParent(iconList.List);
     end
+
+    local uiMinimizedSection:table = CQUI_MinimizedSectionIM:GetInstance(iconList.List);
 
     -- CQUI : Sort by great work type
     local sort_func = function( a,b ) return a.ForTypeDescriptionID < b.ForTypeDescriptionID end;


### PR DESCRIPTION
**These changes are in the current m4a-ppe branch** -- y'all can use that branch for testing if you'd prefer to download 1 version of files instead of 5 or 6 different ones.  I'll leave the pull requests all separated, however. 

From #133 - the Collapse Icons didn't do anything in DiplomacyDealView screen.

** WHAT THIS DOES **
- Integrates the "Minimized" buttons from the basegame code into the CQUI DiploDealView screen.
- City button tool tips now include "Return" or "Cede", if they should have it, to deal with the minimized buttons
- Fix issue where determining if it was a "Cede city" would only work in English
- I did not do the rename of the files in this PR because there's multiple and I'd rather do that in a separate PR.

Screen shots:
![image](https://user-images.githubusercontent.com/8787640/90723568-d15df900-e271-11ea-9547-da6208f7e615.png)
![image](https://user-images.githubusercontent.com/8787640/90723584-e175d880-e271-11ea-811e-8a8f9ca4f325.png)
![image](https://user-images.githubusercontent.com/8787640/90724891-226eec80-e274-11ea-8361-8323524ab4d9.png)

