### PR TITLE
Show War Icon in City State Banner

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -46,22 +46,24 @@
                     </AlphaAnim>
 
                     <!-- CONTENTS -->
-                    <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" Padding="10">
-                        <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" Padding="2"/>
-                        <Container ID="CQUI_DistrictsContainer" Anchor="C,C" Size="auto,parent" Offset="-6,0">
-                            <Stack ID="CQUI_Districts" Anchor="L,C" StackGrowth="Right" Padding="-12"/>
-                        </Container>
+                    <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" StackPadding="2">
+                        <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="L,C" Icon="ICON_RELATIONSHIP_WAR" ToolTip="LOC_DIPLO_STATE_WAR_NAME" Hidden="1"/>
+                        <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" StackPadding="2"/>
                         <!-- CQUI: Show Suzerain in CS banner -->
-                        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Offset="-10,0" Size="28,34" Hidden="1">
-                            <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22" >
+                        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="auto,auto" AutoSizePadding="2,0" Hidden="1">
+                            <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22">
                                 <Image ID="CQUI_CivSuzerainIcon" Size="22,22" Anchor="C,C" IconSize="22"/>
                             </Image>
                         </Container>
-                        <Image ID="CQUI_DistrictAvailable" Anchor="L,C" Offset="-8,0" Icon="ICON_STAT_DISTRICTS" Size="24,24" ToolTip="LOC_HUD_DISTRICTS" Hidden="true" /> <!--Texture="Stats22"-->
-                        <Button ID="CityNameButton" Anchor="L,C" Hidden="0" Size="auto,parent">
-                            <Label ID="CityName" Anchor="L,C" Style="HeaderSmallCaps" />
+
+                        <Container ID="CQUI_DistrictsContainer" Anchor="C,C" Size="auto,parent" Padding="2" Offset="2,0">
+                            <Stack ID="CQUI_Districts" Anchor="C,C" StackGrowth="Right" Padding="-12"/>
+                        </Container>
+                        <Image ID="CQUI_DistrictAvailable" Anchor="C,C" Icon="ICON_STAT_DISTRICTS" Size="24,24" ToolTip="LOC_HUD_DISTRICTS" Hidden="true" /> <!--Texture="Stats22"-->
+                        <Button ID="CityNameButton" Anchor="L,C" Hidden="0" Size="auto,parent" AutoSizePadding="4,0" >
+                            <Label ID="CityName" Anchor="L,C" Offset="4,0" Style="FontFlair16" FontStyle="Shadow" Color0="255,255,255,255" Color1="0,0,0,20" SmallCaps="18" SmallCapsType="EveryWord" />
                         </Button>
-                        <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" Padding="2"/>
+                        <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" StackPadding="4"/>
                     </Stack>
                 </Button>
 

--- a/Assets/Expansion2/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion2/CityBanners/citybannerinstances.xml
@@ -46,6 +46,11 @@
 
                     <!-- CONTENTS -->
                     <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" Padding="10">
+                        <!-- <Container ID="CQUI_AtWarWithCS" Anchor="C,C" Offset="-10,0" Size="28,34" Hidden="1">
+                            <Image ID="CQUI_AtWarWithCSBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22" > -->
+                                <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="C,C" IconSize="22" Hidden="1"/>
+                            <!-- </Image>
+                        </Container> -->
                         <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" Padding="2" />
                         <Container ID="CQUI_DistrictsContainer" Anchor="C,C" Size="auto,parent" Offset="-6,0">
                             <Stack ID="CQUI_Districts" Anchor="L,C" StackGrowth="Right" Padding="-12"/>

--- a/Assets/Expansion2/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion2/CityBanners/citybannerinstances.xml
@@ -45,27 +45,24 @@
                     </AlphaAnim>
 
                     <!-- CONTENTS -->
