### PR TITLE
Show the Heroes on the Heroes&Great People tab

### DIFF
--- a/Assets/UI/Popups/greatpeoplepopup.lua
+++ b/Assets/UI/Popups/greatpeoplepopup.lua
@@ -180,9 +180,6 @@ function AddRecruit( kData:table, kPerson:table )
     local classData :table = GameInfo.GreatPersonClasses[kPerson.ClassID];
     local individualData :table = GameInfo.GreatPersonIndividuals[kPerson.IndividualID];
 
-    -- TEMP
-    print("**** AddRecruit:  classData.Name:"..tostring(classData.Name));
-
     if (kPerson.ClassID ~= nil) then
         local portrait:string = "ICON_GENERIC_" .. classData.GreatPersonClassType;
         portrait = portrait:gsub("_CLASS","_INDIVIDUAL");

--- a/Assets/UI/Popups/greatpeoplepopup.lua
+++ b/Assets/UI/Popups/greatpeoplepopup.lua
@@ -16,13 +16,16 @@ local MAX_BIOGRAPHY_PARAGRAPHS :number = 9;  -- maximum # of paragraphs for a bi
 local RELOAD_CACHE_ID          :string = "GreatPeoplePopup"; -- hotloading
 local SIZE_ACTION_ICON         :number = 38;
 
+local TAB_SIZE                 :number = 170;
+local TAB_PADDING              :number = 10;
 
 -- ===========================================================================
 --  MEMBERS
 -- ===========================================================================
 local m_TopPanelConsideredHeight :number = 0;
 local m_greatPersonPanelIM       :table  = InstanceManager:new("PanelInstance",           "Content", Controls.PeopleStack);
-local m_greatPersonRowIM         :table  = InstanceManager:new("PastRecruitmentInstance", "Content",    Controls.RecruitedStack);
+local m_greatPersonRowIM         :table  = InstanceManager:new("PastRecruitmentInstance", "Content", Controls.RecruitedStack);
+local m_tabButtonIM              :table  = InstanceManager:new("TabButtonInstance",       "Button",  Controls.TabContainer);
 local m_kGreatPeople             :table;
 local m_kData                    :table;
 local m_activeBiographyID        :number = -1; -- Only allow one open at a time (or very quick exceed font allocation)
@@ -32,6 +35,14 @@ local m_defaultPastRowHeight     :number = -1; -- Default/mix height (from XML) 
 local m_displayPlayerID          :number = -1; -- What player are we displaying.    Used for looking at different players in autoplay
 local m_screenWidth              :number = -1;
 
+local m_numTabs                  :number = 0;
+
+-- Dynamic refresh call member used to override the refresh functionality
+local m_RefreshFunc              :ifunction = nil;
+
+local m_pGreatPeopleTabInstance  :table = nil;
+local m_pPrevRecruitedTabInstance:table = nil;
+
 -- ===========================================================================
 --  CQUI
 -- ===========================================================================
@@ -39,6 +50,21 @@ local _, CQUI_screenHeight = UIManager:GetScreenSizeVal();
 local CQUI_MARGIN = 180;
 local CQUI_ModalFrameBaseSize = Controls.ModalFrame:GetSizeY();
 local CQUI_PopupContainerBaseSize = Controls.PopupContainer:GetSizeY();
+
+-- These values are calculated as part of the "AddRecruit" function, which is a function separated out from "ViewCurrent" by Firaxis.
+-- Previously CQUI left the "AddRecruit" logic inline the ViewCurrent function, however given the changes for the Babylon Patch by Firaxis,
+-- it makes sense to move the logic out to that separate function, in case a future update makes use of it.
+-- Notes on Pixel sizes:
+-- 63px from top of container "RecruitProgressBox" to top of scrollpanel "RecruitScroll"
+-- 84px from bottom of scrollpanel "RecruitScroll" to bottom of the container "PopupContainer"
+local CQUI_lowerPanelAdditionalHeight = 147;
+-- When fit to a full screen, the Great Person panel instance is 122px shorter than the "PopupContainer"
+local CQUI_instanceMargin = 127;
+local CQUI_preferredRecruitScrollSize = 0;
+local CQUI_preferredEffectsScrollSize = 240; -- Value defined in the XML
+local CQUI_preferredInstanceSize = 0;
+local CQUI_isPreferredRecruitScrollSizeComputed:boolean = false;
+local CQUI_isPreferredHeightsComputed:boolean = false;
 
 -- ===========================================================================
 function ChangeDisplayPlayerID(bBackward)
@@ -146,6 +172,283 @@ function GetBiographyTextTable( individualID:number )
     return kBiography;
 end
 
