### PR TITLE
Control Debug Prints with a bitwise mask

### DIFF
--- a/Assets/Expansion2/Replacements/ingame.lua
+++ b/Assets/Expansion2/Replacements/ingame.lua
@@ -37,6 +37,9 @@ local m_timeUntilPopupCheck : number = 0;
 -- ===========================================================================
 --  FUNCTIONS
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_InGame, ...)
+end
 
 --CQUI Functions
 function CQUI_RequestUIAddin( request: string ) --Returns the first context to match the request string. Returns nil if a matching context can't be found

--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -35,9 +35,7 @@ g_CQUI_DebugMask_All         = 0xFF;
 
 function print_debug_masked(mask:number, ...)
     if bitAnd(CQUI_ShowDebugPrint, mask) ~= 0 then
--- TEMP
-        local str = "[CQUI "..tostring(mask).."] " .. table.concat({...}, " ");
---        local str = "[CQUI] " .. table.concat({...}, " ");
+        local str = "[CQUI] " .. table.concat({...}, " ");
         print(str);
     end
 end
@@ -107,10 +105,9 @@ function CQUI_GetRealHousingFromImprovements(pCity:table)
     return pCity:GetGrowth():GetHousingFromImprovements() + Round(iNumHousing-math.floor(iNumHousing),1);
 end
 
-
 -- ===========================================================================
 function Initialize()
-    print_debug_masked(g_CQUI_DebugMask_CQUICommon, "CQUICommon: Initialize ENTRY"); 
+    print_debug_masked(g_CQUI_DebugMask_CQUICommon, "INITIALIZE: CQUICommon.lua"); 
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 end

--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -6,6 +6,7 @@
 -- * CQUI_TrimGossipMessage
 -- * CQUI_GetRealHousingFromImprovements
 ------------------------------------------------------------------------------
+include("supportfunctions.lua"); -- bitwise Math
 
 -- ===========================================================================
 -- Expansions check
@@ -17,35 +18,46 @@
 g_bIsRiseAndFall    = Modding and Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9"); -- Rise & Fall
 g_bIsGatheringStorm = Modding and Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 
-
 -- ===========================================================================
 -- Debug support
 -- ===========================================================================
+-- Debug print controlled by a hexadecimal number representing a bit mask (100 in binary is 8 decimal, 1000 binary is 0x10 hex and 16 decimal... )
+-- For example, to enable debug print for settings and worldinput, the value to use is 0x5
+-- Use 0xFF to enable all debug print
+CQUI_ShowDebugPrint = 0x0;
+g_CQUI_DebugMask_CQUICommon  = 0x1;
+g_CQUI_DebugMask_InGame      = 0x2;
+g_CQUI_DebugMask_World       = 0x4;
+g_CQUI_DebugMask_CityBanners = 0x8;
+g_CQUI_DebugMask_Trade       = 0x10;
+g_CQUI_DebugMask_MoreLenses  = 0x20;
+g_CQUI_DebugMask_All         = 0xFF;
 
-CQUI_ShowDebugPrint = false;
-
-function print_debug(...)
-    if CQUI_ShowDebugPrint then
-        print(...);
+function print_debug_masked(mask:number, ...)
+    if bitAnd(CQUI_ShowDebugPrint, mask) ~= 0 then
+-- TEMP
+        local str = "[CQUI "..tostring(mask).."] " .. table.concat({...}, " ");
+--        local str = "[CQUI] " .. table.concat({...}, " ");
+        print(str);
     end
 end
 
+-- ===========================================================================
 function CQUI_OnSettingsUpdate()
-    print_debug("ENTRY: CQUICommon - CQUI_OnSettingsUpdate");
+    print_debug_masked(g_CQUI_DebugMask_CQUICommon, "ENTRY: CQUICommon - CQUI_OnSettingsUpdate");
     if (GameInfo.CQUI_Settings ~= nil and GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"] ~= nil) then
-        CQUI_ShowDebugPrint = ( GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"].Value == 1 );
+        CQUI_ShowDebugPrint = GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"].Value;
     else
         CQUI_ShowDebugPrint = GameConfiguration.GetValue("CQUI_ShowDebugPrint");
     end
 end
-
 
 -- ===========================================================================
 -- Trims source information from gossip messages. Returns nil if the message couldn't be trimmed (this usually means the provided string wasn't a gossip message at all)
 -- ===========================================================================
 
 function CQUI_TrimGossipMessage(str:string)
-    print_debug("ENTRY: CQUICommon - CQUI_TrimGossipMessage - string: "..tostring(str));
+    print_debug_masked(g_CQUI_DebugMask_CQUICommon, "ENTRY: CQUICommon - CQUI_TrimGossipMessage - string: "..tostring(str));
     -- Get a sample of a gossip source string
     local sourceSample = Locale.Lookup("LOC_GOSSIP_SOURCE_DELEGATE", "XX", "Y", "Z");
 
@@ -98,7 +110,7 @@ end
 
 -- ===========================================================================
 function Initialize()
-    print_debug("INITIALIZE: CQUICommon.lua");
+    print_debug_masked(g_CQUI_DebugMask_CQUICommon, "CQUICommon: Initialize ENTRY"); 
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 end

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -69,6 +69,11 @@ local CQUI_CityYields          = UILens.CreateLensLayerHash("City_Yields");
 local CQUI_CitizenManagement   = UILens.CreateLensLayerHash("Citizen_Management");
 
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_CityBanners, ...)
+end
+
+-- ===========================================================================
 function CQUI_OnSettingsInitialized()
     print_debug("CityBannerManager_CQUI: CQUI_OnSettingsInitialized ENTRY")
     CQUI_ShowYieldsOnCityHover         = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");