-                    <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" Padding="10">
-                        <!-- <Container ID="CQUI_AtWarWithCS" Anchor="C,C" Offset="-10,0" Size="28,34" Hidden="1">
-                            <Image ID="CQUI_AtWarWithCSBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22" > -->
-                                <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="C,C" IconSize="22" Hidden="1"/>
-                            <!-- </Image>
-                        </Container> -->
-                        <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" Padding="2" />
-                        <Container ID="CQUI_DistrictsContainer" Anchor="C,C" Size="auto,parent" Offset="-6,0">
-                            <Stack ID="CQUI_Districts" Anchor="L,C" StackGrowth="Right" Padding="-12"/>
-                        </Container>
+                    <Stack ID="ContentStack" Anchor="C,C" StackGrowth="Right" StackPadding="2">
+                        <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="L,C" Icon="ICON_RELATIONSHIP_WAR" ToolTip="LOC_DIPLO_STATE_WAR_NAME" Hidden="1"/>
+                        <Stack ID="CityInfoStack" Anchor="L,C" StackGrowth="Right" StackPadding="2"/>
                         <!-- CQUI: Show Suzerain in CS banner -->
-                        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Offset="-10,0" Size="28,34" Hidden="1">
-                            <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22" >
+                        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="auto,auto" AutoSizePadding="2,0" Hidden="1">
+                            <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22">
                                 <Image ID="CQUI_CivSuzerainIcon" Size="22,22" Anchor="C,C" IconSize="22"/>
                             </Image>
                         </Container>
-                        <Image ID="CQUI_DistrictAvailable" Anchor="L,C" Offset="-8,0" Icon="ICON_STAT_DISTRICTS" Size="24,24" ToolTip="LOC_HUD_DISTRICTS" Hidden="true" /> <!--Texture="Stats22"-->
-                        <Button ID="CityNameButton" Anchor="L,C" Hidden="0" Size="auto,parent">
-                            <Label ID="CityName" Anchor="L,C" Style="FontFlair16" FontStyle="Shadow" Color0="255,255,255,255" Color1="0,0,0,20" SmallCaps="18" SmallCapsType="EveryWord" />
+
+                        <Container ID="CQUI_DistrictsContainer" Anchor="C,C" Size="auto,parent" Padding="2" Offset="2,0">
+                            <Stack ID="CQUI_Districts" Anchor="C,C" StackGrowth="Right" Padding="-12"/>
+                        </Container>
+                        <Image ID="CQUI_DistrictAvailable" Anchor="C,C" Icon="ICON_STAT_DISTRICTS" Size="24,24" ToolTip="LOC_HUD_DISTRICTS" Hidden="true" /> <!--Texture="Stats22"-->
+                        <Button ID="CityNameButton" Anchor="L,C" Hidden="0" Size="auto,parent" AutoSizePadding="4,0" >
+                            <Label ID="CityName" Anchor="L,C" Offset="4,0" Style="FontFlair16" FontStyle="Shadow" Color0="255,255,255,255" Color1="0,0,0,20" SmallCaps="18" SmallCapsType="EveryWord" />
                         </Button>
-                        <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" Padding="2"/>
+                        <Stack ID="CityStatusStack" Anchor="R,C" StackGrowth="Right" StackPadding="4"/>
                     </Stack>
                 </Button>
 

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -96,6 +96,12 @@
     <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="en_US">
       <Text>Show the Civilization Icon of the Suzerain of a City State in the City State Banner</Text>
     </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="en_US">
+      <Text>War Icon in CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="en_US">
+      <Text>When at war with a City State, show the War Icon in the city banner of that city state</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTWORKICON" Language="en_US">
       <Text>Smart Work Icons</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -226,5 +226,17 @@
     <Row Tag="LOC_CQUI_RECOMMENDATIONS_SHOWCITYDETAILADVISOR" Language="de_DE">
       <Text>Zeige Stadt-Ratgeber</Text>
     </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="de_DE">
+    <Text>Suzerain in CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="de_DE">
+        <Text>Zeige die Zivilisationsikone des Suzerains eines Stadtstaates im Stadtstaat Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="de_DE">
+        <Text>Kriegssymbol in CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="de_DE">
+        <Text>Wenn Sie sich im Krieg mit einem Stadtstaat befinden, zeigen Sie die Kriegsikone im Stadtbanner dieses Stadtstaates</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_es.xml
+++ b/Assets/Text/cqui_text_settings_es.xml
@@ -172,6 +172,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="es_ES">
       <Text>Expande acciones del panel de unidad</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="es_ES">