+-- ===========================================================================
+-- Add an instance of a Great Person "recruit" to the Great People Panel
+-- ===========================================================================
+function AddRecruit( kData:table, kPerson:table )
+    local instance  :table = m_greatPersonPanelIM:GetInstance();
+    local classData :table = GameInfo.GreatPersonClasses[kPerson.ClassID];
+    local individualData :table = GameInfo.GreatPersonIndividuals[kPerson.IndividualID];
+
+    -- TEMP
+    print("**** AddRecruit:  classData.Name:"..tostring(classData.Name));
+
+    if (kPerson.ClassID ~= nil) then
+        local portrait:string = "ICON_GENERIC_" .. classData.GreatPersonClassType;
+        portrait = portrait:gsub("_CLASS","_INDIVIDUAL");
+        instance.Portrait:SetIcon(portrait);
+        instance.CircleFlare:SetHide(false);
+
+        local classText:string = Locale.Lookup(classData.Name);
+        instance.ClassName:SetText(classText);
+        instance.ClassName:SetHide(false);
+    else
+        instance.CircleFlare:SetHide(true);
+        instance.ClassName:SetHide(true);
+    end
+    
+    if kPerson.IndividualID ~= nil then
+        local individualName:string = Locale.ToUpper(kPerson.Name);
+        instance.IndividualName:SetText( individualName );
+    end
+
+    if kPerson.EraID ~= nil then
+        local eraName:string = Locale.ToUpper(Locale.Lookup(GameInfo.Eras[kPerson.EraID].Name));
+        instance.EraName:SetText( eraName );
+    end
+
+    if instance["m_EffectsIM"] ~= nil then
+        instance["m_EffectsIM"]:ResetInstances();
+    else
+        instance["m_EffectsIM"] = InstanceManager:new("EffectInstance", "Top", instance.EffectStack);
+    end
+
+    if kPerson.PassiveNameText ~= nil and kPerson.PassiveNameText ~= "" then
+        local effectInst:table  = instance["m_EffectsIM"]:GetInstance();
+        local effectText:string = kPerson.PassiveEffectText;
+        local fullText:string   = kPerson.PassiveNameText .. "[NEWLINE][NEWLINE]" .. effectText;
+        effectInst.Text:SetText( effectText );
+        effectInst.EffectTypeIcon:SetToolTipString( fullText );
+        effectInst.PassiveAbilityIcon:SetHide(false);
+        effectInst.ActiveAbilityIcon:SetHide(true);
+    end
+
+    if (kPerson.ActionNameText ~= nil and kPerson.ActionNameText ~= "") then
+        local effectInst:table  = instance["m_EffectsIM"]:GetInstance();
+        local effectText:string = kPerson.ActionEffectText;
+        local fullText:string   = kPerson.ActionNameText;
+        if (kPerson.ActionCharges > 0) then
+            fullText = fullText .. " (" .. Locale.Lookup("LOC_GREATPERSON_ACTION_CHARGES", kPerson.ActionCharges) .. ")";
+        end
+        fullText = fullText .. "[NEWLINE]" .. kPerson.ActionUsageText;
+        fullText = fullText .. "[NEWLINE][NEWLINE]" .. effectText;
+        effectInst.Text:SetText( effectText );
+        effectInst.EffectTypeIcon:SetToolTipString( fullText );
+
+        local actionIcon:string = classData.ActionIcon;
+        if actionIcon ~= nil and actionIcon ~= "" then
+            local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(actionIcon, SIZE_ACTION_ICON);
+            if (textureSheet == nil or textureSheet == "") then
+                UI.DataError("Could not find icon in ViewCurrent: icon=\""..actionIcon.."\", iconSize="..tostring(SIZE_ACTION_ICON) );
+            else
+                effectInst.ActiveAbilityIcon:SetTexture(textureOffsetX, textureOffsetY, textureSheet);
+                effectInst.ActiveAbilityIcon:SetHide(false);
+                effectInst.PassiveAbilityIcon:SetHide(true);
+            end
+        else
+            effectInst.ActiveAbilityIcon:SetHide(true);
+        end
+    end
+
+    if instance["m_RecruitIM"] ~= nil then
+        instance["m_RecruitIM"]:ResetInstances();
+    else
+        instance["m_RecruitIM"] = InstanceManager:new("RecruitInstance", "Top", instance.RecruitStack);
+    end
+
+    if instance["m_RecruitExtendedIM"] ~= nil then
+        instance["m_RecruitExtendedIM"]:ResetInstances();
+    else
+        instance["m_RecruitExtendedIM"] = InstanceManager:new("RecruitInstance", "Top", instance.RecruitInfoStack);
+    end
+
+    if kPerson.IndividualID ~= nil and kPerson.ClassID ~= nil then
+    -- Buy via gold
+        if (HasCapability("CAPABILITY_GREAT_PEOPLE_RECRUIT_WITH_GOLD") and (not kPerson.CanRecruit and not kPerson.CanReject and kPerson.PatronizeWithGoldCost ~= nil and kPerson.PatronizeWithGoldCost < 1000000)) then
+            if (kPerson.CanPatronizeWithGold) then
+                instance.GoldButton:SetText("[COLOR_GoldMetal]" .. kPerson.PatronizeWithGoldCost .. "[ENDCOLOR][ICON_Gold]");
+                instance.GoldButton:SetDisabled(false);
+            else
+                instance.GoldButton:SetText("[COLOR_GoldMetalDark]" .. kPerson.PatronizeWithGoldCost .. "[ENDCOLOR][ICON_Gold]");
+                instance.GoldButton:SetDisabled(true);
+            end
+
+            instance.GoldButton:SetToolTipString(GetPatronizeWithGoldTT(kPerson));
+            instance.GoldButton:SetVoid1(kPerson.IndividualID);
+            instance.GoldButton:RegisterCallback(Mouse.eLClick, OnGoldButtonClick);
+            instance.GoldButton:SetHide(false);
+        else
+            instance.GoldButton:SetHide(true);
+        end
+
+        -- Buy via Faith
+        if (HasCapability("CAPABILITY_GREAT_PEOPLE_RECRUIT_WITH_FAITH") and (not kPerson.CanRecruit and not kPerson.CanReject and kPerson.PatronizeWithFaithCost ~= nil and kPerson.PatronizeWithFaithCost < 1000000)) then
+            if ((kPerson.CanPatronizeWithFaith) and not IsReadOnly()) then
+                instance.FaithButton:SetText("[COLOR_Faith]" .. kPerson.PatronizeWithFaithCost .. "[ENDCOLOR][ICON_Faith]");
+                instance.FaithButton:SetDisabled(false);
+            else
+                instance.FaithButton:SetText("[COLOR_FaithDark]" .. kPerson.PatronizeWithFaithCost .. "[ENDCOLOR][ICON_Faith]");
+                instance.FaithButton:SetDisabled(true);
+            end
+
+            instance.FaithButton:SetToolTipString(GetPatronizeWithFaithTT(kPerson));
+            instance.FaithButton:SetVoid1(kPerson.IndividualID);
+            instance.FaithButton:RegisterCallback(Mouse.eLClick, OnFaithButtonClick);
+            instance.FaithButton:SetHide(false);
+        else
+            instance.FaithButton:SetHide(true);
+        end
+
+        -- Recruiting 
+        if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_RECRUIT") and kPerson.CanRecruit and kPerson.RecruitCost ~= nil) then
+            instance.RecruitButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_RECRUIT_DETAILS", kPerson.RecruitCost) );
+            instance.RecruitButton:SetVoid1(kPerson.IndividualID);
+            instance.RecruitButton:RegisterCallback(Mouse.eLClick, OnRecruitButtonClick);
+            instance.RecruitButton:SetHide(false);
+
+        -- Auto scroll to first recruitable person.
+            if kInstanceToShow==nil then
+                kInstanceToShow = instance;
+            end
+        else
+            instance.RecruitButton:SetHide(true);
+        end
+
+        -- Rejecting
+        if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_REJECT") and kPerson.CanReject and kPerson.RejectCost ~= nil) then
+            instance.RejectButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_PASS_DETAILS", kPerson.RejectCost ) );
+            instance.RejectButton:SetVoid1(kPerson.IndividualID);
+            instance.RejectButton:RegisterCallback(Mouse.eLClick, OnRejectButtonClick);
+            instance.RejectButton:SetHide(false);
+        else
+            instance.RejectButton:SetHide(true);
+        end
+
+        -- If Recruit or Reject buttons are shown hide the minimized recruit stack
+        -- CQUI: Do not hide the "Minimized Recruit" Stack (which lists the progress of all of the civs for that Great Person)
+            -- if not instance.RejectButton:IsHidden() or not instance.RecruitButton:IsHidden() then
+        --    instance.RecruitMinimizedStack:SetHide(true);
+        -- else
+        --    instance.RecruitMinimizedStack:SetHide(false);
+        -- end
+        
+        -- Recruiting standings
+        -- Let's sort the table first by points total, then by the lower player id (to push yours toward the top of the list for readability)
+        local recruitTable: table = {};
+        for i, kPlayerPoints in ipairs(kData.PointsByClass[kPerson.ClassID]) do
+            table.insert(recruitTable,kPlayerPoints);
+        end
+        table.sort(recruitTable,
+            function (a,b) 
+                if (a.PointsTotal == b.PointsTotal) then
+                    return a.PlayerID < b.PlayerID;
+                else
+                    return a.PointsTotal > b.PointsTotal;
+                end 
+                end);
+
+        for i, kPlayerPoints in ipairs(recruitTable) do
+            if (kPlayerPoints.PlayerID == Game.GetLocalPlayer()) then
+                FillRecruitInstance(instance.LocalPlayerRecruitInstance, kPlayerPoints, kPerson, classData);
+            else
+                local recruitInst:table = instance["m_RecruitIM"]:GetInstance();
+                FillRecruitInstance(recruitInst, kPlayerPoints, kPerson, classData);
+                if not CQUI_isPreferredRecruitScrollSizeComputed then
+                    CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + recruitInst.Top:GetSizeY() + 5; -- AZURENCY : 5 is the padding
+                end
+            end
+
+            local recruitExtendedInst:table = instance["m_RecruitExtendedIM"]:GetInstance();
+            FillRecruitInstance(recruitExtendedInst, kPlayerPoints, kPerson, classData);
+        end
+
+        if not CQUI_isPreferredRecruitScrollSizeComputed then
+            CQUI_isPreferredRecruitScrollSizeComputed = true;
+        end
+
+        if (kPerson.EarnConditions ~= nil and kPerson.EarnConditions ~= "") then
+            instance.RecruitInfo:SetText("[COLOR_Civ6Red]" .. Locale.Lookup("LOC_GREAT_PEOPLE_CANNOT_EARN_PERSON") .. "[ENDCOLOR]");
+            instance.RecruitInfo:SetToolTipString("[COLOR_Civ6Red]" .. kPerson.EarnConditions .. "[ENDCOLOR]");
+            instance.RecruitInfo:SetHide(false);
+        else
+            instance.RecruitInfo:SetHide(true);
+        end
+
+        instance.RecruitScroll:CalculateSize();
+    end
+
+    
+    if kPerson.IndividualID ~= nil then
+        -- Set the biography buttons
+        instance.BiographyBackButton:SetVoid1( kPerson.IndividualID );
+        instance.BiographyBackButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
+        instance.BiographyOpenButton:SetVoid1( kPerson.IndividualID );
+        instance.BiographyOpenButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
+        
+        -- Setup extended recruit info buttons
+        instance.RecruitInfoOpenButton:SetVoid1( kPerson.IndividualID );
+        instance.RecruitInfoOpenButton:RegisterCallback( Mouse.eLClick, OnRecruitInfoClick );
+        instance.RecruitInfoBackButton:SetVoid1( kPerson.IndividualID );
+        instance.RecruitInfoBackButton:RegisterCallback( Mouse.eLClick, OnRecruitInfoClick );
+
+        m_kGreatPeople[kPerson.IndividualID] = instance; -- Store instance for later look up
+    end
+
+    local noneAvailable :boolean = (kPerson.IndividualID == nil);
+    instance.ClassName:SetHide( noneAvailable );
+    instance.TitleLine:SetHide( noneAvailable );
+    instance.IndividualName:SetHide( noneAvailable );
+    instance.EraName:SetHide( noneAvailable );
+    instance.MainInfo:SetHide( noneAvailable );
+    instance.BiographyBackButton:SetHide( noneAvailable );
+    instance.ClaimedLabel:SetHide( not noneAvailable );
+    instance.BiographyArea:SetHide( true );
+    instance.RecruitInfoArea:SetHide( true );
+    instance.FadedBackground:SetHide( true );
+    instance.BiographyOpenButton:SetHide( noneAvailable );
+    instance.EffectStack:CalculateSize();
+    instance.EffectStackScroller:CalculateSize();
+
+    if (CQUI_isPreferredHeightsComputed == false) then
+        --CQUI_preferredRecruitScrollSize = 1000;  -- for quick testing
+        if (CQUI_preferredRecruitScrollSize > (CQUI_screenHeight / 4)) then
+            CQUI_preferredRecruitScrollSize = (CQUI_screenHeight / 4);
+        end
+
+        -- 670 is the default Instance size in the XML... 86 is a number that represents some undocumented thing
+        CQUI_preferredInstanceSize =  670 - 86 + CQUI_preferredRecruitScrollSize;
+        -- CQUI_preferredInstanceSize = 3000 -- for quick testing
+        if (CQUI_preferredInstanceSize > (CQUI_screenHeight - CQUI_instanceMargin)) then
+            -- The instance area cannot be bigger than the screen height minus CQUI_instanceMargin:
+            -- When the Gold/Faith (or Recruit/Pass) buttons are 5px above the PeopleScroller horizontal scroll, 
+            -- the PanelInstance is CQUI_instanceMargin pixels less in height than the PeopleContainer, which is defined as 768 in the XML.
+            -- These adjustments are necessary to properly fit the screen
+            local prevPreferredInstanceSize = CQUI_preferredInstanceSize;
+            CQUI_preferredInstanceSize = CQUI_screenHeight - CQUI_instanceMargin;
+
+            -- Instead of shrinking the recruit scroll size, instead shrink the EffectsStackScroller, as there's typically room to spare in that section
+            -- 240 is the value defined in the XML.  We cannot do a GetSizeY here because subsequent calls to this function
+            -- would update the smaller value, eventually shrinking the control to less than zero.
+            local effectStackScrollerAdjustment = prevPreferredInstanceSize - CQUI_preferredInstanceSize;
+            CQUI_preferredEffectsScrollSize = 240 - effectStackScrollerAdjustment;
+        end
+
+        CQUI_isPreferredHeightsComputed = true;
+    end
+
+    -- CQUI : change size
+    -- CQUI DEBUG TEST :
+    -- CQUI_preferredRecruitScrollSize = 300;
+    instance.Content:SetSizeY(CQUI_preferredInstanceSize);
+    instance.EffectStackScroller:SetSizeY(CQUI_preferredEffectsScrollSize);
+    instance.RecruitScroll:SetSizeY(CQUI_preferredRecruitScrollSize);
+end
+
+-- ===========================================================================
+function ResetGreatPeopleInstances()
+    m_greatPersonPanelIM:ResetInstances();
+    m_greatPersonRowIM:ResetInstances();
+end
 
 -- ===========================================================================
 --  View the great people currently available (to be purchased)
