### PR TITLE
Bugfix, More Information on Suzerainty in CityBanner and ability to switch between civ icon and leader icon

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -53,6 +53,8 @@
                         <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="auto,auto" AutoSizePadding="2,0" Hidden="1">
                             <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22">
                                 <Image ID="CQUI_CivSuzerainIcon" Size="22,22" Anchor="C,C" IconSize="22"/>
+								<Label ID="CQUI_SuzerainEnvoys" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+								<Label ID="CQUI_LocalPlayerEnvoys" Anchor="C,T" Offset="-10,-2" Style="StrongSmall2"/>
                             </Image>
                         </Container>
 

--- a/Assets/Expansion2/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion2/CityBanners/citybannerinstances.xml
@@ -52,6 +52,8 @@
                         <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="auto,auto" AutoSizePadding="2,0" Hidden="1">
                             <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22">
                                 <Image ID="CQUI_CivSuzerainIcon" Size="22,22" Anchor="C,C" IconSize="22"/>
+								<Label ID="CQUI_SuzerainEnvoys" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+								<Label ID="CQUI_LocalPlayerEnvoys" Anchor="C,T" Offset="-10,-2" Style="StrongSmall2"/>
                             </Image>
                         </Container>
 

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -96,6 +96,12 @@
     <Row Tag="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP" Language="en_US">
       <Text>Show the Civilization Icon of the Suzerain of a City State in the City State Banner</Text>
     </Row>
+	<Row Tag="LOC_CQUI_SHOW_LEADER_ICON_IN_CITY_STATE_BANNER" Language="en_US">
+      <Text>Leader instead of Civ Icon as Suzerain</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_SHOW_LEADER_ICON_IN_CITY_STATE_BANNER_TOOLTIP" Language="en_US">
+      <Text>Check this if you have "Suzerain in CityState Banner enabled and would like to see the leader icon instead of the civilization icon in the City State Banner</Text>
+    </Row>
     <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="en_US">
       <Text>War Icon in CityState Banner</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -100,7 +100,7 @@
       <Text>Leader instead of Civ Icon as Suzerain</Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_LEADER_ICON_IN_CITY_STATE_BANNER_TOOLTIP" Language="en_US">
-      <Text>Check this if you have "Suzerain in CityState Banner enabled and would like to see the leader icon instead of the civilization icon in the City State Banner</Text>
+      <Text>Check this if you have "Suzerain in CityState Banner" enabled and would like to see the leader icon instead of the civilization icon in the City State Banner</Text>
     </Row>
     <Row Tag="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" Language="en_US">
       <Text>War Icon in CityState Banner</Text>

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -200,6 +200,8 @@
                             <Container ID="CQUI_CivSuzerain" Anchor="C,C" Size="34,34" Hidden="1">
                                 <Image ID="CQUI_CivSuzerainIconBackground" Size="22,22" Anchor="C,C" Texture="CircleBacking22" >
                                     <Image ID="CQUI_CivSuzerainIcon" Size="22,22" Anchor="C,C" IconSize="22"/>
+									<Label ID="CQUI_SuzerainEnvoys" Anchor="C,T" Offset="10,-2" Style="StrongSmall2"/>
+									<Label ID="CQUI_LocalPlayerEnvoys" Anchor="C,T" Offset="-10,-2" Style="StrongSmall2"/>
                                 </Image>
                             </Container>
                             <Label ID="CityName" Anchor="L,C" Style="HeaderSmallCaps" String="BALTIMORE" />

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -60,6 +60,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ('CQUI_ShowProductionRecommendations', 0), -- Shows the advisor recommendation in the city produciton panel
         ('CQUI_ShowTechCivicRecommendations', 1), -- Shows the advisor recommendation in the techs/civics tree/panel
         ('CQUI_ShowSuzerainInCityStateBanner', 1), -- Show the Icon of the Suzerain Civilization in the CityState Banner