+      <Text>Suzerain en CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="es_ES">
+      <Text>Mostrar el icono de la civilización del Suzerain de un estado de la ciudad en el estandarte del estado de la ciudad</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="es_ES">
+      <Text>Icono de guerra en CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="es_ES">
+      <Text>Cuando esté en guerra con un estado de la ciudad, muestre el icono de guerra en la bandera de la ciudad de ese estado de la ciudad</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_fr.xml
+++ b/Assets/Text/cqui_text_settings_fr.xml
@@ -169,6 +169,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="fr_FR">
       <Text>Montrer toutes les actions dans le panel de l'unité</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="fr_FR">
+      <Text>Suzerain dans CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="fr_FR">
+      <Text>Afficher l’icône de civilisation du Suzerain d’un état de ville dans la bannière d’état de ville</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="fr_FR">
+      <Text>Icône de guerre dans citystate banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="fr_FR">
+      <Text>En guerre contre un État de la ville, montrez l’icône de guerre dans la bannière de la ville de cet État de la ville</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_it.xml
+++ b/Assets/Text/cqui_text_settings_it.xml
@@ -238,5 +238,17 @@
     <Row Tag="LOC_CQUI_RECOMMENDATIONS_SHOWCITYDETAILADVISOR" Language="it_IT">
       <Text>Mostra il consigliere cittadino</Text>
     </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="it_IT">
+      <Text>Suzerain in CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="it_IT">
+      <Text>Mostra l'icona della civiltà del Suzerain di uno Stato della Città nello Stendardo dello Stato della Città</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="it_IT">
+      <Text>Icona guerra in CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="it_IT">
+      <Text>Quando sei in guerra con una città, mostra l'icona di guerra nella bandiera della città di quella città</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_ja.xml
+++ b/Assets/Text/cqui_text_settings_ja.xml
@@ -238,6 +238,17 @@
     <Row Tag="LOC_CQUI_RECOMMENDATIONS_SHOWCITYDETAILADVISOR" Language="ja_JP">
       <Text>都市詳細画面にアドバイザーを表示</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="ja_JP">
+      <Text>スゼレイン・イン・シティ州旗</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="ja_JP">
+      <Text>都市国家旗の中に都市国家のスゼレインの文明アイコンを表示する</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="ja_JP">
+      <Text>シティステートバナーの戦争アイコン</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="ja_JP">
+      <Text>都市国家との戦争時には、その都市国家の都市旗に戦争アイコンを表示します</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_ko.xml
+++ b/Assets/Text/cqui_text_settings_ko.xml
@@ -172,6 +172,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="ko_KR">
       <Text>유닛 패널의 숨겨진 행동 아이콘 자동 표시</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="ko_KR">
+      <Text>수제레인 인 시티스테이트 배너</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="ko_KR">
+      <Text>도시 국가 배너에서 도시 국가의 수제레인의 문명 아이콘을 보여</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="ko_KR">
+      <Text>시티스테이트 배너의 전쟁 아이콘</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="ko_KR">
+      <Text>도시 국가와의 전쟁 때, 그 도시 국가의 도시 배너에 전쟁 아이콘을 표시</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -172,6 +172,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="pl_PL">
       <Text>Rozwijaj listę akcji w panelu jednostki</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="pl_PL">
+      <Text>Suzerain w Banner CityState</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="pl_PL">
+      <Text>Pokaż ikonę cywilizacji Suzerain państwa miejskiego na sztandarze państwa miejskiego</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="pl_PL">
+      <Text>Ikona wojny w bannerie CityState</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="pl_PL">
+      <Text>Będąc w stanie wojny z państwem miejskim, pokaż ikonę wojny w sztandarze miasta tego państwa miasta</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -143,7 +143,7 @@
       <Text>Automatycznie włącz filtr zwiadowcy</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="pl_PL">
-      <Text>Popup'y</Text>
+      <Text>Wyskakujące okna</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS_ALWAYSOPENTECHTREES" Language="pl_PL">
       <Text>Zawsze otwieraj drzewo technologii</Text>
@@ -161,7 +161,7 @@
       <Text>Przełącza odtwarzanie dzwięku po zakończeniu badania bądź kodeksu prawnego. Jest całkowicie niezależny od popup'u i może być odtwarzany nawet gdy wizualny popup jest wyłączony</Text>
     </Row>
     <Row Tag="LOC_CQUI_SETTINGS_REMINDER" Language="pl_PL">
