### PR TITLE
Clean up the debug prints

### DIFF
--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -17,21 +17,20 @@
 g_bIsRiseAndFall    = Modding and Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9"); -- Rise & Fall
 g_bIsGatheringStorm = Modding and Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 
-
 -- ===========================================================================
 -- Debug support
 -- ===========================================================================
-
 CQUI_ShowDebugPrint = false;
 
 function print_debug(...)
     if CQUI_ShowDebugPrint then
-        print(...);
+        local str = "[CQUI] " .. table.concat({...}, " ");
+        print(str);
     end
 end
 
+-- ===========================================================================
 function CQUI_OnSettingsUpdate()
-    print_debug("ENTRY: CQUICommon - CQUI_OnSettingsUpdate");
     if (GameInfo.CQUI_Settings ~= nil and GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"] ~= nil) then
         CQUI_ShowDebugPrint = ( GameInfo.CQUI_Settings["CQUI_ShowDebugPrint"].Value == 1 );
     else
@@ -39,13 +38,12 @@ function CQUI_OnSettingsUpdate()
     end
 end
 
-
 -- ===========================================================================
 -- Trims source information from gossip messages. Returns nil if the message couldn't be trimmed (this usually means the provided string wasn't a gossip message at all)
 -- ===========================================================================
 
 function CQUI_TrimGossipMessage(str:string)
-    print_debug("ENTRY: CQUICommon - CQUI_TrimGossipMessage - string: "..tostring(str));
+    -- print_debug("ENTRY: CQUICommon - CQUI_TrimGossipMessage - string: "..tostring(str));
     -- Get a sample of a gossip source string
     local sourceSample = Locale.Lookup("LOC_GOSSIP_SOURCE_DELEGATE", "XX", "Y", "Z");
 
@@ -98,7 +96,7 @@ end
 
 -- ===========================================================================
 function Initialize()
-    print_debug("INITIALIZE: CQUICommon.lua");
+    -- print_debug("INITIALIZE: CQUICommon.lua");
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 end

--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -24,8 +24,7 @@ CQUI_ShowDebugPrint = false;
 
 function print_debug(...)
     if CQUI_ShowDebugPrint then