+		("CQUI_ShowLeaderIconInCityStateBanner", 0), -- Whether to show the leader icon instead of the civilization icon if CQUI_ShowSuzerainInCityStateBanner is enabled
         ('CQUI_ShowWarIconInCityStateBanner', 1), -- When at war with a City State, show the War Icon in the banner of that City State
         ('CQUI_ShowImprovementsRecommendations', 0), -- Shows the advisor recommendation for the builder improvements
         ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -545,6 +545,7 @@ function Initialize()
     PopulateCheckBox(Controls.SmartbannerDistrictsAvailableCheckbox, "CQUI_Smartbanner_DistrictsAvailable", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_AVAILABLE_TOOLTIP"));
     PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
     PopulateCheckBox(Controls.ShowSuzerainInCityStateBanner, "CQUI_ShowSuzerainInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER_TOOLTIP"));
+    PopulateCheckBox(Controls.ShowLeaderIconInCityStateBanner, "CQUI_ShowLeaderIconInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_LEADER_ICON_IN_CITY_STATE_BANNER_TOOLTIP"));
     PopulateCheckBox(Controls.ShowWarIconInCityStateBanner, "CQUI_ShowWarIconInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateCityStrikeCheckbox, "CQUI_RelocateCityStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateEncampmentStrikeCheckbox, "CQUI_RelocateEncampmentStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -47,6 +47,9 @@
                             <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                 <GridButton ID="ShowSuzerainInCityStateBanner" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_SHOW_SUZERAIN_IN_CITYSTATE_BANNER" />
                             </Stack>
+							<Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                <GridButton ID="ShowLeaderIconInCityStateBanner" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_SHOW_LEADER_ICON_IN_CITY_STATE_BANNER" />
+                            </Stack>
                             <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                 <GridButton ID="ShowWarIconInCityStateBanner" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER" />
                             </Stack>


### PR DESCRIPTION
For some reason my commits all got merged into one? I am sorry for that, now they are all called bugfix... I hope this PR follows the guidelines, I did my best to.

Addressing #175 
Changes:

- Fixed a bug where the current Suzerain would be revealed even if the Civilization was not met yet by the player.

- Added the ability to change between civ icon and leader icon for the Suzerainty icon in the CityBanner (also added a corresponding option in CQUI settings)

- Added two extra labels: the one to the right shows the envoys sent by the current Suzerain, the left shows the envoys sent by the player (hidden if player == suzerain)

**Tested:**

- Base, XP1, XP2
- Verified the settings in CQUI options menu work, with the banner updating accordingly.
- Verified that only met civilizations are shown by name and icon, unmet civilizations get the default icon and an appropriate tooltip


Screenshots:

XP2:

Self suzerain:

![xp2_leaderIcon_self](https://user-images.githubusercontent.com/32304731/93009584-3829b600-f583-11ea-889d-5b1f1b563f24.PNG)
![xp2_civIcon_self](https://user-images.githubusercontent.com/32304731/93009585-395ae300-f583-11ea-80b9-5b4deddbe4f4.PNG)

Other suzerain:

![xp2_leaderIcon_other](https://user-images.githubusercontent.com/32304731/93009587-3fe95a80-f583-11ea-8459-cd05e7e8404e.PNG)
![xp2_civIcon_other](https://user-images.githubusercontent.com/32304731/93009588-411a8780-f583-11ea-8669-e6abc905b14f.PNG)

Base:
Self suzerain:

![base_leaderIcon_self](https://user-images.githubusercontent.com/32304731/93009594-4a0b5900-f583-11ea-8d19-e6d789882542.PNG)
![base_civIcon_self](https://user-images.githubusercontent.com/32304731/93009595-4aa3ef80-f583-11ea-8cef-6cedeb228ef4.PNG)

Other suzerain:

![base_civIcon_other](https://user-images.githubusercontent.com/32304731/93009599-51326700-f583-11ea-8314-f6a80db61e06.PNG)
![base_leaderIcon_other](https://user-images.githubusercontent.com/32304731/93009601-542d5780-f583-11ea-917b-cc6e4f18c6b8.PNG)

Position in CQUI menu:
![tt](https://user-images.githubusercontent.com/32304731/93009663-f51c1280-f583-11ea-9b28-7460d8a03410.PNG)

Bugfix:
![unknown_true](https://user-images.githubusercontent.com/32304731/93009613-5ee7ec80-f583-11ea-875d-fcb920870575.PNG)
![unknown](https://user-images.githubusercontent.com/32304731/93009624-7c1cbb00-f583-11ea-9111-928cb04a977d.PNG)
(I decided to let the labels still be shown, since the same functionality is available from the citystates panel, however the version without would also be available)