@@ -157,291 +460,18 @@ function ViewCurrent( data:table )
     end
 
     m_kGreatPeople = {};
-    m_greatPersonPanelIM:ResetInstances();
+    ResetGreatPeopleInstances();
     Controls.PeopleScroller:SetHide(false);
     Controls.RecruitedArea:SetHide(true);
 
     local kInstanceToShow:table = nil;
 
-    -- 63px from top of container "RecruitProgressBox" to top of scrollpanel "RecruitScroll"
-    -- 84px from bottom of scrollpanel "RecruitScroll" to bottom of the container "PopupContainer"
-    local CQUI_lowerPanelAdditionalHeight = 147;
-    -- When fit to a full screen, the Great Person panel instance is 122px shorter than the "PopupContainer"
-    local CQUI_instanceMargin = 127;
-    local CQUI_preferredRecruitScrollSize = 0;
-    local CQUI_preferredEffectsScrollSize = 240; -- Value defined in the XML
-    local CQUI_preferredInstanceSize = 0;
-    local CQUI_isPreferredRecruitScrollSizeComputed:boolean = false;
-    local CQUI_isPreferredHeightsComputed:boolean = false;
-
     for i, kPerson:table in ipairs(data.Timeline) do
-        local instance  :table = m_greatPersonPanelIM:GetInstance();
-        local classData :table = GameInfo.GreatPersonClasses[kPerson.ClassID];
-        local individualData :table = GameInfo.GreatPersonIndividuals[kPerson.IndividualID];
-
-        if (kPerson.ClassID ~= nil) then
-            local portrait:string = "ICON_GENERIC_" .. classData.GreatPersonClassType;
-            portrait = portrait:gsub("_CLASS","_INDIVIDUAL");
-            instance.Portrait:SetIcon(portrait);
-            instance.CircleFlare:SetHide(false);
-
-            local classText:string = Locale.Lookup(classData.Name);
-            instance.ClassName:SetText(classText);
-            instance.ClassName:SetHide(false);
-        else
-            instance.CircleFlare:SetHide(true);
-            instance.ClassName:SetHide(true);
-        end
-        
-        if kPerson.IndividualID ~= nil then
-            local individualName:string = Locale.ToUpper(kPerson.Name);
-            instance.IndividualName:SetText( individualName );
-        end
-
-        if kPerson.EraID ~= nil then
-            local eraName:string = Locale.ToUpper(Locale.Lookup(GameInfo.Eras[kPerson.EraID].Name));
-            instance.EraName:SetText( eraName );
-        end
-
-        if instance["m_EffectsIM"] ~= nil then
-            instance["m_EffectsIM"]:ResetInstances();
-        else
-            instance["m_EffectsIM"] = InstanceManager:new("EffectInstance", "Top", instance.EffectStack);
-        end
-
-        if kPerson.PassiveNameText ~= nil and kPerson.PassiveNameText ~= "" then
-            local effectInst:table  = instance["m_EffectsIM"]:GetInstance();
-            local effectText:string = kPerson.PassiveEffectText;
-            local fullText:string   = kPerson.PassiveNameText .. "[NEWLINE][NEWLINE]" .. effectText;
-            effectInst.Text:SetText( effectText );
-            effectInst.EffectTypeIcon:SetToolTipString( fullText );
-            effectInst.PassiveAbilityIcon:SetHide(false);
-            effectInst.ActiveAbilityIcon:SetHide(true);
-        end
-
-        if (kPerson.ActionNameText ~= nil and kPerson.ActionNameText ~= "") then
-            local effectInst:table  = instance["m_EffectsIM"]:GetInstance();
-            local effectText:string = kPerson.ActionEffectText;
-            local fullText:string   = kPerson.ActionNameText;
-            if (kPerson.ActionCharges > 0) then
-                fullText = fullText .. " (" .. Locale.Lookup("LOC_GREATPERSON_ACTION_CHARGES", kPerson.ActionCharges) .. ")";
-            end
-            fullText = fullText .. "[NEWLINE]" .. kPerson.ActionUsageText;
-            fullText = fullText .. "[NEWLINE][NEWLINE]" .. effectText;
-            effectInst.Text:SetText( effectText );
-            effectInst.EffectTypeIcon:SetToolTipString( fullText );
-
-            local actionIcon:string = classData.ActionIcon;
-            if actionIcon ~= nil and actionIcon ~= "" then
-                local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(actionIcon, SIZE_ACTION_ICON);
-                if (textureSheet == nil or textureSheet == "") then
-                    UI.DataError("Could not find icon in ViewCurrent: icon=\""..actionIcon.."\", iconSize="..tostring(SIZE_ACTION_ICON) );
-                else
-                    effectInst.ActiveAbilityIcon:SetTexture(textureOffsetX, textureOffsetY, textureSheet);
-                    effectInst.ActiveAbilityIcon:SetHide(false);
-                    effectInst.PassiveAbilityIcon:SetHide(true);
-                end
-            else
-                effectInst.ActiveAbilityIcon:SetHide(true);
-            end
-        end
-
-        if instance["m_RecruitIM"] ~= nil then
-            instance["m_RecruitIM"]:ResetInstances();
-        else
-            instance["m_RecruitIM"] = InstanceManager:new("RecruitInstance", "Top", instance.RecruitStack);
-        end
-
-        if instance["m_RecruitExtendedIM"] ~= nil then
-            instance["m_RecruitExtendedIM"]:ResetInstances();
-        else
-            instance["m_RecruitExtendedIM"] = InstanceManager:new("RecruitInstance", "Top", instance.RecruitInfoStack);
-        end
-
-        if kPerson.IndividualID ~= nil and kPerson.ClassID ~= nil then
-        -- Buy via gold
-            if (HasCapability("CAPABILITY_GREAT_PEOPLE_RECRUIT_WITH_GOLD") and (not kPerson.CanRecruit and not kPerson.CanReject and kPerson.PatronizeWithGoldCost ~= nil and kPerson.PatronizeWithGoldCost < 1000000)) then
-                if (kPerson.CanPatronizeWithGold) then
-                    instance.GoldButton:SetText("[COLOR_GoldMetal]" .. kPerson.PatronizeWithGoldCost .. "[ENDCOLOR][ICON_Gold]");
-                    instance.GoldButton:SetDisabled(false);
-                else
-                    instance.GoldButton:SetText("[COLOR_GoldMetalDark]" .. kPerson.PatronizeWithGoldCost .. "[ENDCOLOR][ICON_Gold]");
-                    instance.GoldButton:SetDisabled(true);
-                end
-
-                instance.GoldButton:SetToolTipString(GetPatronizeWithGoldTT(kPerson));
-                instance.GoldButton:SetVoid1(kPerson.IndividualID);
-                instance.GoldButton:RegisterCallback(Mouse.eLClick, OnGoldButtonClick);
-                instance.GoldButton:SetHide(false);
-            else
-                instance.GoldButton:SetHide(true);
-            end
-
-            -- Buy via Faith
-            if (HasCapability("CAPABILITY_GREAT_PEOPLE_RECRUIT_WITH_FAITH") and (not kPerson.CanRecruit and not kPerson.CanReject and kPerson.PatronizeWithFaithCost ~= nil and kPerson.PatronizeWithFaithCost < 1000000)) then
-                if ((kPerson.CanPatronizeWithFaith) and not IsReadOnly()) then
-                    instance.FaithButton:SetText("[COLOR_Faith]" .. kPerson.PatronizeWithFaithCost .. "[ENDCOLOR][ICON_Faith]");
-                    instance.FaithButton:SetDisabled(false);
-                else
-                    instance.FaithButton:SetText("[COLOR_FaithDark]" .. kPerson.PatronizeWithFaithCost .. "[ENDCOLOR][ICON_Faith]");
-                    instance.FaithButton:SetDisabled(true);
-                end
-
-                instance.FaithButton:SetToolTipString(GetPatronizeWithFaithTT(kPerson));
-                instance.FaithButton:SetVoid1(kPerson.IndividualID);
-                instance.FaithButton:RegisterCallback(Mouse.eLClick, OnFaithButtonClick);
-                instance.FaithButton:SetHide(false);
-            else
-                instance.FaithButton:SetHide(true);
-            end
-
-            -- Recruiting 
-            if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_RECRUIT") and kPerson.CanRecruit and kPerson.RecruitCost ~= nil) then
-                instance.RecruitButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_RECRUIT_DETAILS", kPerson.RecruitCost) );
-                instance.RecruitButton:SetVoid1(kPerson.IndividualID);
-                instance.RecruitButton:RegisterCallback(Mouse.eLClick, OnRecruitButtonClick);
-                instance.RecruitButton:SetHide(false);
-
-              -- Auto scroll to first recruitable person.
-                if kInstanceToShow==nil then
-                    kInstanceToShow = instance;
-                end
-            else
-                instance.RecruitButton:SetHide(true);
-            end
-
-            -- Rejecting
-            if (HasCapability("CAPABILITY_GREAT_PEOPLE_CAN_REJECT") and kPerson.CanReject and kPerson.RejectCost ~= nil) then
-                instance.RejectButton:SetToolTipString( Locale.Lookup("LOC_GREAT_PEOPLE_PASS_DETAILS", kPerson.RejectCost ) );
-                instance.RejectButton:SetVoid1(kPerson.IndividualID);
-                instance.RejectButton:RegisterCallback(Mouse.eLClick, OnRejectButtonClick);
-                instance.RejectButton:SetHide(false);
-            else
-                instance.RejectButton:SetHide(true);
-            end
-
-            -- If Recruit or Reject buttons are shown hide the minimized recruit stack
-            -- CQUI: Do not hide the "Minimized Recruit" Stack (which lists the progress of all of the civs for that Great Person)
-                -- if not instance.RejectButton:IsHidden() or not instance.RecruitButton:IsHidden() then
-            --    instance.RecruitMinimizedStack:SetHide(true);
-            -- else
-            --    instance.RecruitMinimizedStack:SetHide(false);
-            -- end
-            
-            -- Recruiting standings
-            -- Let's sort the table first by points total, then by the lower player id (to push yours toward the top of the list for readability)
-            local recruitTable: table = {};
-            for i, kPlayerPoints in ipairs(data.PointsByClass[kPerson.ClassID]) do
-                table.insert(recruitTable,kPlayerPoints);
-            end
-            table.sort(recruitTable,
-                function (a,b) 
-                    if (a.PointsTotal == b.PointsTotal) then
-                        return a.PlayerID < b.PlayerID;
-                    else
-                        return a.PointsTotal > b.PointsTotal;
-                    end 
-                    end);
-
-            for i, kPlayerPoints in ipairs(recruitTable) do
-                if (kPlayerPoints.PlayerID == Game.GetLocalPlayer()) then
-                    FillRecruitInstance(instance.LocalPlayerRecruitInstance, kPlayerPoints, kPerson, classData);
-                else
-                    local recruitInst:table = instance["m_RecruitIM"]:GetInstance();
-                    FillRecruitInstance(recruitInst, kPlayerPoints, kPerson, classData);
-                    if not CQUI_isPreferredRecruitScrollSizeComputed then
-                        CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + recruitInst.Top:GetSizeY() + 5; -- AZURENCY : 5 is the padding
-                    end
-                end
-
-                local recruitExtendedInst:table = instance["m_RecruitExtendedIM"]:GetInstance();
-                FillRecruitInstance(recruitExtendedInst, kPlayerPoints, kPerson, classData);
-            end
-
-            if not CQUI_isPreferredRecruitScrollSizeComputed then
-                CQUI_isPreferredRecruitScrollSizeComputed = true;
-            end
-
-            if (kPerson.EarnConditions ~= nil and kPerson.EarnConditions ~= "") then
-                instance.RecruitInfo:SetText("[COLOR_Civ6Red]" .. Locale.Lookup("LOC_GREAT_PEOPLE_CANNOT_EARN_PERSON") .. "[ENDCOLOR]");
-                instance.RecruitInfo:SetToolTipString("[COLOR_Civ6Red]" .. kPerson.EarnConditions .. "[ENDCOLOR]");
-                instance.RecruitInfo:SetHide(false);
-            else
-                instance.RecruitInfo:SetHide(true);
-            end
-
-            instance.RecruitScroll:CalculateSize();
-        end
-
-        
-        if kPerson.IndividualID ~= nil then
-            -- Set the biography buttons
-            instance.BiographyBackButton:SetVoid1( kPerson.IndividualID );
-            instance.BiographyBackButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
-            instance.BiographyOpenButton:SetVoid1( kPerson.IndividualID );
-            instance.BiographyOpenButton:RegisterCallback( Mouse.eLClick, OnBiographyClick );
-            
-            -- Setup extended recruit info buttons
-            instance.RecruitInfoOpenButton:SetVoid1( kPerson.IndividualID );
-            instance.RecruitInfoOpenButton:RegisterCallback( Mouse.eLClick, OnRecruitInfoClick );
-            instance.RecruitInfoBackButton:SetVoid1( kPerson.IndividualID );
-            instance.RecruitInfoBackButton:RegisterCallback( Mouse.eLClick, OnRecruitInfoClick );
-
-            m_kGreatPeople[kPerson.IndividualID] = instance; -- Store instance for later look up
-        end
-
-        local noneAvailable :boolean = (kPerson.IndividualID == nil);
-        instance.ClassName:SetHide( noneAvailable );
-        instance.TitleLine:SetHide( noneAvailable );
-        instance.IndividualName:SetHide( noneAvailable );
-        instance.EraName:SetHide( noneAvailable );
-        instance.MainInfo:SetHide( noneAvailable );
-        instance.BiographyBackButton:SetHide( noneAvailable );
-        instance.ClaimedLabel:SetHide( not noneAvailable );
-        instance.BiographyArea:SetHide( true );
-        instance.RecruitInfoArea:SetHide( true );
-        instance.FadedBackground:SetHide( true );
-        instance.BiographyOpenButton:SetHide( noneAvailable );
-        instance.EffectStack:CalculateSize();
-        instance.EffectStackScroller:CalculateSize();
-
-        if (CQUI_isPreferredHeightsComputed == false) then
-            --CQUI_preferredRecruitScrollSize = 1000;  -- for quick testing
-            if (CQUI_preferredRecruitScrollSize > (CQUI_screenHeight / 4)) then
-                CQUI_preferredRecruitScrollSize = (CQUI_screenHeight / 4);
-            end
-
-            -- 670 is the default Instance size in the XML... 86 is a number that represents some undocumented thing
-            CQUI_preferredInstanceSize =  670 - 86 + CQUI_preferredRecruitScrollSize;
-            -- CQUI_preferredInstanceSize = 3000 -- for quick testing
-            if (CQUI_preferredInstanceSize > (CQUI_screenHeight - CQUI_instanceMargin)) then
-                -- The instance area cannot be bigger than the screen height minus CQUI_instanceMargin:
-                -- When the Gold/Faith (or Recruit/Pass) buttons are 5px above the PeopleScroller horizontal scroll, 
-                -- the PanelInstance is CQUI_instanceMargin pixels less in height than the PeopleContainer, which is defined as 768 in the XML.
-                -- These adjustments are necessary to properly fit the screen
-                local prevPreferredInstanceSize = CQUI_preferredInstanceSize;
-                CQUI_preferredInstanceSize = CQUI_screenHeight - CQUI_instanceMargin;
-
-                -- Instead of shrinking the recruit scroll size, instead shrink the EffectsStackScroller, as there's typically room to spare in that section
-                -- 240 is the value defined in the XML.  We cannot do a GetSizeY here because subsequent calls to this function
-                -- would update the smaller value, eventually shrinking the control to less than zero.
-                local effectStackScrollerAdjustment = prevPreferredInstanceSize - CQUI_preferredInstanceSize;
-                CQUI_preferredEffectsScrollSize = 240 - effectStackScrollerAdjustment;
-            end
-
-            CQUI_isPreferredHeightsComputed = true;
-        end
-
-        -- CQUI : change size
-        -- CQUI DEBUG TEST :
-        -- CQUI_preferredRecruitScrollSize = 300;
-        instance.Content:SetSizeY(CQUI_preferredInstanceSize);
-        instance.EffectStackScroller:SetSizeY(CQUI_preferredEffectsScrollSize);
-        instance.RecruitScroll:SetSizeY(CQUI_preferredRecruitScrollSize);
+        AddRecruit(data, kPerson);
     end
 