-      <Text>Pamiętaj: Ustawienia CQUI są przypisane do poszczególnych zapisów gry![NEWLINE]Jeśli chcesz zmienić ustawienia na stałe, zmień je w pliku[NEWLINE] CQUI_Settings.sql znajdującym się w katalogu [KATALOG INSTALACJI MODU]/CQUI/Assets</Text>
+      <Text>Pamiętaj: Ustawienia CQUI są przypisane do poszczególnych zapisów gry![NEWLINE]Jeśli chcesz zmienić ustawienia na stałe, zmień je w pliku[NEWLINE] cqui_settings_local.sql znajdującym się w katalogu instalacyjnym modów (NIE w katalogu modu).</Text>
     </Row>
     <Row Tag="LOC_CQUI_UNITS" Language="pl_PL">
       <Text>Jednostki</Text>
@@ -173,16 +173,16 @@
       <Text>Rozwijaj listę akcji w panelu jednostki</Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="pl_PL">
-      <Text>Suzerain w Banner CityState</Text>
+      <Text>Ikona cywilizacji suzerena w sztandarze państwa-miasta</Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="pl_PL">
-      <Text>Pokaż ikonę cywilizacji Suzerain państwa miejskiego na sztandarze państwa miejskiego</Text>
+      <Text>Pokaż ikonę cywilizacji suzerena państwa-miasta na sztandarze tego państwa-miasta</Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="pl_PL">
-      <Text>Ikona wojny w bannerie CityState</Text>
+      <Text>Ikona wojny w sztandarze państwa-miasta </Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="pl_PL">
-      <Text>Będąc w stanie wojny z państwem miejskim, pokaż ikonę wojny w sztandarze miasta tego państwa miasta</Text>
+      <Text>Będąc w stanie wojny z państwem-miastem, pokaż ikonę wojny w sztandarze tego państwa-miasta</Text>
     </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_pt.xml
+++ b/Assets/Text/cqui_text_settings_pt.xml
@@ -226,5 +226,17 @@
     <Row Tag="LOC_CQUI_RECOMMENDATIONS_SHOWCITYDETAILADVISOR" Language="pt_BR">
       <Text>Mostrar o assessor de detalhes da cidade</Text>
     </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="pt_BR">
+      <Text>Suzerain em CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="pt_BR">
+      <Text>Mostre o Ícone da Civilização do Suzerain de um Estado da Cidade banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="pt_BR">
+      <Text>Ícone de guerra em CityState Banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="pt_BR">
+      <Text>Quando estiver em guerra com um Estado da cidade, mostre o Ícone da Guerra na bandeira da cidade daquele estado da cidade</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_ru.xml
+++ b/Assets/Text/cqui_text_settings_ru.xml
@@ -172,6 +172,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="ru_RU">
       <Text>Автопоказ действий на панели юнита</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="ru_RU">
+      <Text>Сюзерен в ГородскомГосударственном Знамени</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="ru_RU">
+      <Text>Показать цивилизационную икону Сюзерена городского государства в городском государственном знамени</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="ru_RU">
+      <Text>Икона войны в Городском Знамени Государства</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="ru_RU">
+      <Text>Во время войны с городским государством, показать икону войны в городе знамя этого города государства</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings_zh.xml
+++ b/Assets/Text/cqui_text_settings_zh.xml
@@ -172,6 +172,17 @@
     <Row Tag="LOC_CQUI_UNITS_AUTOEXPANDUNITACTIONS" Language="zh_Hans_CN">
       <Text>自动展开单位的指令面板</Text>
     </Row>
-
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" Language="zh_Hans">
+      <Text>城市州横幅中的苏泽兰</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="zh_Hans">
+      <Text>在城市国家旗帜中展示一个城市国家苏塞兰的文明图标</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="zh_Hans">
+      <Text>城市国家旗帜中的战争图标</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP" Language="zh_Hans">
+      <Text>当与城市州开战时， 在该城邦的城市旗帜中展示战争图标</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -194,7 +194,7 @@
                             </Label>
                             <Label ID="CityUnderSiegeIcon" Anchor="L,C" Style="FontNormal20" String="[ICON_UnderSiege]" ConsumeMouse="1" ToolTip="LOC_HUD_REPORTS_STATUS_UNDER_SEIGE"/>
                             <Label ID="CityOccupiedIcon" Anchor="L,C" Style="FontNormal20" String="[ICON_Occupied]" ConsumeMouse="1" ToolTip="LOC_HUD_CITY_GROWTH_OCCUPIED"/>