-        local str = "[CQUI] " .. table.concat({...}, " ");
-        print(str);
+        print("[CQUI]", ...);
     end
 end
 

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -70,7 +70,7 @@ local CQUI_CitizenManagement   = UILens.CreateLensLayerHash("Citizen_Management"
 
 -- ===========================================================================
 function CQUI_OnSettingsInitialized()
-    print_debug("CityBannerManager_CQUI: CQUI_OnSettingsInitialized ENTRY")
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnSettingsInitialized ENTRY")
     CQUI_ShowYieldsOnCityHover         = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
     CQUI_ShowSuzerainInCityStateBanner = GameConfiguration.GetValue("CQUI_ShowSuzerainInCityStateBanner");
 
@@ -95,7 +95,7 @@ end
 
 -- ===========================================================================
 function CQUI_OnSettingsUpdate()
-    print_debug("CityBannerManager_CQUI: CQUI_OnSettingsUpdate ENTRY")
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnSettingsUpdate ENTRY")
     CQUI_OnSettingsInitialized();
     Reload();
 end
@@ -129,7 +129,7 @@ end
 -- Functions that enhance the unmodified versions
 -- ===========================================================================
 function OnGameDebugReturn( context:string, contextTable:table )
-    print_debug("CityBannerManager_CQUI: OnGameDebugReturn ENTRY context:"..tostring(context).." contextTable:"..tostring(contextTable));
+    -- print_debug("CityBannerManager_CQUI: OnGameDebugReturn ENTRY context:"..tostring(context).." contextTable:"..tostring(contextTable));
     if (context == "CityBannerManager") then
         -- CQUI settings
         CQUI_OnSettingsUpdate();
@@ -140,7 +140,7 @@ end
 
 -- ===========================================================================
 function OnInterfaceModeChanged( oldMode:number, newMode:number )
-    print_debug("CityBannerManager_CQUI: OnInterfaceModeChanged ENTRY");
+    -- print_debug("CityBannerManager_CQUI: OnInterfaceModeChanged ENTRY");
     BASE_CQUI_OnInterfaceModeChanged(oldMode, newMode);
 
     if (newMode == InterfaceModeTypes.DISTRICT_PLACEMENT) then
@@ -151,13 +151,13 @@ end
 
 -- ===========================================================================
 function OnProductionClick( playerID, cityID )
-    print_debug("CityBannerManager_CQUI: OnProductionClick ENTRY");
+    -- print_debug("CityBannerManager_CQUI: OnProductionClick ENTRY");
     OnCityBannerClick( playerID, cityID);
 end
 
 -- ===========================================================================
 function OnShutdown()
-    print_debug("CityBannerManager_CQUI: OnShutdown ENTRY");
+    -- print_debug("CityBannerManager_CQUI: OnShutdown ENTRY");
     CQUI_PlotIM:DestroyInstances();
 
     BASE_CQUI_OnShutdown();
@@ -165,7 +165,7 @@ end
 
 -- ===========================================================================
 function Reload()
-    print_debug("CityBannerManager_CQUI: Reload ENTRY");
+    -- print_debug("CityBannerManager_CQUI: Reload ENTRY");
     BASE_CQUI_Reload();
 
     local pLocalPlayerVis:table = PlayersVisibility[Game.GetLocalPlayer()];
@@ -186,7 +186,7 @@ end
 -- ============================================================================
 -- Move the CityStrike icon and button to the top of the City bar; similar to the Sukritact Simple UI Mod (which puts it on the right)
 function CityBanner.UpdateRangeStrike(self)
-    print_debug("CityBannerManager_CQUI: CityBanner.UpdateRangeStrike ENTRY");
+    -- print_debug("CityBannerManager_CQUI: CityBanner.UpdateRangeStrike ENTRY");
     BASE_CQUI_CityBanner_UpdateRangeStrike(self);
 
     local banner = self.m_Instance;
@@ -216,7 +216,7 @@ end
 -- CQUI Replacement Functions (Common to both basegame and expansions)
 -- ============================================================================
 function OnCityBannerClick( playerID, cityID )
-    print_debug("CityBannerManager_CQUI: OnCityBannerClick ENTRY  playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
+    -- print_debug("CityBannerManager_CQUI: OnCityBannerClick ENTRY  playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
     local pPlayer = Players[playerID];
     if (pPlayer == nil) then
         return;
@@ -291,7 +291,7 @@ end
 
 -- ===========================================================================
 function OnDistrictAddedToMap( playerID, districtID, cityID, districtX, districtY, districtType, percentComplete )
-    print_debug("CityBannerManager_CQUI: OnDistrictAddedToMap ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID).." cityID:"..tostring(cityID).." districtXY:"..tostring(districtX)..","..tostring(districtY).." districtType:"..tostring(districtType).." pctComplete:"..tostring(percentComplete));
+    -- print_debug("CityBannerManager_CQUI: OnDistrictAddedToMap ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID).." cityID:"..tostring(cityID).." districtXY:"..tostring(districtX)..","..tostring(districtY).." districtType:"..tostring(districtType).." pctComplete:"..tostring(percentComplete));
 
     local locX = districtX;
     local locY = districtY;
@@ -408,7 +408,7 @@ end
 
 -- ===========================================================================
 function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
-    print_debug("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
+    -- print_debug("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
     if eImprovementType == -1 then
         UI.DataError("Received -1 eImprovementType for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
         return;
@@ -550,7 +550,7 @@ end
 -- ===========================================================================
 -- CQUI update all cities real housing from improvements
 function CQUI_OnAllCitiesInfoUpdated(localPlayerID)
-    print_debug("CityBannerManager_CQUI: CQUI_OnCityInfoUpdated ENTRY localPlayerID:"..tostring(localPlayerID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnCityInfoUpdated ENTRY localPlayerID:"..tostring(localPlayerID));
     local m_pCity:table = Players[localPlayerID]:GetCities();
     for i, pCity in m_pCity:Members() do
         local pCityID = pCity:GetID();
@@ -748,14 +748,14 @@ end
 -- ===========================================================================
 -- CQUI update city's real housing from improvements
 function CQUI_OnCityInfoUpdated(localPlayerID, pCityID)
-    print_debug("CityBannerManager_CQUI: CQUI_OnCityInfoUpdated ENTRY localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnCityInfoUpdated ENTRY localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
     CQUI_HousingUpdated[localPlayerID][pCityID] = nil;
 end
 
 -- ===========================================================================
 -- CQUI update close to a culture bomb cities data and real housing from improvements
 function CQUI_OnCityLostTileToCultureBomb(localPlayerID, x, y)
-    print_debug("CityBannerManager_CQUI: CQUI_OnCityLostTileToCultureBomb ENTRY localPlayerID:"..tostring(localPlayerID).." LocationXY:"..tostring(x)..","..tostring(y));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnCityLostTileToCultureBomb ENTRY localPlayerID:"..tostring(localPlayerID).." LocationXY:"..tostring(x)..","..tostring(y));
     local m_pCity:table = Players[localPlayerID]:GetCities();
     for i, pCity in m_pCity:Members() do
         if Map.GetPlotDistance( pCity:GetX(), pCity:GetY(), x, y ) <= 4 then
@@ -769,7 +769,7 @@ end
 -- ===========================================================================
 -- Common handler for the City Strike Button (Vanilla and the expansions have 2 different functions for this)
 function CQUI_OnCityRangeStrikeButtonClick( playerID, cityID )
-    print_debug("CityBannerManager_CQUI: CQUI_OnCityRangeStrikeButtonClick ENTRY localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnCityRangeStrikeButtonClick ENTRY localPlayerID:"..tostring(localPlayerID).." pCityID:"..tostring(pCityID));
     local pPlayer = Players[playerID];
     if (pPlayer == nil) then
         return;
@@ -801,7 +801,7 @@ end
 -- ===========================================================================
 -- Common handler for the District Strike Button
 function OnDistrictRangeStrikeButtonClick( playerID, districtID )
-    print_debug("CityBannerManager_CQUI: OnDistrictRangeStrikeButtonClick ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID));
+    -- print_debug("CityBannerManager_CQUI: OnDistrictRangeStrikeButtonClick ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID));
     local pPlayer = Players[playerID];
     if (pPlayer == nil) then
         return;
@@ -827,7 +827,7 @@ end
 
 -- ===========================================================================
 function CQUI_OnInfluenceGiven()
-    print_debug("CityBannerManager_CQUI: CQUI_OnInfluenceGiven ENTRY");
+    -- print_debug("CityBannerManager_CQUI: CQUI_OnInfluenceGiven ENTRY");
     for i, pPlayer in ipairs(PlayerManager.GetAliveMinors()) do
         local iPlayer = pPlayer:GetID();
         -- AZURENCY : check if there's a CapitalCity
@@ -841,7 +841,7 @@ end
 
 -- ===========================================================================
 function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance )
-    print_debug("CityBannerManager_CQUI: CQUI_UpdateSuzerainIcon ENTRY  pPlayer:"..tostring(pPlayer).."  bannerInstance:"..tostring(bannerInstance));
+    -- print_debug("CityBannerManager_CQUI: CQUI_UpdateSuzerainIcon ENTRY  pPlayer:"..tostring(pPlayer).."  bannerInstance:"..tostring(bannerInstance));
     if (bannerInstance == nil) then
         return;
     end
@@ -940,7 +940,7 @@ end
 -- Game Engine EVENT
 -- ===========================================================================
 function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
-    print_debug("CityBannerManager_CQUI: OnCityWorkerChanged ENTRY ownerPlayerID:"..tostring(ownerPlayerID).." cityID:"..tostring(cityID));
+    -- print_debug("CityBannerManager_CQUI: OnCityWorkerChanged ENTRY ownerPlayerID:"..tostring(ownerPlayerID).." cityID:"..tostring(cityID));
     if (Game.GetLocalPlayer() == ownerPlayerID) then
         RefreshBanner( ownerPlayerID, cityID )
     end

--- a/Assets/UI/WorldView/citybannermanager_CQUI_basegame.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_basegame.lua
@@ -26,7 +26,7 @@ BASE_CQUI_CityBanner_UpdateStats = CityBanner.UpdateStats;
 -- ===========================================================================
 --function CityBanner.Initialize( self : CityBanner, playerID: number, cityID : number, districtID : number, bannerType : number, bannerStyle : number)
 function CityBanner.Initialize( self, playerID, cityID, districtID, bannerType, bannerStyle)
-    print_debug("CityBannerManager_CQUI_basegame: CityBanner:Initialize ENTRY: playerID:"..tostring(playerID).." cityID:"..tostring(cityID).." districtID:"..tostring(districtID).." bannerType:"..tostring(bannerType).." bannerStyle:"..tostring(bannerStyle));
+    -- print_debug("CityBannerManager_CQUI_basegame: CityBanner:Initialize ENTRY: playerID:"..tostring(playerID).." cityID:"..tostring(cityID).." districtID:"..tostring(districtID).." bannerType:"..tostring(bannerType).." bannerStyle:"..tostring(bannerStyle));
     CQUI_Common_CityBanner_Initialize(self, playerID, cityID, districtID, bannerType, bannerStyle);
 end
 
@@ -34,7 +34,7 @@ end
 function CityBanner.UpdateProduction(self)
     -- Single line difference between this and the base version that allows the icon of that
     -- which is being built to appear in the CityBanner
-    print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateProduction ENTRY");
+    -- print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateProduction ENTRY");
     BASE_CQUI_CityBanner_UpdateProduction(self);
 
     local localPlayerID :number = Game.GetLocalPlayer();
@@ -55,7 +55,7 @@ end
 -- ===========================================================================
 function CityBanner.UpdateStats(self)
     -- Most of the logic here is basegame only, XP1/XP2 do this work in the CityBanner.UpdatePopulation function
-    print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateStats ENTRY");
+    -- print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateStats ENTRY");
     BASE_CQUI_CityBanner_UpdateStats(self);
 
     -- CQUI get real housing from improvements value (do this regardless of whether or not the banners will be updated)
@@ -127,7 +127,7 @@ end
 -- Functions that override the unmodified versions in the game
 -- ===========================================================================
 function CityBanner.UpdateName( self )
-    print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateName ENTRY");
+    -- print_debug("CityBannerManager_CQUI_basegame: CityBanner.UpdateName ENTRY");
 
     if (IsBannerTypeCityCenter(self.m_Type) == false) then
         return;
@@ -326,7 +326,7 @@ end
 -- ===========================================================================
 -- Basegame and Expansions call this two different things (OnCityRangeStrikeButtonClick and OnCityStrikeButtonClick, respectively)
 function OnCityRangeStrikeButtonClick( playerID, cityID )
-    print_debug("CityBannerManager_CQUI_basegame: OnCityRangeStrikeButtonClick ENTRY");
+    -- print_debug("CityBannerManager_CQUI_basegame: OnCityRangeStrikeButtonClick ENTRY");
 
     -- Call the common code for handling the City Strike button
     CQUI_OnCityRangeStrikeButtonClick(playerID, cityID);

--- a/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
@@ -25,7 +25,7 @@ BASE_CQUI_CityBanner_UpdateStats = CityBanner.UpdateStats;
 -- CQUI Expansion Extension Functions
 -- ============================================================================
 function CityBanner.Initialize(self, playerID, cityID, districtID, bannerType, bannerStyle)
-    print_debug("CityBannerManager_CQUI_Expansions: CityBanner:Initialize ENTRY: playerID:"..tostring(playerID).." cityID:"..tostring(cityID).." districtID:"..tostring(districtID).." bannerType:"..tostring(bannerType).." bannerStyle:"..tostring(bannerStyle));
+    -- print_debug("CityBannerManager_CQUI_Expansions: CityBanner:Initialize ENTRY: playerID:"..tostring(playerID).." cityID:"..tostring(cityID).." districtID:"..tostring(districtID).." bannerType:"..tostring(bannerType).." bannerStyle:"..tostring(bannerStyle));
     CQUI_Common_CityBanner_Initialize(self, playerID, cityID, districtID, bannerType, bannerStyle);
 
     if (IsBannerTypeCityCenter(bannerType) and (self.CQUI_DistrictBuiltIM == nil)) then
@@ -35,7 +35,7 @@ end
 
 -- ============================================================================
 function CityBanner.Uninitialize(self)
-    print_debug("CityBannerManager_CQUI_Expansions: CityBanner.Uninitialize ENTRY");
+    -- print_debug("CityBannerManager_CQUI_Expansions: CityBanner.Uninitialize ENTRY");
     BASE_CQUI_CityBanner_Uninitialize(self);
 
     -- CQUI : Clear CQUI_DistrictBuiltIM
@@ -46,7 +46,7 @@ end
 
 -- ============================================================================
 function CityBanner.UpdateInfo(self, pCity : table )
-    print_debug("CityBannerManager_CQUI_Expansions: CityBanner.UpdateInfo ENTRY  pCity:"..tostring(pCity));
+    -- print_debug("CityBannerManager_CQUI_Expansions: CityBanner.UpdateInfo ENTRY  pCity:"..tostring(pCity));
     BASE_CQUI_CityBanner_UpdateInfo(self, pCity);
 
     if (pCity == nil) then
@@ -138,7 +138,7 @@ end
 
 -- ============================================================================
 function CityBanner.UpdatePopulation(self, isLocalPlayer:boolean, pCity:table, pCityGrowth:table)
-    print_debug("CityBannerManager_CQUI_Expansions: CityBanner:UpdatePopulation:  pCity: "..tostring(pCity).."  pCityGrowth:"..tostring(pCityGrowth));
+    -- print_debug("CityBannerManager_CQUI_Expansions: CityBanner:UpdatePopulation:  pCity: "..tostring(pCity).."  pCityGrowth:"..tostring(pCityGrowth));
     BASE_CQUI_CityBanner_UpdatePopulation(self, isLocalPlayer, pCity, pCityGrowth);
 
     if (isLocalPlayer == false) then
@@ -188,7 +188,7 @@ end
 
 -- ============================================================================
 function CityBanner.UpdateStats(self)
-    print_debug("CityBannerManager_CQUI_Expansions: CityBanner.UpdateStats ENTRY");
+    -- print_debug("CityBannerManager_CQUI_Expansions: CityBanner.UpdateStats ENTRY");
     BASE_CQUI_CityBanner_UpdateStats(self);
 
     local pDistrict:table = self:GetDistrict();
@@ -278,7 +278,7 @@ end
 -- CQUI Replacement Functions
 -- ============================================================================
 function OnCityStrikeButtonClick( playerID, cityID )
-    print_debug("CityBannerManager_CQUI_Expansions: OnCityStrikeButtonClick ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
+    -- print_debug("CityBannerManager_CQUI_Expansions: OnCityStrikeButtonClick ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
     CQUI_OnCityRangeStrikeButtonClick(playerID, cityID);
 end
 

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -69,8 +69,8 @@ end
 
 -- ===========================================================================
 function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, isSelected:boolean, isEditable:boolean )
-    local msg = "** Function Entry: OnUnitSelectionChanged (CQUI Hook).  playerId:"..tostring(playerID).." unitId:"..tostring(unitID).." hexI:"..tostring(hexI).." hexJ:"..tostring(hexJ).." hexK:"..tostring(hexK).." isSelected:"..tostring(isSelected).." isEditable:"..tostring(isEditable);
-    print_debug(msg);
+    -- local msg = "** Function Entry: OnUnitSelectionChanged (CQUI Hook).  playerId:"..tostring(playerID).." unitId:"..tostring(unitID).." hexI:"..tostring(hexI).." hexJ:"..tostring(hexJ).." hexK:"..tostring(hexK).." isSelected:"..tostring(isSelected).." isEditable:"..tostring(isEditable);
+    -- print_debug(msg);
     if playerID ~= Game.GetLocalPlayer() then
         return;
     end
@@ -86,18 +86,18 @@ end
 
 -- ===========================================================================
 function DefaultKeyDownHandler( uiKey:number )
-    print_debug("** Function Entry: DefaultKeyDownHandler (CQUI Hook).  uiKey: "..tostring(uiKey));
+    -- print_debug("** Function Entry: DefaultKeyDownHandler (CQUI Hook).  uiKey: "..tostring(uiKey));
     -- Note: This function always returns false, by design in Base game
     BASE_CQUI_DefaultKeyDownHandler( uiKey );
 
     --CQUI Keybinds
     if uiKey == Keys.VK_SHIFT then
-        print_debug("CQUI_isShiftDown = true");
+        -- print_debug("CQUI_isShiftDown = true");
         CQUI_isShiftDown = true;
     end
 
     if uiKey == Keys.VK_ALT then
-        print_debug("CQUI_isAltDown = true");
+        -- print_debug("CQUI_isAltDown = true");
         CQUI_isAltDown = true;
     end
 
@@ -107,7 +107,7 @@ end
 
 -- ===========================================================================
 function DefaultKeyUpHandler( uiKey:number )
-    print_debug("** Function Entry: DefaultKeyUpHandler (CQUI Hook) uiKey: "..tostring(uiKey));
+    -- print_debug("** Function Entry: DefaultKeyUpHandler (CQUI Hook) uiKey: "..tostring(uiKey));
 
     -- If set to Standard, just let the game do its thing
     if CQUI_hotkeyMode == CQUI_HOTKEYMODE_STANDARD then
@@ -257,7 +257,7 @@ function DefaultKeyUpHandler( uiKey:number )
     end
 
     if (cquiHandledKey == false) then
-        print_debug("** CQUI DefaultKeyUpHandler did not handle key: "..tostring(uiKey));
+        -- print_debug("** CQUI DefaultKeyUpHandler did not handle key: "..tostring(uiKey));
         cquiHandledKey = BASE_CQUI_DefaultKeyUpHandler(uiKey);
     end
 
@@ -266,7 +266,7 @@ end
 
 -- ===========================================================================
 function ClearAllCachedInputState()
-    print_debug("** Function Entry: ClearAllCachedInputState (CQUI Hook)");
+    -- print_debug("** Function Entry: ClearAllCachedInputState (CQUI Hook)");
     BASE_CQUI_ClearAllCachedInputState();
 
     CQUI_isShiftDown = false;
@@ -278,7 +278,7 @@ end
 -- These functions do not call the function of the same name found in base WorldInput.lua
 -- ===========================================================================
 function RealizeMovementPath(showQueuedPath:boolean, unitID:number)
-    print_debug("** Function Entry: RealizeMovementPath (CQUI Hook) -- showQueuedPath: "..tostring(showQueuedPath).." unitID"..tostring(unitID));
+    -- print_debug("** Function Entry: RealizeMovementPath (CQUI Hook) -- showQueuedPath: "..tostring(showQueuedPath).." unitID"..tostring(unitID));
     -- Largely the same as the base RealizeMovementPath, save for the additional unitID parameter
     -- The unitID allows CQUI to show the movement path when a unit is hovered over (base game returns because no unit is actually selected)
     -- Note: Adding the "show movement path on hover" mechanism means that this function cannot be extended and therefore must be replaced entirely
@@ -581,7 +581,7 @@ end
 
 -- ===========================================================================
 function ClearMovementPath()
-    print_debug("** Function Entry: ClearMovementPath (CQUI Hook)");
+    -- print_debug("** Function Entry: ClearMovementPath (CQUI Hook)");
     -- Replace base function because of the if statement around the UILens.ClearLayerHexes
     UILens.ClearLayerHexes( g_MovementPath );
     UILens.ClearLayerHexes( g_Numbers );
@@ -598,7 +598,7 @@ end
 
 -- ===========================================================================
 function OnInterfaceModeEnter_CityManagement( eNewMode:number )
-    print_debug("** Function Entry: OnInterfaceModeEnter_CityManagement (CQUI Hook)");
+    -- print_debug("** Function Entry: OnInterfaceModeEnter_CityManagement (CQUI Hook)");
     UIManager:SetUICursor(CursorTypes.RANGE_ATTACK);
     -- AZURENCY : fix the Appeal lens not being applied in city view
     -- UILens.SetActive("CityManagement");
@@ -606,7 +606,7 @@ end
 
 -- ===========================================================================
 function OnMouseBuildingPlacementCancel( pInputStruct:table )
-    print_debug("** Function Entry: OnMouseBuildingPlacementCancel (CQUI Hook)");
+    -- print_debug("** Function Entry: OnMouseBuildingPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
         LuaEvents.CQUI_CityviewEnable();
         -- CQUI: Do not call ExitPlacementMode here
@@ -616,7 +616,7 @@ end
 
 -- ===========================================================================
 function OnMouseDistrictPlacementCancel( pInputStruct:table )
-    print_debug("** Function Entry: OnMouseDistrictPlacementCancel (CQUI Hook)");
+    -- print_debug("** Function Entry: OnMouseDistrictPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
         LuaEvents.StoreHash(0);
         LuaEvents.CQUI_CityviewEnable();
@@ -627,7 +627,7 @@ end
 
 -- ===========================================================================
 function OnCycleUnitSelectionRequest()
-    print_debug("** Function Entry: OnCycleUnitSelectionRequest (CQUI Hook)");
+    -- print_debug("** Function Entry: OnCycleUnitSelectionRequest (CQUI Hook)");
     if (UI.GetInterfaceMode() ~= InterfaceModeTypes.CINEMATIC or m_isMouseButtonRDown) then
         -- AZURENCY : OnCycleUnitSelectionRequest is called by UI.SetCycleAdvanceTimer()
         -- in SelectedUnit.lua causing a conflict with the auto-cyling of unit
@@ -668,7 +668,7 @@ end
 
 -- ===========================================================================
 function CQUI_BuildImprovement (unit, improvementHash: number)
-    print_debug("** Function Entry: CQUI_BuildImprovement (CQUI Hook)");
+    -- print_debug("** Function Entry: CQUI_BuildImprovement (CQUI Hook)");
     if unit == nil then return end
 
     local tParameters = {};
@@ -685,7 +685,7 @@ end
 
 -- ===========================================================================
 function Initialize()
-    print_debug("** Function Entry: Initialize (CQUI Hook)");
+    print_debug("INITIALIZE: WorldInput_CQUI");
 
     -- Pre-process the SQL key binding data
     CQUI_keyMaps = {};

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -91,7 +91,7 @@ local WorkIconAlphaConverter = {
 -- ===========================================================================
 -- Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)
 function RegisterControl(control, setting_name, update_function, extra_data)
-    print_debug("ENTRY: CQUICommon - RegisterControl");
+    -- print_debug("ENTRY: CQUICommon - RegisterControl");
     LuaEvents.CQUI_SettingsUpdate.Add(function() update_function(control, setting_name, extra_data); end);
 end
 
@@ -99,7 +99,7 @@ end
 -- Companion functions to RegisterControl
 -- ===========================================================================
 function UpdateCheckbox(control, setting_name)
-    print_debug("ENTRY: CQUICommon - UpdateCheckbox");
+    -- print_debug("ENTRY: CQUICommon - UpdateCheckbox");
     local value = GameConfiguration.GetValue(setting_name);
     if (value == nil) then
         return;
@@ -110,7 +110,7 @@ end
 
 -- ===========================================================================
 function UpdateSlider( control, setting_name, data_converter)
-    print_debug("ENTRY: CQUICommon - UpdateSlider");
+    -- print_debug("ENTRY: CQUICommon - UpdateSlider");
     local value = GameConfiguration.GetValue(setting_name);
     if (value == nil) then
         return;
@@ -122,7 +122,7 @@ end
 -- ===========================================================================
 --Used to populate combobox options
 function PopulateComboBox(control, values, setting_name, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateComboBox");
+    -- print_debug("ENTRY: CQUICommon - PopulateComboBox");
     control:ClearEntries();
     local current_value = GameConfiguration.GetValue(setting_name);
 
@@ -180,7 +180,7 @@ end
 
 --Used to populate checkboxes
 function PopulateCheckBox(control, setting_name, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateCheckBox");
+    -- print_debug("ENTRY: CQUICommon - PopulateCheckBox");
     local current_value = GameConfiguration.GetValue(setting_name);
     if (current_value == nil) then
         --LY Checks if this setting has a default state defined in the database
@@ -222,7 +222,7 @@ end
 --Used to populate sliders. data_converter is a table containing two functions: ToStep and ToValue, which describe how to hanlde converting from the incremental slider steps to a setting value, think of it as a less elegant inner class
 --Optional third function: ToString. When included, this function will handle how the value is converted to a display value, otherwise this defaults to using the value from ToValue
 function PopulateSlider(control, label, setting_name, data_converter, tooltip)
-    print_debug("ENTRY: CQUICommon - PopulateSlider");
+    -- print_debug("ENTRY: CQUICommon - PopulateSlider");
     --This is necessary because RegisterSliderCallback fires twice when releasing the mouse cursor for some reason
     local hasScrolled = false;
     local current_value = GameConfiguration.GetValue(setting_name);
@@ -271,7 +271,7 @@ end
 
 --Used to switch active panels/tabs in the settings panel
 function ShowTab(button, panel)
-    print_debug("CQUI_SettingsElement: ShowTab Function Entry");
+    -- print_debug("CQUI_SettingsElement: ShowTab Function Entry");
     -- Unfocus all tabs and hide panels
     for i, v in ipairs(m_tabs) do
         v[2]:SetHide(true);

--- a/Integrations/BTS/UI/Choosers/traderoutechooser.lua
+++ b/Integrations/BTS/UI/Choosers/traderoutechooser.lua
@@ -1147,20 +1147,20 @@ function Open()
   -- Select last route if one exists
   local lastRoute:table = GetLastRouteForTrader(selectedUnitID);
   if lastRoute ~= nil then
-    print_debug("Last route for trader " .. selectedUnitID .. ": " .. GetTradeRouteString(lastRoute));
+    -- print_debug("Last route for trader " .. selectedUnitID .. ": " .. GetTradeRouteString(lastRoute));
     originCity = Cities.GetCityInPlot(selectedUnit:GetX(), selectedUnit:GetY());
 
     -- Don't select the route, if trader was transferred
     if lastRoute.OriginCityID ~= originCity:GetID() then
-      print_debug("Trader was transferred. Not selecting the last route")
+      -- print_debug("Trader was transferred. Not selecting the last route")
     elseif IsRoutePossible(originCity:GetOwner(), originCity:GetID(), lastRoute.DestinationCityPlayer, DestinationCityID) then
       local destinationPlayer:table = Players[lastRoute.DestinationCityPlayer];
       m_destinationCity = destinationPlayer:GetCities():FindID(lastRoute.DestinationCityID);
     else
-      print_debug("Route is no longer valid.");
+      -- print_debug("Route is no longer valid.");
     end
   else
-    print_debug("No last route was found for trader " .. selectedUnitID);
+    -- print_debug("No last route was found for trader " .. selectedUnitID);
   end
 
   Refresh();

--- a/Integrations/BTS/UI/tradeoverview.lua
+++ b/Integrations/BTS/UI/tradeoverview.lua
@@ -138,7 +138,7 @@ end
 
 -- Finds and adds all possible trade routes
 function RebuildAvailableTradeRoutesTable()
-  print_debug("Rebuilding Trade Routes table");
+  -- print_debug("Rebuilding Trade Routes table");
   m_AvailableTradeRoutes = {};
 
   local sourcePlayerID = Game.GetLocalPlayer();
@@ -171,14 +171,14 @@ function RebuildAvailableTradeRoutesTable()
     end
   end
 
-  print_debug("Total routes = " .. table.count(m_AvailableTradeRoutes))
+  -- print_debug("Total routes = " .. table.count(m_AvailableTradeRoutes))
 
   m_HasBuiltTradeRouteTable = true;
   m_LastTurnBuiltTradeRouteTable = Game.GetCurrentGameTurn();
 end
 
 function RebuildAvailableTraders()
-  print_debug("Building available traders")
+  -- print_debug("Building available traders")
   local playerID = Game.GetLocalPlayer()
   local pPlayer = Players[playerID]
   local pPlayerUnits = pPlayer:GetUnits()
@@ -208,7 +208,7 @@ end
 
 function Refresh()
   local time1 = Automation.GetTime();
-  print_debug("Refresh start")
+  -- print_debug("Refresh start")
   PreRefresh();
 
   RefreshGroupByPulldown();
@@ -231,7 +231,7 @@ function Refresh()
 
   PostRefresh();
   local time2 = Automation.GetTime()
-  print_debug(string.format("Time taken to refresh: %.4f sec(s)", time2-time1))
+  -- print_debug(string.format("Time taken to refresh: %.4f sec(s)", time2-time1))
 end
 
 function PreRefresh()
@@ -252,7 +252,7 @@ function PostRefresh()
   Controls.BodyScrollPanel:ReprocessAnchoring();
   Controls.BodyScrollPanel:CalculateInternalSize();
   local time2 = Automation.GetTime()
-  print_debug(string.format("Time to calculate stack sizes: %.4f sec(s)", time2-time1))
+  -- print_debug(string.format("Time to calculate stack sizes: %.4f sec(s)", time2-time1))
 end
 
 -- ===========================================================================
@@ -438,14 +438,14 @@ function ViewAvailableRoutes()
     time1 = Automation.GetTime()
     RebuildAvailableTradeRoutesTable();
     time2 = Automation.GetTime()
-    print_debug(string.format("Time taken to build routes: %.4f sec(s)", time2-time1))
+    -- print_debug(string.format("Time taken to build routes: %.4f sec(s)", time2-time1))
 
     -- Cache routes info.
     time1 = Automation.GetTime()
     CacheEmpty();
     if CacheRoutesInfo(m_AvailableTradeRoutes) then
       time2 = Automation.GetTime()
-      print_debug(string.format("Time taken to cache: %.4f sec(s)", time2-time1))
+      -- print_debug(string.format("Time taken to cache: %.4f sec(s)", time2-time1))
     end
 
     -- Just rebuilt base routes table. need to do everything again
@@ -453,7 +453,7 @@ function ViewAvailableRoutes()
     m_FilterSettingsChanged = true;
     m_GroupSettingsChanged = true;
   else
-    print_debug("Trade Route table last built on: " .. m_LastTurnBuiltTradeRouteTable .. ". Current game turn: " .. Game.GetCurrentGameTurn());
+    -- print_debug("Trade Route table last built on: " .. m_LastTurnBuiltTradeRouteTable .. ". Current game turn: " .. Game.GetCurrentGameTurn());
     if opt_print then
       print("OPT: Not Rebuilding or recaching routes table")
     end
@@ -464,12 +464,12 @@ function ViewAvailableRoutes()
     time1 = Automation.GetTime()
     m_FinalTradeRoutes = FilterTradeRoutes(m_AvailableTradeRoutes);
     time2 = Automation.GetTime()
-    print_debug(string.format("Time taken to filter: %.4f sec(s)", time2-time1))
+    -- print_debug(string.format("Time taken to filter: %.4f sec(s)", time2-time1))
 
     -- Need to regroup routes (some groups could dissapear because of filter)
     m_GroupSettingsChanged = true
   else
-    print_debug("OPT: Not refiltering routes")
+    -- print_debug("OPT: Not refiltering routes")
   end
 
   -- Sort and display the routes
@@ -479,7 +479,7 @@ function ViewAvailableRoutes()
       time1 = Automation.GetTime()
       m_AvailableGroupedRoutes = GroupRoutes(m_FinalTradeRoutes, m_groupByList[m_groupBySelected].groupByID)
       time2 = Automation.GetTime()
-      print_debug(string.format("Time taken to group: %.4f sec(s)", time2-time1))
+      -- print_debug(string.format("Time taken to group: %.4f sec(s)", time2-time1))
 
       -- Need to resort to show correct order
       m_SortSettingsChanged = true
@@ -497,13 +497,13 @@ function ViewAvailableRoutes()
         m_AvailableGroupedRoutes[i] = SortTradeRoutes(m_AvailableGroupedRoutes[i], m_InGroupSortBySettings)
       end
       time2 = Automation.GetTime()
-      print_debug(string.format("Time taken to within group sort: %.4f sec(s)", time2-time1))
+      -- print_debug(string.format("Time taken to within group sort: %.4f sec(s)", time2-time1))
 
       -- Sort the order of groups. You need to do this AFTER each group has been sorted
       time1 = Automation.GetTime()
       m_AvailableGroupedRoutes = SortGroupedRoutes(m_AvailableGroupedRoutes, m_GroupSortBySettings);
       time2 = Automation.GetTime()
-      print_debug(string.format("Time taken to group sort: %.4f sec(s)", time2-time1))
+      -- print_debug(string.format("Time taken to group sort: %.4f sec(s)", time2-time1))
     else
       if opt_print then
         print("OPT: Not resorting within and of groups")
@@ -530,7 +530,7 @@ function ViewAvailableRoutes()
         time1 = Automation.GetTime()
         m_FinalTradeRoutes = SortTradeRoutes(m_FinalTradeRoutes, m_GroupSortBySettings);
         time2 = Automation.GetTime()
-        print_debug(string.format("Time taken to sort: %.4f sec(s)", time2-time1))
+        -- print_debug(string.format("Time taken to sort: %.4f sec(s)", time2-time1))
       else
         if opt_print then
           print("OPT: Not resorting routes")
@@ -649,7 +649,7 @@ function AddRouteInstancesFromTable( tradeRoutes:table, showCount:number )
     local tTime = Automation.GetTime();
     for i=1, #tradeRoutes do
       if (tTime + 1 < Automation.GetTime()) then
-        print_debug("+1 sec ... " .. i)
+        -- print_debug("+1 sec ... " .. i)
         tTime = Automation.GetTime()
       end
       AddRouteInstanceFromRouteInfo(tradeRoutes[i]);
@@ -691,7 +691,7 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
 
   SetOriginRouteInstanceYields(routeInstance, routeInfo)
   if GetNetYieldForDestinationCity(routeInfo, true) > 0 then
-    print_debug(GetTradeRouteString(routeInfo), "has destination has yield")
+    -- print_debug(GetTradeRouteString(routeInfo), "has destination has yield")
     routeInstance.DestinationYields:SetHide(false);
     SetDestinationRouteInstanceYields(routeInstance, routeInfo)
   else
@@ -864,13 +864,13 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
               for i in pairs(m_AvailableTraders[cityID]) do
                 local traderID = m_AvailableTraders[cityID][i]
                 local tradeUnit:table = originPlayer:GetUnits():FindID(traderID);
-                print_debug("Calling transfer from " .. cityID)
+                -- print_debug("Calling transfer from " .. cityID)
                 TransferTraderTo(tradeUnit, originCity)
                 coroutine.yield()
               end
             end
           else
-            print_debug("Backup 2 yield")
+            -- print_debug("Backup 2 yield")
             coroutine.yield() -- gauranteed yield to prevent infinite cycle bug
           end
         end
@@ -1188,7 +1188,7 @@ function OnExpandRoutes( checkbox, cityOwnerID:number, cityID:number )
 
     -- Only add entry if it isn't already in the list
     if findIndex(m_GroupsFullyExpanded, cityEntry, CompareCityEntries) == -1 then
-      print_debug("Adding " .. GetCityEntryString(cityEntry) .. " to the exclusion list");
+      -- print_debug("Adding " .. GetCityEntryString(cityEntry) .. " to the exclusion list");
       table.insert(m_GroupsFullyExpanded, cityEntry);
     else
       print_debug("City already exists in exclusion list");
@@ -1209,7 +1209,7 @@ function OnExpandRoutes( checkbox, cityOwnerID:number, cityID:number )
     local cityIndex = findIndex(m_GroupsFullyExpanded, cityEntry, CompareCityEntries)
 
     if findIndex(m_GroupsFullyExpanded, cityEntry, CompareCityEntries) > 0 then
-      print_debug("Removing " .. GetCityEntryString(cityEntry) .. " to the exclusion list");
+      -- print_debug("Removing " .. GetCityEntryString(cityEntry) .. " to the exclusion list");
       table.remove(m_GroupsFullyExpanded, cityIndex);
     else
       print_debug("City does not exist in exclusion list");
@@ -1275,7 +1275,7 @@ end
 -- ---------------------------------------------------------------------------
 function UpdateRouteHistoryForTrader(routeInfo:table, routesTable:table)
   if routeInfo.TraderUnitID ~= nil then
-    print_debug("Updating trader " .. routeInfo.TraderUnitID .. " with route history: " .. GetTradeRouteString(routeInfo));
+    -- print_debug("Updating trader " .. routeInfo.TraderUnitID .. " with route history: " .. GetTradeRouteString(routeInfo));
     routesTable[routeInfo.TraderUnitID] = routeInfo;
   else
     print_debug("Could not find the trader unit")
@@ -1467,7 +1467,7 @@ end
 -- ===========================================================================
 -- Returns the grouped routes version based on the passed group setting
 function GroupRoutes( routesTable, groupSetting )
-  print_debug("Group setting: " .. m_groupByList[m_groupBySelected].groupByString);
+  -- print_debug("Group setting: " .. m_groupByList[m_groupBySelected].groupByString);
 
   if GroupSettingIsNone(groupSetting) then
     return routesTable
@@ -1510,7 +1510,7 @@ end
 -- Gets top route from each group and sorts them based on that
 function SortGroupedRoutes( groupedRoutes:table, sortSettings:table, sortSettingsChanged:boolean )
   if (sortSettingsChanged ~= nil and (not sortSettingsChanged)) then
-    print_debug("OPT: Not sorting groups")
+    -- print_debug("OPT: Not sorting groups")
     return groupedRoutes
   end
 
@@ -1782,12 +1782,12 @@ function RemoveTrader( traderID )
     for i in pairs(m_AvailableTraders[cityID]) do
       -- Remove trader
       if m_AvailableTraders[cityID][i] == traderID then
-        print_debug("Removing trader " .. traderID .. " from available traders.")
+        -- print_debug("Removing trader " .. traderID .. " from available traders.")
         table.remove(m_AvailableTraders[cityID], i)
 
         -- Check if for that city has no traders. Remove the city entry if it does
         if table_nnill_count(m_AvailableTraders[cityID]) <= 0 then
-          print_debug("Removing city " .. cityID)
+          -- print_debug("Removing city " .. cityID)
           table.remove(m_AvailableTraders, cityID)
         end
 
@@ -2086,7 +2086,7 @@ function OnUnitOperationStarted( ownerID:number, unitID:number, operationID:numb
         local outgoingRoutes = city:GetTrade():GetOutgoingRoutes();
         for _, route in ipairs(outgoingRoutes) do
           if route.TraderUnitID == unitID then
-            print_debug("Found route...")
+            -- print_debug("Found route...")
             -- Remove it from the available routes
             RemoveRouteFromTable(route, m_AvailableGroupedRoutes, not GroupSettingIsNone(m_groupBySelected));
             foundRoute = true
@@ -2096,7 +2096,7 @@ function OnUnitOperationStarted( ownerID:number, unitID:number, operationID:numb
       end
 
       if not foundRoute then
-        print_debug("Route not found!!")
+        -- print_debug("Route not found!!")
         return
       end
 

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -204,7 +204,7 @@ function ShowModLensKey(lensName:string)
     Controls.KeyPanel:SetHide(false);
     Controls.KeyScrollPanel:CalculateSize();
   else
-    print_debug("ERROR [ModalLensPanel]: " .. lensName .. " has no g_ModLensModalPanel entry")
+    -- print_debug("ERROR [ModalLensPanel]: " .. lensName .. " has no g_ModLensModalPanel entry")
   end
 end
 


### PR DESCRIPTION
This takes most of the print_debug statements and comments them out (based on conversation with the debug mask PR from yesterday).  The few that remain are mostly tied to error cases or initialization calls.  "[CQUI] " will be automatically prepended to the debug print string to make them stand out in the FireTuner.