-    -- CQUI : change size
-    --CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + 32 + 28 + 48 + 28 ;
+    -- CQUI : change size.  CQUI_preferredRecruitScrollSize and the like were calculated in the AddRecruit function
+    -- CQUI_preferredRecruitScrollSize = CQUI_preferredRecruitScrollSize + 32 + 28 + 48 + 28 ;
     -- CQUI : 22 our LocalPlayerRecruitInstance, 28 Recruit progress title, 48 buttons, 28 distance from scroll bar to edge of PeopleScroller control
     Controls.CQUI_RecruitWoodPaneling:SetSizeY(CQUI_preferredRecruitScrollSize + CQUI_lowerPanelAdditionalHeight); 
 
@@ -531,8 +561,8 @@ function ViewPast( data:table )
         UI.DataError("GreatPeople attempting to view past timeline data but received NIL instead.");
         return;
     end
-    
-    m_greatPersonRowIM:ResetInstances();
+
+    ResetGreatPeopleInstances();
     Controls.PeopleScroller:SetHide(true);
     Controls.RecruitedArea:SetHide(false);
 
@@ -561,6 +591,7 @@ function ViewPast( data:table )
             UI.DataError("GreatPeople previous recruited as unable to find the class text for #"..tostring(i));
         end
         instance.ClassName:SetText( Locale.ToUpper(classText) );