-                            <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="L,C" Icon="ICON_RELATIONSHIP_WAR" ToolTip="LOC_DIPLO_STATE_WAR_NAME" Hidden="1"/>
+                            <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="C,C" Icon="ICON_RELATIONSHIP_WAR" ToolTip="LOC_DIPLO_STATE_WAR_NAME" Hidden="1"/>
                             <Label ID="CityQuestIcon" Anchor="L,C" Style="FontNormal20"/>
                             <!-- CQUI: Show Suzerain in CS banner -->
                             <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="34,34" Hidden="1">

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -194,6 +194,7 @@
                             </Label>
                             <Label ID="CityUnderSiegeIcon" Anchor="L,C" Style="FontNormal20" String="[ICON_UnderSiege]" ConsumeMouse="1" ToolTip="LOC_HUD_REPORTS_STATUS_UNDER_SEIGE"/>
                             <Label ID="CityOccupiedIcon" Anchor="L,C" Style="FontNormal20" String="[ICON_Occupied]" ConsumeMouse="1" ToolTip="LOC_HUD_CITY_GROWTH_OCCUPIED"/>
+                            <Image ID="CQUI_AtWarWithCSIcon" Size="22,22" Anchor="L,C" Icon="ICON_RELATIONSHIP_WAR" ToolTip="LOC_DIPLO_STATE_WAR_NAME" Hidden="1"/>
                             <Label ID="CityQuestIcon" Anchor="L,C" Style="FontNormal20"/>
                             <!-- CQUI: Show Suzerain in CS banner -->
                             <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="34,34" Hidden="1">

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -56,6 +56,7 @@ local CQUI_ShowCityManageAreaOnCityHover = true;
 local CQUI_CityManageAreaShown           = false;
 local CQUI_CityManageAreaShouldShow      = false;
 local CQUI_ShowSuzerainInCityStateBanner = true;
+local CQUI_ShowWarIconInCityStateBanner = true;
 
 local CQUI_SmartBanner                    = true;
 local CQUI_SmartBanner_Unmanaged_Citizen  = false;
@@ -73,6 +74,7 @@ function CQUI_OnSettingsInitialized()
     -- print_debug("CityBannerManager_CQUI: CQUI_OnSettingsInitialized ENTRY")
     CQUI_ShowYieldsOnCityHover         = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
     CQUI_ShowSuzerainInCityStateBanner = GameConfiguration.GetValue("CQUI_ShowSuzerainInCityStateBanner");
+    CQUI_ShowWarIconInCityStateBanner  = GameConfiguration.GetValue("CQUI_ShowWarIconInCityStateBanner");
 
     CQUI_SmartBanner            = GameConfiguration.GetValue("CQUI_Smartbanner");
     CQUI_SmartBanner_Districts  = CQUI_SmartBanner and GameConfiguration.GetValue("CQUI_Smartbanner_Districts");
@@ -922,6 +924,10 @@ function IsCQUI_ShowSuzerainInCityStateBannerEnabled()
     return (CQUI_SmartBanner and CQUI_ShowSuzerainInCityStateBanner);
 end
 
+function IsCQUI_ShowWarIconInCityStateBannerEnabled()
+    return (CQUI_SmartBanner and CQUI_ShowWarIconInCityStateBanner);
+end
+
 -- ===========================================================================
 function CQUI_SetCityStrikeButtonLocation(cityBannerInstance, rotate, offsetY, anchor)
     cityStrikeImage = nil;
@@ -939,12 +945,15 @@ end
 
 -- ===========================================================================
 function CQUI_UpdateCityStateBannerAtWarIcon( pCityState, bannerInstance )