--- a/Assets/UI/WorldViewIconsManager_CQUI.lua
+++ b/Assets/UI/WorldViewIconsManager_CQUI.lua
@@ -19,6 +19,11 @@ local CQUI_RESOURCEICONSTYLE_HIDDEN = 2;
 local CQUI_ResourceIconStyle = CQUI_RESOURCEICONSTYLE_TRANSPARENT;
 
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_World, ...)
+end
+
+-- ===========================================================================
 function CQUI_GetSettingsValues()
     CQUI_ResourceIconStyle = GameConfiguration.GetValue("CQUI_ResourceDimmingStyle");
     if CQUI_ResourceIconStyle == nil then

--- a/Assets/UI/ingame.lua
+++ b/Assets/UI/ingame.lua
@@ -42,6 +42,10 @@ local m_timeUntilPopupCheck : number = 0;
 --  FUNCTIONS
 -- ===========================================================================
 -- ==== CQUI CUSTOMIZATION BEGIN  ==================================================================================== --
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_InGame, ...)
+end
+
 --CQUI Functions
 function CQUI_RequestUIAddin( request: string ) --Returns the first context to match the request string. Returns nil if a matching context can't be found
     for _,v in ipairs(g_uiAddins) do

--- a/Assets/UI/supportfunctions.lua
+++ b/Assets/UI/supportfunctions.lua
@@ -226,7 +226,7 @@ function bitNot( value:number )
 -- ===========================================================================
 --  Bitwise or (because LUA 5.2 support doesn't exist yet in Havok script)
 -- ===========================================================================
- function bitOr( na:number, nb:number)
+function bitOr( na:number, nb:number)
     local ka :table = numberToBitsTable(na);
     local kb :table = numberToBitsTable(nb);
 
@@ -260,7 +260,6 @@ function bitAnd( na:number, nb:number)
     end
     return bitsTableToNumber( kResult );
 end
-
 
 -- ===========================================================================
 -- Left shift (because LUA 5.2 support doesn't exist yet in Havok script)

--- a/Assets/UI/supportfunctions.lua
+++ b/Assets/UI/supportfunctions.lua
@@ -223,10 +223,10 @@ function bitNot( value:number )
     return bitsTableToNumber(kBits);
  end
 
- -- ===========================================================================
+-- ===========================================================================
 --  Bitwise or (because LUA 5.2 support doesn't exist yet in Havok script)
 -- ===========================================================================
- local function bitOr( na:number, nb:number)
+ function bitOr( na:number, nb:number)
     local ka :table = numberToBitsTable(na);
     local kb :table = numberToBitsTable(nb);
 
@@ -238,6 +238,25 @@ function bitNot( value:number )
     local digits  :number = table.count(ka);
     for i:number = 1, digits, 1 do
         kResult[i] = (ka[i]==1 or kb[i]==1) and 1 or 0;
+    end
+    return bitsTableToNumber( kResult );
+end
+
+ -- ===========================================================================
+--  Bitwise and (because LUA 5.2 support doesn't exist yet in Havok script)
+-- ===========================================================================
+function bitAnd( na:number, nb:number)
+    local ka :table = numberToBitsTable(na);
+    local kb :table = numberToBitsTable(nb);
+
+    -- Make sure both are the same size; pad with 0's if necessary.
+    while table.count(ka) < table.count(kb) do ka[table.count(ka)+1] = 0; end
+    while table.count(kb) < table.count(ka) do kb[table.count(kb)+1] = 0; end
+
+    local kResult :table  = {};
+    local digits  :number = table.count(ka);
+    for i:number = 1, digits, 1 do
+        kResult[i] = (ka[i]==1 and kb[i]==1) and 1 or 0;
     end
     return bitsTableToNumber( kResult );
 end

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -36,6 +36,11 @@ LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
 LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsUpdate );
 
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_World, ...)
+end
+
+-- ===========================================================================
 function CQUI_GetActionFromKey( uiKey:number )
     local action :table = {};
     for i, keymap in ipairs(CQUI_keyMaps) do

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -62,7 +62,8 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ('CQUI_ShowSuzerainInCityStateBanner', 1), -- Show the Icon of the Suzerain Civilization in the CityState Banner
         ('CQUI_ShowImprovementsRecommendations', 0), -- Shows the advisor recommendation for the builder improvements
         ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel
-        ('CQUI_ShowDebugPrint', 0); -- Shows print in the console
+        ('CQUI_ShowDebugPrint', 0x0); -- Shows print in the console (Hexidecimal number)
+                                      -- 0xFF to enable all debug print, see CQUICommon.lua for other mask values
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐
     │                                    Combobox settings                                       │

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -86,7 +86,9 @@ local WorkIconAlphaConverter = {
 -- ============================================================================
 -- FUNCTIONS
 -- ============================================================================
-
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_CQUICommon, ...)
+end
 
 -- ===========================================================================
 -- Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)

--- a/Integrations/BTS/UI/Choosers/traderoutechooser.lua
+++ b/Integrations/BTS/UI/Choosers/traderoutechooser.lua
@@ -62,7 +62,11 @@ local opt_print = false
 -- ===========================================================================
 --  CQUI
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_Trade, ...)
+end
 