+        instance.ClassName:SetHide(false); --  TODO: CQUI didn't have this previously???
         instance.GreatPersonInfo:SetText( kPerson.Name )
         DifferentiateCiv(kPerson.ClaimantID, instance.CivIcon, instance.CivIcon, instance.CivIndicator, nil, nil, localPlayerID);
         instance.RecruitedImage:SetHide(true);
@@ -942,7 +973,8 @@ end
 --  LUA Event
 -- =======================================================================================
 function OnOpenViaNotification()
-    Open();        
+    Open();
+    SelectTab( m_pGreatPeopleTabInstance.Button );
 end
 
 -- =======================================================================================
@@ -1056,46 +1088,60 @@ end
 
 
 -- ===========================================================================
---  
+function Refresh( newRefreshFunc:ifunction )
+    -- Update the refresh function if passed in a new one
+    if newRefreshFunc ~= nil then
+        m_RefreshFunc = newRefreshFunc;
+    end
+
+    -- Call current refresh function
+    if m_RefreshFunc ~= nil then
+        m_RefreshFunc();
+    end
+end
+
 -- ===========================================================================
-function Refresh()
+function RefreshCurrentGreatPeople()
     local kData :table = {
         Timeline       = {},
         PointsByClass  = {},
     };        
-    if m_tabs.selectedControl == Controls.ButtonPreviouslyRecruited then
-        PopulateData(kData, true);  -- use past data
-        ViewPast(kData);
-    else
-        PopulateData(kData, false);  -- do not use past data
-        ViewCurrent(kData);
-    end
+
+    PopulateData(kData, false);  -- do not use past data
+    ViewCurrent(kData);
 
     m_kData = kData;
 end
 