-    -- TODO: Make this a configurable setting in the CQUI Settings
-    local localPlayerID = Game.GetLocalPlayer();
-    if (localPlayerID ~= nil 
-       and pCityState:GetDiplomacy() ~= nil
-       and pCityState:GetDiplomacy():IsAtWarWith(localPlayerID)) then
-        bannerInstance.m_Instance.CQUI_AtWarWithCSIcon:SetHide(false);
+    if (IsCQUI_ShowWarIconInCityStateBannerEnabled()) then
+        local localPlayerID = Game.GetLocalPlayer();
+        if (localPlayerID ~= nil 
+        and pCityState:GetDiplomacy() ~= nil
+        and pCityState:GetDiplomacy():IsAtWarWith(localPlayerID)) then
+            bannerInstance.m_Instance.CQUI_AtWarWithCSIcon:SetHide(false);
+        else
+            bannerInstance.m_Instance.CQUI_AtWarWithCSIcon:SetHide(true);
+        end
     else
         bannerInstance.m_Instance.CQUI_AtWarWithCSIcon:SetHide(true);
     end
@@ -1010,6 +1019,6 @@ function Initialize_CQUI()
     Events.InfluenceGiven.Add(CQUI_OnInfluenceGiven);
 
     Events.DiplomacyDeclareWar.Add( CQUI_OnDiplomacyDeclareWarMakePeace );
-	Events.DiplomacyMakePeace.Add( CQUI_OnDiplomacyDeclareWarMakePeace );
+    Events.DiplomacyMakePeace.Add( CQUI_OnDiplomacyDeclareWarMakePeace );
 end
 Initialize_CQUI();

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -946,6 +946,47 @@ function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
     end
 end
 
+function CQUI_OnDiplomacyDeclareWar(firstPlayerID, secondPlayerID)
+    --TEMP PRint
+    print("")
+    local localPlayerID = Game.GetLocalPlayer();
+    if (localPlayerID ~= nil) then
+        if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+            --blah
+        end
+    end
+end
+
+    function OnDiplomacyDeclareWar(firstPlayerID, secondPlayerID)
+        local localPlayerID = Game.GetLocalPlayer();
+        if (localPlayerID == nil) then
+            print_debug("OnDiplomacyDecalreWar: Game.GetLocalPlayer returned nil!")
+            return;
+        end
+
+        local pOtherPlayer = nil;
+        if (localPlayerID == firstPlayerID) then
+            pOtherPlayer = Players[secondPlayerID]; 
+        else
+            pOtherPlayer = Players[firstPlayerID];
+        end
+
+        if (pOtherPlayer:IsMinor()) then
+
+
+        end
+        
+        if (localPlayerID ~= nil) then
+            if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+                m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
+            end
+        end
+        if not ContextPtr:IsHidden() then
+            Refresh();
+        end
+    end
+    
+
 -- ===========================================================================
 --  CQUI Initialize Function
 -- ===========================================================================
@@ -963,5 +1004,8 @@ function Initialize_CQUI()
     Events.CitySelectionChanged.Add(CQUI_OnBannerMouseExit);
     Events.CityWorkerChanged.Add(OnCityWorkerChanged);
     Events.InfluenceGiven.Add(CQUI_OnInfluenceGiven);
+
+    Events.DiplomacyDeclareWar.Add( CQUI_OnDiplomacyDeclareWar );
+	Events.DiplomacyMakePeace.Add( CQUI_OnDiplomacyMakePeace );
 end
 Initialize_CQUI();

--- a/Assets/UI/WorldView/citybannermanager_CQUI_basegame.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_basegame.lua
@@ -312,7 +312,8 @@ function CityBanner.UpdateName( self )
     local pPlayerConfig :table = PlayerConfigurations[owner];
     local isMinorCiv :boolean = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
     if (isMinorCiv) then
-        CQUI_UpdateSuzerainIcon(pPlayer, self);
+        CQUI_UpdateCityStateBannerSuzerain(pPlayer, self);
+        CQUI_UpdateCityStateBannerAtWarIcon(pPlayer, self);
     end
 
     self.m_Instance.CityQuestIcon:SetToolTipString(questTooltip);

--- a/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI_expansions.lua
@@ -122,7 +122,8 @@ function CityBanner.UpdateInfo(self, pCity : table )
             end
         end
     elseif pPlayer:IsMinor() then