+-- ===========================================================================
 function CQUI_OnSettingsUpdate()
   showSortOrdersPermanently = GameConfiguration.GetValue("CQUI_TraderShowSortOrder");
 

--- a/Integrations/BTS/UI/tradeoverview.lua
+++ b/Integrations/BTS/UI/tradeoverview.lua
@@ -124,7 +124,11 @@ local m_dividerCount = 0
 -- ===========================================================================
 --  CQUI
 -- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_Trade, ...)
+end
 
+-- ===========================================================================
 function CQUI_OnSettingsUpdate()
   showSortOrdersPermanently = GameConfiguration.GetValue("CQUI_TraderShowSortOrder");
   addDividerBetweenGroups = GameConfiguration.GetValue("CQUI_TraderAddDivider");

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -27,6 +27,11 @@ local m_EmpireDetails : number = UILens.CreateLensLayerHash("Empire_Details");
 
 local m_KeyStackIM:table = InstanceManager:new( "KeyEntry", "KeyColorImage", Controls.KeyStack );
 
+-- ===========================================================================
+function print_debug(...)
+    print_debug_masked(g_CQUI_DebugMask_MoreLenses, ...)
+end
+
 --============================================================================
 function Close()
   --ContextPtr:SetHide(true);


### PR DESCRIPTION
I find debug prints very useful... when there is a bit of control on what can be enabled and disabled.  The simple on/off for debug print has been something that I haven't been a fan of, so I wanted to do something with it.

**What this does**
- CQUI_ShowDebugPrint is now treated as a hexadecimal number, rather than true/false.
- Various entities (like TradeOverview, CQUI Settings, or CityBannerManager) can have their debug_prints enabled on or off by setting the value of CQUI_ShowDebugPrint.
  - A debug print only appears if the bitwise-AND of the CQUI_ShowDebugPrint value and the mask value from that entity are not zero.
- Automatically pre-pends [CQUI] to the beginning of the print_debug lines
- Files that had print_debug calls had a function added to the top to handle adding the entity mask (CityBannerManager_CQUI_basegame and _expansions call through CityBannerManager_CQUI, so that last one is the only file to get that wrapper function)

Mask Values, defined in CQUICommon.lua:
```
g_CQUI_DebugMask_CQUICommon  = 0x1;
g_CQUI_DebugMask_InGame      = 0x2;
g_CQUI_DebugMask_World       = 0x4;
g_CQUI_DebugMask_CityBanners = 0x8;
g_CQUI_DebugMask_Trade       = 0x10;
g_CQUI_DebugMask_MoreLenses  = 0x20;
```
Examples:
  - if CQUI_ShowDebugPrint is 0x8, then only the debug prints from CityBannerManager show in the FireTuner.
  - if CQUI_ShowDebugPrint is 0x7, then debug prints from "CQUI" (CQUISettings and CQUICommon), "InGame", and "World" (WorldInput and WorldViewIconsManager) will appear.
  - if CQUI_ShowDebugPrint is 0xFF, then all debug prints will appear

CQUICommon is the only file that calls the print_debug_masked from the other functions, all the other files that had an instance of print_debug now have a print_debug wrapper function added that calls print_debug_masked with the mask file.

**How Tested**
Set the value to various things and verified it worked.