-
-
 -- ===========================================================================
---  Tab callback
--- ===========================================================================
-function OnGreatPeopleClick()
-    Controls.SelectGreatPeople:SetHide( false );
-    Controls.ButtonGreatPeople:SetSelected( true );
-    Controls.SelectPreviouslyRecruited:SetHide( true );
-    Controls.ButtonPreviouslyRecruited:SetSelected( false );
-    Refresh();
+function RefreshPreviousGreatPeople()
+    local kData :table = {
+        Timeline       = {},
+        PointsByClass  = {},
+    };        
+
+    PopulateData(kData, true);  -- use past data
+    ViewCurrent(kData);
+
+    m_kData = kData;
 end
 
 -- ===========================================================================
 --  Tab callback
 -- ===========================================================================
-function OnPreviousRecruitedClick()
-    Controls.SelectGreatPeople:SetHide( true );
-    Controls.ButtonGreatPeople:SetSelected( false );
-    Controls.SelectPreviouslyRecruited:SetHide( false );
-    Controls.ButtonPreviouslyRecruited:SetSelected( true );
-    Refresh();
+function OnGreatPeopleClick( uiSelectedButton:table )
+    ResetTabButtons();
+    SetTabButtonsSelected(uiSelectedButton);
+    Refresh(RefreshCurrentGreatPeople);
+end
+
+-- ===========================================================================
+--  Tab callback
+-- ===========================================================================
+function OnPreviousRecruitedClick( uiSelectedButton:table )
+    ResetTabButtons();
+    SetTabButtonsSelected(uiSelectedButton);
+    Refresh(RefreshPreviousGreatPeople);
 end
 
 -- ===========================================================================
@@ -1109,6 +1155,7 @@ end
 --  UI Event
 -- =======================================================================================
 function OnInit( isHotload:boolean )
+    LateInitialize();
     if isHotload then
         LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);
     end
@@ -1138,6 +1185,21 @@ end
 function OnShutdown()
     LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "isHidden",      ContextPtr:IsHidden() );
     LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "isPreviousTab", (m_tabs.selectedControl == Controls.ButtonPreviouslyRecruited) );
+
+    m_tabButtonIM:ResetInstances();
+
+    -- Game engine Events	
+    Events.LocalPlayerChanged.Remove( OnLocalPlayerChanged );
+    Events.LocalPlayerTurnBegin.Remove( OnLocalPlayerTurnBegin );
+    Events.LocalPlayerTurnEnd.Remove( OnLocalPlayerTurnEnd );
+    Events.UnitGreatPersonActivated.Remove( OnUnitGreatPersonActivated );
+    Events.GreatPeoplePointsChanged.Remove( OnGreatPeoplePointsChanged );
+
+    -- LUA Events
+    LuaEvents.GameDebug_Return.Remove( OnGameDebugReturn );
+    LuaEvents.LaunchBar_OpenGreatPeoplePopup.Remove( OnOpenViaLaunchBar );
+    LuaEvents.NotificationPanel_OpenGreatPeoplePopup.Remove( OnOpenViaNotification );
+    LuaEvents.LaunchBar_CloseGreatPeoplePopup.Remove( OnClose );
 end
 
 -- ===========================================================================
@@ -1158,6 +1220,63 @@ function OnGameDebugReturn( context:string, contextTable:table )
 end
 
 -- =======================================================================================
