### PR TITLE
CQUICommon clean-up

### DIFF
--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -1,5 +1,10 @@
 ------------------------------------------------------------------------------
---  Additional CQUI Common LUA support functions specific to Civilization 6
+-- Additional CQUI Common LUA support functions specific to Civilization 6
+-- Contains:
+-- * Expansions check
+-- * Debug support
+-- * CQUI_TrimGossipMessage
+-- * CQUI_GetRealHousingFromImprovements
 ------------------------------------------------------------------------------
 
 -- ===========================================================================
@@ -12,21 +17,19 @@
 g_bIsRiseAndFall    = Modding and Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9"); -- Rise & Fall
 g_bIsGatheringStorm = Modding and Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 
--- ===========================================================================
---  VARIABLES
--- ===========================================================================
-CQUI_ShowDebugPrint = false;
 
 -- ===========================================================================
---CQUI setting control support functions
+-- Debug support
 -- ===========================================================================
+
+CQUI_ShowDebugPrint = false;
+
 function print_debug(...)
     if CQUI_ShowDebugPrint then
         print(...);
     end
 end
 
--- ===========================================================================
 function CQUI_OnSettingsUpdate()
     print_debug("ENTRY: CQUICommon - CQUI_OnSettingsUpdate");
     if (GameInfo.CQUI_Settings ~= nil and GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"] ~= nil) then
@@ -36,188 +39,11 @@ function CQUI_OnSettingsUpdate()
     end
 end
 
--- ===========================================================================
--- Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)
-function RegisterControl(control, setting_name, update_function, extra_data)
-    print_debug("ENTRY: CQUICommon - RegisterControl");
-    LuaEvents.CQUI_SettingsUpdate.Add(function() update_function(control, setting_name, extra_data); end);
-end
-
--- ===========================================================================
--- Companion functions to RegisterControl
--- ===========================================================================
-function UpdateCheckbox(control, setting_name)
-    print_debug("ENTRY: CQUICommon - UpdateCheckbox");
-    local value = GameConfiguration.GetValue(setting_name);
-    if (value == nil) then
-        return;
-    end
-
-    control:SetSelected(value);
-end
-
--- ===========================================================================
-function UpdateSlider( control, setting_name, data_converter)
-    print_debug("ENTRY: CQUICommon - UpdateSlider");
-    local value = GameConfiguration.GetValue(setting_name);
-    if (value == nil) then
-        return;
-    end
-
-    control:SetStep(data_converter.ToSteps(value));
-end
-
--- ===========================================================================
---Used to populate combobox options
-function PopulateComboBox(control, values, setting_name, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateComboBox");
-    control:ClearEntries();
-    local current_value = GameConfiguration.GetValue(setting_name);
-
-    -- Validate the Value retrieved is legal
-    local isLegalValue = false;
-    if (current_value ~= nil) then
-        for _, v in ipairs(values) do
-            if (v[2] == current_value) then
-                isLegalValue = true;
-                break;
-            end
-        end
-    end
-
-    if (current_value == nil or isLegalValue == false) then
-        --LY Checks if this setting has a default state defined in the database
-        if (GameInfo.CQUI_Settings[setting_name]) then
-            --reads the default value from the database. Set them in Settings.sql
-            current_value = GameInfo.CQUI_Settings[setting_name].Value;
-        else
-            current_value = 0;
-        end
-
-        GameConfiguration.SetValue(setting_name, current_value); --/LY
-    end
-
-    for i, v in ipairs(values) do
-        local instance = {};
-        control:BuildEntry( "InstanceOne", instance );
-        instance.Button:SetVoid1(i);
-        instance.Button:LocalizeAndSetText(v[1]);
-        if (v[2] == current_value) then
-            local button = control:GetButton();
-            button:LocalizeAndSetText(v[1]);
-        end
-    end
-
-    control:CalculateInternals();
-    if (setting_name) then
-        control:RegisterSelectionCallback(
-            function(voidValue1, voidValue2, control)
-                local option = values[voidValue1];
-                local button = control:GetButton();
-                button:LocalizeAndSetText(option[1]);
-                GameConfiguration.SetValue(setting_name, option[2]);
-                LuaEvents.CQUI_SettingsUpdate();
-            end
-        );
-    end
-
-    if (tooltip ~= nil)then
-        control:SetToolTipString(tooltip);
-    end
-end
-
---Used to populate checkboxes
-function PopulateCheckBox(control, setting_name, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateCheckBox");
-    local current_value = GameConfiguration.GetValue(setting_name);
-    if (current_value == nil) then
-        --LY Checks if this setting has a default state defined in the database
-        if (GameInfo.CQUI_Settings[setting_name]) then
-            --because 0 is true in Lua
-            if (GameInfo.CQUI_Settings[setting_name].Value == 0) then
-                current_value = false;
-            else
-                current_value = true;
-            end
-        else
-            current_value = false;
-        end
-
-        GameConfiguration.SetValue(setting_name, current_value);
-    end
-
-    if (current_value == false) then
-        control:SetSelected(false);
-    else
-        control:SetSelected(true);
-    end
-
-    control:RegisterCallback(Mouse.eLClick,
-        function()
-            local selected = not control:IsSelected();
-            control:SetSelected(selected);
-            GameConfiguration.SetValue(setting_name, selected);
-            LuaEvents.CQUI_SettingsUpdate();
-        end
-    );
-
-    if (tooltip ~= nil)then
-        control:SetToolTipString(tooltip);
-    end
-end
-
--- ===========================================================================
---Used to populate sliders. data_converter is a table containing two functions: ToStep and ToValue, which describe how to hanlde converting from the incremental slider steps to a setting value, think of it as a less elegant inner class
---Optional third function: ToString. When included, this function will handle how the value is converted to a display value, otherwise this defaults to using the value from ToValue
-function PopulateSlider(control, label, setting_name, data_converter, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateSlider");
-    --This is necessary because RegisterSliderCallback fires twice when releasing the mouse cursor for some reason
-    local hasScrolled = false;
-    local current_value = GameConfiguration.GetValue(setting_name);
-    if (current_value == nil) then
-        --LY Checks if this setting has a default state defined in the database
-        if (GameInfo.CQUI_Settings[setting_name]) then
-            current_value = GameInfo.CQUI_Settings[setting_name].Value;
-        else
-            current_value = 0;
-        end
-
-        GameConfiguration.SetValue(setting_name, current_value); --/LY
-    end
-
-    control:SetStep(data_converter.ToSteps(current_value));
-    if (data_converter.ToString) then
-        label:SetText(data_converter.ToString(current_value));
-    else
-        label:SetText(current_value);
-    end
-
-    control:RegisterSliderCallback(
-        function()
-            local value = data_converter.ToValue(control:GetStep());
-            if (data_converter.ToString) then
-                label:SetText(data_converter.ToString(value));
-            else
-                label:SetText(value);
-            end
-
-            if (not control:IsTrackingLeftMouseButton() and hasScrolled == true) then
-                GameConfiguration.SetValue(setting_name, value);
-                LuaEvents.CQUI_SettingsUpdate();
-                hasScrolled = false;
-            else
-                hasScrolled = true;
-            end
-        end
-    );
-
-    if (tooltip ~= nil)then
-        control:SetToolTipString(tooltip);
-    end
-end
 
 -- ===========================================================================
 -- Trims source information from gossip messages. Returns nil if the message couldn't be trimmed (this usually means the provided string wasn't a gossip message at all)
+-- ===========================================================================
+
 function CQUI_TrimGossipMessage(str:string)
     print_debug("ENTRY: CQUICommon - CQUI_TrimGossipMessage - string: "..tostring(str));
     -- Get a sample of a gossip source string
@@ -242,11 +68,16 @@ function CQUI_TrimGossipMessage(str:string)
     return Split(str, last .. " " , 2)[2];
 end
 
+
 -- ===========================================================================
+-- Calculate real housing from improvements
 -- Author: Infixo, code from Better Report Screen
 -- 2020-06-09 new idea for calculations - calculate only a correction and apply to the game function
 -- please note that another condition was added - a tile must be within workable distance - this is how the game's engine works
+-- ===========================================================================
+
 local iCityMaxBuyPlotRange:number = tonumber(GlobalParameters.CITY_MAX_BUY_PLOT_RANGE);
+
 function CQUI_GetRealHousingFromImprovements(pCity:table)
     local cityX:number, cityY:number = pCity:GetX(), pCity:GetY();
     --local centerIndex:number = Map.GetPlotIndex(pCity:GetLocation());
@@ -264,9 +95,10 @@ function CQUI_GetRealHousingFromImprovements(pCity:table)
     return pCity:GetGrowth():GetHousingFromImprovements() + Round(iNumHousing-math.floor(iNumHousing),1);
 end
 
+
 -- ===========================================================================
 function Initialize()
-    print_debug("INITIALZE: CQUICommon.lua");
+    print_debug("INITIALIZE: CQUICommon.lua");
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 end

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -86,6 +86,189 @@ local WorkIconAlphaConverter = {
 -- ============================================================================
 -- FUNCTIONS
 -- ============================================================================
+
+
+-- ===========================================================================
+-- Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)
+function RegisterControl(control, setting_name, update_function, extra_data)
+    print_debug("ENTRY: CQUICommon - RegisterControl");
+    LuaEvents.CQUI_SettingsUpdate.Add(function() update_function(control, setting_name, extra_data); end);
+end
+
+-- ===========================================================================
+-- Companion functions to RegisterControl
+-- ===========================================================================
+function UpdateCheckbox(control, setting_name)
+    print_debug("ENTRY: CQUICommon - UpdateCheckbox");
+    local value = GameConfiguration.GetValue(setting_name);
+    if (value == nil) then
+        return;
+    end
+
+    control:SetSelected(value);
+end
+
+-- ===========================================================================
+function UpdateSlider( control, setting_name, data_converter)
+    print_debug("ENTRY: CQUICommon - UpdateSlider");
+    local value = GameConfiguration.GetValue(setting_name);
+    if (value == nil) then
+        return;
+    end
+
+    control:SetStep(data_converter.ToSteps(value));
+end
+
+-- ===========================================================================
+--Used to populate combobox options
+function PopulateComboBox(control, values, setting_name, tooltip)
+    print_debug("ENTRY: CQUICommon - PopulateComboBox");
+    control:ClearEntries();
+    local current_value = GameConfiguration.GetValue(setting_name);
+
+    -- Validate the Value retrieved is legal
+    local isLegalValue = false;
+    if (current_value ~= nil) then
+        for _, v in ipairs(values) do
+            if (v[2] == current_value) then
+                isLegalValue = true;
+                break;
+            end
+        end
+    end
+
+    if (current_value == nil or isLegalValue == false) then
+        --LY Checks if this setting has a default state defined in the database
+        if (GameInfo.CQUI_Settings[setting_name]) then
+            --reads the default value from the database. Set them in Settings.sql
+            current_value = GameInfo.CQUI_Settings[setting_name].Value;
+        else
+            current_value = 0;
+        end
+
+        GameConfiguration.SetValue(setting_name, current_value); --/LY
+    end
+
+    for i, v in ipairs(values) do
+        local instance = {};
+        control:BuildEntry( "InstanceOne", instance );
+        instance.Button:SetVoid1(i);
+        instance.Button:LocalizeAndSetText(v[1]);
+        if (v[2] == current_value) then
+            local button = control:GetButton();
+            button:LocalizeAndSetText(v[1]);
+        end
+    end
+
+    control:CalculateInternals();
+    if (setting_name) then
+        control:RegisterSelectionCallback(
+            function(voidValue1, voidValue2, control)
+                local option = values[voidValue1];
+                local button = control:GetButton();
+                button:LocalizeAndSetText(option[1]);
+                GameConfiguration.SetValue(setting_name, option[2]);
+                LuaEvents.CQUI_SettingsUpdate();
+            end
+        );
+    end
+
+    if (tooltip ~= nil)then
+        control:SetToolTipString(tooltip);
+    end
+end
+
+--Used to populate checkboxes
+function PopulateCheckBox(control, setting_name, tooltip)
+    print_debug("ENTRY: CQUICommon - PopulateCheckBox");
+    local current_value = GameConfiguration.GetValue(setting_name);
+    if (current_value == nil) then
+        --LY Checks if this setting has a default state defined in the database
+        if (GameInfo.CQUI_Settings[setting_name]) then
+            --because 0 is true in Lua
+            if (GameInfo.CQUI_Settings[setting_name].Value == 0) then
+                current_value = false;
+            else
+                current_value = true;
+            end
+        else
+            current_value = false;
+        end
+
+        GameConfiguration.SetValue(setting_name, current_value);
+    end
+
+    if (current_value == false) then
+        control:SetSelected(false);
+    else
+        control:SetSelected(true);
+    end
+
+    control:RegisterCallback(Mouse.eLClick,
+        function()
+            local selected = not control:IsSelected();
+            control:SetSelected(selected);
+            GameConfiguration.SetValue(setting_name, selected);
+            LuaEvents.CQUI_SettingsUpdate();
+        end
+    );
+
+    if (tooltip ~= nil)then
+        control:SetToolTipString(tooltip);
+    end
+end
+
+-- ===========================================================================
+--Used to populate sliders. data_converter is a table containing two functions: ToStep and ToValue, which describe how to hanlde converting from the incremental slider steps to a setting value, think of it as a less elegant inner class
+--Optional third function: ToString. When included, this function will handle how the value is converted to a display value, otherwise this defaults to using the value from ToValue
+function PopulateSlider(control, label, setting_name, data_converter, tooltip)
+    print_debug("ENTRY: CQUICommon - PopulateSlider");
+    --This is necessary because RegisterSliderCallback fires twice when releasing the mouse cursor for some reason
+    local hasScrolled = false;
+    local current_value = GameConfiguration.GetValue(setting_name);
+    if (current_value == nil) then
+        --LY Checks if this setting has a default state defined in the database
+        if (GameInfo.CQUI_Settings[setting_name]) then
+            current_value = GameInfo.CQUI_Settings[setting_name].Value;
+        else
+            current_value = 0;
+        end
+
+        GameConfiguration.SetValue(setting_name, current_value); --/LY
+    end
+
+    control:SetStep(data_converter.ToSteps(current_value));
+    if (data_converter.ToString) then
+        label:SetText(data_converter.ToString(current_value));
+    else
+        label:SetText(current_value);
+    end
+
+    control:RegisterSliderCallback(
+        function()
+            local value = data_converter.ToValue(control:GetStep());
+            if (data_converter.ToString) then
+                label:SetText(data_converter.ToString(value));
+            else
+                label:SetText(value);
+            end
+
+            if (not control:IsTrackingLeftMouseButton() and hasScrolled == true) then
+                GameConfiguration.SetValue(setting_name, value);
+                LuaEvents.CQUI_SettingsUpdate();
+                hasScrolled = false;
+            else
+                hasScrolled = true;
+            end
+        end
+    );
+
+    if (tooltip ~= nil)then
+        control:SetToolTipString(tooltip);
+    end
+end
+
+
 --Used to switch active panels/tabs in the settings panel
 function ShowTab(button, panel)
     print_debug("CQUI_SettingsElement: ShowTab Function Entry");


### PR DESCRIPTION
Clean-up for #48 
Functions that deal with settiung elements are moved to cqui_settingelement.lua because this is the only place where they are used.
CQUICommon is to te be used for reusable functions i.e. called from different files.
Added a header.