-        CQUI_UpdateSuzerainIcon(pPlayer, self);
+        CQUI_UpdateCityStateBannerSuzerain(pPlayer, self);
+        CQUI_UpdateCityStateBannerAtWarIcon(pPlayer, self);
     elseif pPlayer:IsFreeCities() then
         tooltip = Locale.Lookup("LOC_CITY_BANNER_FREE_CITY_TT") .. tooltipOrignal;
     else -- city states

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -60,6 +60,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ('CQUI_ShowProductionRecommendations', 0), -- Shows the advisor recommendation in the city produciton panel
         ('CQUI_ShowTechCivicRecommendations', 1), -- Shows the advisor recommendation in the techs/civics tree/panel
         ('CQUI_ShowSuzerainInCityStateBanner', 1), -- Show the Icon of the Suzerain Civilization in the CityState Banner
+        ('CQUI_ShowWarIconInCityStateBanner', 1), -- When at war with a City State, show the War Icon in the banner of that City State
         ('CQUI_ShowImprovementsRecommendations', 0), -- Shows the advisor recommendation for the builder improvements
         ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel
         ('CQUI_ShowDebugPrint', 0); -- Shows print in the console

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -545,6 +545,7 @@ function Initialize()
     PopulateCheckBox(Controls.SmartbannerDistrictsAvailableCheckbox, "CQUI_Smartbanner_DistrictsAvailable", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_AVAILABLE_TOOLTIP"));
     PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
     PopulateCheckBox(Controls.ShowSuzerainInCityStateBanner, "CQUI_ShowSuzerainInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP"));
+    PopulateCheckBox(Controls.ShowWarIconInCityStateBanner, "CQUI_ShowWarIconInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateCityStrikeCheckbox, "CQUI_RelocateCityStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateEncampmentStrikeCheckbox, "CQUI_RelocateEncampmentStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -47,6 +47,9 @@
                             <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                 <GridButton ID="ShowSuzerainInCityStateBanner" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" />
                             </Stack>
+                            <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                <GridButton ID="ShowWarIconInCityStateBanner" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" />
+                            </Stack>
                         </Stack>
                     </Container>
                     <Container ID="PopupsOptions" Size="parent,parent" Hidden="1">


### PR DESCRIPTION
When at war with a City State, show the red crossed swords icon in the banner.

Expansions (CS without and with a Suzerain):
![image](https://user-images.githubusercontent.com/8787640/92359658-7c5b1900-f0a0-11ea-8627-9b38f6a7b886.png)
![image](https://user-images.githubusercontent.com/8787640/92359749-9d236e80-f0a0-11ea-9ada-090ccfb8edab.png)
For comparison, not at war, Maya is Suzerain:
![image](https://user-images.githubusercontent.com/8787640/92360350-83cef200-f0a1-11ea-8654-1e50fdc53fdd.png)

Vanilla (CS without and with a Suzerain):
![image](https://user-images.githubusercontent.com/8787640/92359467-25554400-f0a0-11ea-8535-4cb471a90373.png)
![image](https://user-images.githubusercontent.com/8787640/92359485-2e461580-f0a0-11ea-96b6-574d97e34903.png)

**Changes**
- Added as a CQUI setting, default to enabled.
- Expansions: modified the padding and anchor settings for elements in the City Banner.
  - For the expansions, I wanted the "At War" icon to be the left-most icon.
  - This meant a standalone icon rather than using the Stack control that houses the CS Icon and CS Type icon.  In order to get things to look correct, it took some playing with the anchors and padding to get that done.
- Vanilla game, the At War icon ends up in the same spot where the Suzerain icon happens to go if you declare war on one of your Suzerain City States.  Otherwise the icon goes to the left of the Suzerain icon.
  - For whatever it's worth the Vanilla banners just look so wonky to me, but I do not think that's a thing caused by CQUI.

**Tested**
- Vanilla, EXP1, EXP2
- Declared war on CS, validated that the icon appears in the banner
- Declared war on Major Civ, validated that the at war icon appears in the banner where the Major Civ is the CS Suzerain
- Validated the icon disappears/reappears when disabling/enabling the setting
- Validated the icon shows on a game load for the CS I am at war with