+function AddTabInstance( buttonText:string, callbackFunc:ifunction )
+    local kInstance:object = m_tabButtonIM:GetInstance();
+    kInstance.Button:SetText(Locale.Lookup(buttonText));
+    kInstance.Button:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
+    m_tabs.AddTab( kInstance.Button, callbackFunc );
+    m_numTabs = m_numTabs + 1;
+    return kInstance;
+end
+
+-- =======================================================================================
+function SelectTab( buttonControl:table )
+    m_tabs.SelectTab(buttonControl);
+end
+
+-- =======================================================================================
+function SetTabButtonsSelected( buttonControl:table )
+    for i=1, m_tabButtonIM.m_iCount, 1 do
+        local buttonInstance:table = m_tabButtonIM:GetAllocatedInstance(i);
+        if buttonInstance and buttonInstance.Button == buttonControl then
+            buttonInstance.Button:SetSelected(true);
+            buttonInstance.SelectButton:SetHide(false);
+        end
+    end
+end
+
+-- =======================================================================================
+function ResetTabButtons()
+    for i=1, m_tabButtonIM.m_iCount, 1 do
+        local buttonInstance:table = m_tabButtonIM:GetAllocatedInstance(i);
+        if buttonInstance then
+            buttonInstance.Button:SetSelected(false);
+            buttonInstance.SelectButton:SetHide(true);
+        end
+    end
+end
+
+-- =======================================================================================
+function ResizeTabContainer()
+    if m_numTabs > 0 then
+        local desiredSize = (TAB_SIZE * m_numTabs) + (TAB_PADDING * (m_numTabs - 1));
+        Controls.TabContainer:SetSizeX(desiredSize);
+    end
+end
+
+-- =======================================================================================
+-- This function should be overridden in mods/dlc to add new tabs to this screen
+-- =======================================================================================
+function AddCustomTabs()
+    -- No custom tabs in base games
+end
+
+-- =======================================================================================
+function LateInitialize()
+  -- Basegame code has an empty function
+end
+
+-- =======================================================================================
 --
 -- =======================================================================================
 function Initialize()
@@ -1167,12 +1286,20 @@ function Initialize()
         return;
     end
 
+    m_numTabs = 0;
+
     -- Tab setup and setting of default tab.
     m_tabs = CreateTabs( Controls.TabContainer, 42, 34, UI.GetColorValueFromHexLiteral(0xFF331D05) );
-    m_tabs.AddTab( Controls.ButtonGreatPeople,         OnGreatPeopleClick );
-    m_tabs.AddTab( Controls.ButtonPreviouslyRecruited, OnPreviousRecruitedClick );
+    m_pGreatPeopleTabInstance = AddTabInstance("LOC_GREAT_PEOPLE_TAB_GREAT_PEOPLE", OnGreatPeopleClick);
+    m_pPrevRecruitedTabInstance = AddTabInstance("LOC_GREAT_PEOPLE_TAB_PREVIOUSLY_RECRUITED", OnPreviousRecruitedClick);
+
+    AddCustomTabs();
+
+    ResizeTabContainer();
+
     m_tabs.CenterAlignTabs(-10);
-    m_tabs.SelectTab( Controls.ButtonGreatPeople );
+    m_tabs.SelectTab( m_pGreatPeopleTabInstance.Button );
+
 
     -- UI Events
     ContextPtr:SetInitHandler( OnInit );
@@ -1197,11 +1324,13 @@ function Initialize()
     LuaEvents.LaunchBar_OpenGreatPeoplePopup.Add(         OnOpenViaLaunchBar );
     LuaEvents.NotificationPanel_OpenGreatPeoplePopup.Add( OnOpenViaNotification );
     LuaEvents.LaunchBar_CloseGreatPeoplePopup.Add(        OnClose );
-    
-    -- Audio Events
-    Controls.ButtonGreatPeople:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
-    Controls.ButtonPreviouslyRecruited:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
 
     m_TopPanelConsideredHeight = Controls.Vignette:GetSizeY() - TOP_PANEL_OFFSET;
 end
+
+-- This wildcard include will include all loaded files beginning with "GreatPeoplePopup_"
+-- This method replaces the uses of include("GreatPeoplePopup") in files that want to override 
+-- functions from this file. If you're implementing a new "GreatPeoplePopup_" file DO NOT include this file.
+include("GreatPeoplePopup_", true);
+
 Initialize();

--- a/Assets/UI/Popups/greatpeoplepopup.lua
+++ b/Assets/UI/Popups/greatpeoplepopup.lua
@@ -521,7 +521,6 @@ function FillRecruitInstance(instance:table, playerPoints:table, personData:tabl
 
     instance.Amount:SetText( "(+" .. tostring(Round(playerPoints.PointsPerTurn,1)) .. ") " .. tostring(recruitTurnsLeft) .. "[ICON_Turn]");
 
-
     local progressPercent :number = Clamp( playerPoints.PointsTotal / personData.RecruitCost, 0, 1 );
     instance.ProgressBar:SetPercent( progressPercent );
     
@@ -1118,7 +1117,7 @@ function RefreshPreviousGreatPeople()
     };        
 
     PopulateData(kData, true);  -- use past data
-    ViewCurrent(kData);
+    ViewPast(kData);
 
     m_kData = kData;
 end

--- a/Assets/UI/Popups/greatpeoplepopup.xml
+++ b/Assets/UI/Popups/greatpeoplepopup.xml
@@ -5,7 +5,6 @@
 
     <Container ID="PopupContainer" Anchor="C,C" Size="parent,768">
         <ScrollPanel ID="PeopleScroller" Offset="0,0" Size="parent,parent" Vertical="0" AutoScrollBar="1">
-
             <!-- CQUI : new textures that adapt the height -->
             <Image ID="CQUI_ContentWoodPaneling" Size="214,parent" Texture="CQUI_GreatPeople_Background_Repeat_Top.dds" StretchMode="Tile"/>
             <Image ID="WoodPaneling" Size="214,547" Texture="CQUI_GreatPeople_Background_Top.dds" StretchMode="TileX"/>
@@ -15,9 +14,6 @@
             <!-- This image is the bottom of the paneling outline (curved corner and horizontal line) -->
             <!-- At 40px tall, it has 5px gap between the bottom horizontal line and the PeopleScroller scroll bar, must be at least 40px in height -->
             <Image ID="CQUI_BottomWoodPaneling" Size="214,40" Texture="CQUI_GreatPeople_Background_Bottom.dds" StretchMode="TileX" Anchor="L,B" />
-
-
-
             <Stack ID="PeopleStack" Offset="0,78" StackGrowth="Right" StackPadding="0" />
             <ScrollBar Anchor="L,B" Offset="0,10" Size="parent-10,8" Style="ScrollHorizontalBackingAlt">
                 <Thumb Style="ScrollThumbHAlt" />
@@ -25,13 +21,13 @@
 
             <Tutorial ID="GPAbilityPointer" Style="TutorialContainer" Anchor="L,C" Offset="410,70" TriggerBy="TutorialGPAbilityPointer">
                 <SlideAnim Start="110,-40" EndOffset="30,0" Cycle="Bounce" Function="OutQuad">
-                    <Image Texture="Tutorial_ArrowH" Size="58,44" />
+                    <Image Texture="Tutorial_ArrowH" Size="58,44" Offset="25,-90"/>
                 </SlideAnim>
             </Tutorial>
 
             <Tutorial ID="GPCostPointer" Style="TutorialContainer" Anchor="L,C" Offset="410,270" TriggerBy="TutorialGPCostPointer">
                 <SlideAnim Start="110,-40" EndOffset="30,0" Cycle="Bounce" Function="OutQuad">
-                    <Image Texture="Tutorial_ArrowH" Size="58,44" />
+                    <Image Texture="Tutorial_ArrowH" Size="58,44" Offset="45,111"/>
                 </SlideAnim>
             </Tutorial>
         </ScrollPanel>
@@ -55,18 +51,12 @@
         </Box>
 
         <!-- Tabs -->
