### PR TITLE
Fix issue where Policy Reminder popup is shown after turn 1

### DIFF
--- a/Assets/UI/actionpanel.lua
+++ b/Assets/UI/actionpanel.lua
@@ -526,10 +526,16 @@ function CQUI_CheckPolicyCanBeChanged()
     -- AURENCY : get the Index of the future tech
     local futureCivicIndex = GameInfo["Civics"]["CIVIC_FUTURE_CIVIC"].Index
 
-    local PRD:table    = pPlayer:GetCulture()
-    if (PRD:CivicCompletedThisTurn() and PRD:GetCivicCompletedThisTurn() ~= futureCivicIndex and not PRD:PolicyChangeMade()) then
+    local PRD:table = pPlayer:GetCulture()
+    local completedThisTurnIndex = PRD:GetCivicCompletedThisTurn()
+
+    if (PRD:CivicCompletedThisTurn() 
+        and completedThisTurnIndex ~= futureCivicIndex
+        and completedThisTurnIndex ~= -1 -- Civs with free policy slots can show, on the first turn, as CivicCompletedThisTurn = true and GetCivicCompletedThisTurn as -1
+        and not PRD:PolicyChangeMade()) then
         return true
     end
+
     return false
 end
 


### PR DESCRIPTION
I documented the bug and interesting behavior in comments in the #195 thread, but didn't mention there that this applies to any Civ that has extra policy slots (you can see this behavior when playing as Gorgo, for example).

On turn 1, the CQUI_CheckPolicyCanBeChanged function in actionpanel.lua was improperly returning true.  The _GetCivicCompletedThisTurn_ value returned was -1, which is invalid, and results in _ShowPolicyReminderPopup_ in policyreminderpopup.lua showing the panel without making any of the visual changes (like changing the text on the button itself).

This fix is pretty straightforward - if _GetCivicCompletedThisTurn_ is -1, then do not return true.  I played a bit and verified that when a civic is completed and government unlocked, the reminder shows up properly.  Does not matter vanilla/exp1/exp2, they all use the same code here.
