### PR TITLE
Fix for Oct2020 Patch Issue

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion1/CityBanners/citybannerinstances.xml
@@ -253,7 +253,7 @@
                 <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="14,14" SliceSize="51,5" SliceTextureSize="80,34"/>
 
                 <!-- District Font Icon -->
-                <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
+                <Label ID="EncampmentFontIcon" Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
 
                 <!-- Healthbars -->
                 <TextureBar ID="CityHealthBar" Anchor="R,C" Offset="8,3" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" />

--- a/Assets/Expansion2/CityBanners/citybannerinstances.xml
+++ b/Assets/Expansion2/CityBanners/citybannerinstances.xml
@@ -246,7 +246,7 @@
                 <Grid ID="Banner_Base" Size="parent,parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
 
                 <!-- District Font Icon -->
-                <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
+                <Label ID="EncampmentFontIcon" Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
 
                 <!-- Healthbars -->
                 <TextureBar ID="CityHealthBar" Anchor="R,C" Offset="8,3" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" />

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -350,7 +350,7 @@
                 <Grid ID="Banner_Base" Size="Parent,Parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
 
                 <!-- District Font Icon -->
-                <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
+                <Label ID="EncampmentFontIcon" Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
 
                 <!-- Healthbars -->
                 <TextureBar ID="CityHealthBar" Anchor="R,C" Offset="8,3" Size="66,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" />

--- a/Assets/UI/WorldView/citybannermanager_CQUI.lua
+++ b/Assets/UI/WorldView/citybannermanager_CQUI.lua
@@ -119,9 +119,7 @@ function CQUI_Common_CityBanner_Initialize(self, playerID, cityID, districtID, b
     end
 
     -- Register the MouseOver callbacks
-    if (bannerType == BANNERTYPE_CITY_CENTER 
-        and bannerStyle == BANNERSTYLE_LOCAL_TEAM 
-        and playerID == Game.GetLocalPlayer()) then
+    if (bannerType == BANNERTYPE_CITY_CENTER) then
         -- Register the callbacks 
         self.m_Instance.CityNameButton:RegisterCallback( Mouse.eMouseEnter, CQUI_OnBannerMouseOver );
         self.m_Instance.CityNameButton:RegisterCallback( Mouse.eMouseExit,  CQUI_OnBannerMouseExit );


### PR DESCRIPTION
Note: I have already uploaded this to the Steam Workshop, as this was a simple fix and it seems like not too many of us have been around lately (myself included).

**The Fixes:**
- Issue #194 - Health and range strike buttons have disappeared for the encampment
  - Firaxis went and added a label to something in the XML and started referring to it
- Issue #191 - Banners of other Civs / City States are not clickable
  - It seems that limiting the button click-callback to only our own banners is not necessary

I played for a bit, did not see problems.