-        <Container Anchor="C,T" Offset="0,30" Size="400,61">
-            <Image Anchor="C,C" Size="439,27" Texture="Controls_TabLedge2_Fill" StretchMode="Tile" />
-            <Grid Anchor="C,T" Size="580,61" Texture="Controls_TabLedge2" SliceCorner="194,18" SliceSize="52,26" SliceTextureSize="438,61">
-                <Container ID="TabContainer" Offset="50,13" Size="parent-80,34">
-                    <GridButton ID="ButtonGreatPeople" Size="170,34" Style="TabButton" FontSize="14" TextOffset="0,2" String="LOC_GREAT_PEOPLE_TAB_GREAT_PEOPLE">
-                        <GridButton ID="SelectGreatPeople" Size="parent,parent" Style="TabButtonSelected" ConsumeMouseButton="0" ConsumeMouseOver="1" />
-                    </GridButton>
-                    <GridButton ID="ButtonPreviouslyRecruited" Size="170,34" Style="TabButton" FontSize="14" TextOffset="0,2" String="LOC_GREAT_PEOPLE_TAB_PREVIOUSLY_RECRUITED">
-                        <GridButton ID="SelectPreviouslyRecruited" Size="parent,parent" Style="TabButtonSelected" ConsumeMouseButton="0" ConsumeMouseOver="1" />
-                    </GridButton>
-                </Container>
-            </Grid>
+        <Container Anchor="C,T" Offset="0,48" Size="auto,61">
+            <Image Anchor="C,T" Size="auto,27" AutoSizePadding="-100,0" Texture="Controls_TabLedge2_Fill" StretchMode="Tile">
+                <Grid Anchor="C,T" Offset="0,-17" Size="auto,61" AutoSizePadding="100,0" Texture="Controls_TabLedge2" SliceCorner="194,18" SliceSize="52,26" SliceTextureSize="438,61">
+                    <Container ID="TabContainer" Anchor="C,T" Offset="0,13" Size="0,34"/>
+                </Grid>
+            </Image>
         </Container>
 
         <!-- Place the modal screen controls in a separate container; this uses a custom background inside of the scroll panel. -->
@@ -218,5 +208,11 @@
                 <Image ID="CivIcon" Anchor="C,C" Texture="CivSymbols22" Size="22,22"/>
             </Image>
         </Container>
+    </Instance>
+
+    <Instance Name="TabButtonInstance">
+        <GridButton ID="Button" Anchor="L,T" Size="170,34" Style="TabButton" FontSize="14" TextOffset="0,2">
+            <GridButton ID="SelectButton" Size="parent,parent" Style="TabButtonSelected" ConsumeMouseButton="0" ConsumeMouseOver="1" Hidden="1"/>
+        </GridButton>
     </Instance>
 </Context>

--- a/Assets/UI/supportfunctions.lua
+++ b/Assets/UI/supportfunctions.lua
@@ -110,6 +110,54 @@ function TruncateStringByLength( textString, textLen )
     return textString;
 end
 
+-- ===========================================================================
+--	Given a table of strings, format it as a single string separated by spaces.
+-- ===========================================================================
+function FormatTableAsString( tStringTable:table)
+    if tStringTable == nil or #tStringTable == 0 then
+        return "";
+    end
+    local sFormattedString:string = "";
+    for i,line in ipairs(tStringTable) do
+        if (line ~= nil and line ~= "") then
+            if (sFormattedString ~= "") then
+                sFormattedString = sFormattedString .. " ";
+            end
+            sFormattedString = sFormattedString .. Locale.Lookup(line);
+        end
+    end
+    
+    return sFormattedString;
+end
+
+-- ===========================================================================
+--	Given a table of strings, format it as a single string separated by 
+--	line breaks. Optional bool uses two-line breaks.
+-- ===========================================================================
+function FormatTableAsNewLineString( tStringTable:table, bDoubleLines:boolean )
+    if tStringTable == nil or #tStringTable == 0 then
+        return "";
+    end
+    bDoubleLines = bDoubleLines or false;
+
+    local sFormattedString:string = "";
+    for i,line in ipairs(tStringTable) do
+        if (line ~= nil and line ~= "") then
+            if (sFormattedString ~= "") then
+                if bDoubleLines == true then
+                    sFormattedString = sFormattedString .. "[NEWLINE][NEWLINE]";
+                else
+                    sFormattedString = sFormattedString .. "[NEWLINE]";
+                end
+            end
+            sFormattedString = sFormattedString .. Locale.Lookup(line);
+        end
+    end
+    
+    return sFormattedString;
+end
+
+
 -- Wraps a string according to the provided length, but, unlike the built in wrapping, will ignore the limit if a single continuous word exceeds the length of the wrap width
 function CQUI_SmartWrap( textString, wrapWidth )
     local lines = {""}; --Table that holds each individual line as it's build
@@ -466,6 +514,40 @@ function RandRange(min:number, max:number, logString:string)
         return min;
     end
 end
+
+-- ===========================================================================
+--	RandWeight()
+--	Performs a weighted random roll and returns a row from rollTable.  
+--  NOTE: Only table elements in rollTable that have a "Weight" value will be eligable for the roll.
+-- ===========================================================================
+function RandWeight(rollTable :table, logString:string)
+    if (Game.GetRandNum == nil) then
+        print("Error: missing GetRandNum!");
+        return rollTable[1];
+    end
+
+    local totalWeight = 0;
+    for _, totalRow in ipairs(rollTable) do
+        if(totalRow.Weight ~= nil) then
+            totalWeight = totalWeight + totalRow.Weight;
+        end
+    end
+
+    local randNum = Game.GetRandNum(totalWeight, logString);
+    for _, rollRow in ipairs(rollTable) do
+        if(rollRow.Weight ~= nil) then
+            randNum = randNum - rollRow.Weight;
+            if (randNum < 0) then
+                -- This row's weight puts the rand number into the negative.  This is the selected row!
+                return rollRow;
+            end
+        end
+    end
+
+    print("Error: no rollRow found! This shouldn't be possible.");
+    return rollTable[1];
+    end
+
 
 -- ===========================================================================
 --  Triangular()


### PR DESCRIPTION
edit: I annotated the greatpeoplepopup.lua file -- it is almost entirely just copy/paste of the Firaxis code in their version of the greatpeoplepopup.  I would like to get this uploaded to the Steam site sooner than later, hopefully @alexeyOnGitHub or @Infixo are around?

This is a bit of a mess, but it's that way because this is one of the files that we have to replace entirely in order to do the stuff we want CQUI to do, with the dynamic panel sizing.
**What this does**
- Adds the Heroes button and tab to the Great People panel (like basegame)
- Makes the Heroes tab functional

**What this does not**
- Make the heroes tab look pretty.  We should do a separate issue and change to handle that stuff.

**What changed**
- greatpeoplepopup.lua updated to incorporate recent changes from Firaxis
- missing functions from SupportFunctions.lua were added (we need to put the CQUI-specific stuff that is in that file somewhere else and *not* overwrite that file... but that's a different PR)
  - When stuff breaks in SupportFunctions, it often does NOT show up on the LiveTuner, which makes for tough sledding when trying to debug

**Tested?**
I played some turns and recruited more heroes using the save game from @loks1234.  Screen shots below are from that game, running CQUI and whatever other mods were required for that save game.

This is from a game with 8 total players, so the height of the Recruit panel is set accordingly:
![image](https://user-images.githubusercontent.com/8787640/100219838-5d179f00-2ecb-11eb-8ed5-599627da1fe5.png)

![image](https://user-images.githubusercontent.com/8787640/100219856-630d8000-2ecb-11eb-98b3-6efffe0920b6.png)
