### PR TITLE
added hotkeys: "rest and heal", "spread religion", "remove heresy"

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -330,6 +330,9 @@
     <Row Tag="LOC_CQUI_SPREAD_RELIGION" Language="en_US">
       <Text>Spread religion</Text>
     </Row>
+    <Row Tag="LOC_CQUI_REMOVE_HERESY" Language="en_US">
+      <Text>Remove heresy</Text>
+    </Row>
     <Row Tag="LOC_CQUI_RELIGIOUS_HEAL" Language="en_US">
       <Text>Religious heal</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -333,8 +333,8 @@
     <Row Tag="LOC_CQUI_REMOVE_HERESY" Language="en_US">
       <Text>Remove heresy</Text>
     </Row>
-    <Row Tag="LOC_CQUI_RELIGIOUS_HEAL" Language="en_US">
-      <Text>Religious heal</Text>
+    <Row Tag="LOC_CQUI_REST_HEAL" Language="en_US">
+      <Text>Rest and heal</Text>
     </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -327,5 +327,11 @@
     <Row Tag="LOC_CQUI_LENSES_RELIGIONLENSUNITFLAGSTYLE_TOOLTIP" Language="en_US">
       <Text>The style for unit flag icons of non-Religious units[NEWLINE]when the Religion Lens is on[NEWLINE]Solid: Unit Flags remain visible, unchanged[NEWLINE]Transparent: Unit Flags become transparent[NEWLINE]Hidden:Unit flags are hidden</Text>
     </Row>
+    <Row Tag="LOC_CQUI_SPREAD_RELIGION" Language="en_US">
+      <Text>Spread religion</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_RELIGIOUS_HEAL" Language="en_US">
+      <Text>Religious heal</Text>
+    </Row>
   </LocalizedText>
 </GameData>

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -246,7 +246,8 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
-    if action["SPREAD_RELIGION"] and CQUI_UnitSupportsSpreadingReligion(unitType) then
+    local bCanSpreadReligion = selectedUnit and UnitManager.CanStartOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash, nil, true);
+    if action["SPREAD_RELIGION"] and bCanSpreadReligion then
         UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash);
         cquiHandledKey = true;
     end

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -246,10 +246,13 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
-    if (action["SPREAD_RELIGION"]
-        and
-        (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
+    if action["SPREAD_RELIGION"] and CQUI_UnitSupportsSpreadingReligion(unitType) then
         UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash);
+        cquiHandledKey = true;
+    end
+
+    if action["REMOVE_HERESY"] and unitType == "UNIT_INQUISITOR" then
+        UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REMOVE_HERESY"].Hash);
         cquiHandledKey = true;
     end
 
@@ -691,6 +694,12 @@ function CQUI_BuildImprovement (unit, improvementHash: number)
     tParameters[UnitOperationTypes.PARAM_IMPROVEMENT_TYPE] = improvementHash;
 
     UnitManager.RequestOperation( unit, UnitOperationTypes.BUILD_IMPROVEMENT, tParameters );
+end
+
+-- you can get unit type by calling
+-- GameInfo.Units[selectedUnit:GetUnitType()].UnitType;
+function CQUI_UnitSupportsSpreadingReligion(unitType)
+  return unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE"
 end
 
 -- ===========================================================================

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -251,7 +251,8 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
-    if action["REMOVE_HERESY"] and unitType == "UNIT_INQUISITOR" then
+    local bCanRemoveHeresy = selectedUnit and UnitManager.CanStartOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REMOVE_HERESY"].Hash, nil, true);
+    if action["REMOVE_HERESY"] and bCanRemoveHeresy then
         UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REMOVE_HERESY"].Hash);
         cquiHandledKey = true;
     end

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -256,7 +256,7 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
-    if (action["RELIGIOS_HEAL"]
+    if (action["RELIGIOUS_HEAL"]
         and
         (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
         UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REST_REPAIR"].Hash);

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -114,7 +114,7 @@ function DefaultKeyUpHandler( uiKey:number )
         if uiKey == Keys.VK_SHIFT then
             CQUI_isShiftDown = false;
         end
-    
+
         if uiKey == Keys.VK_ALT then
             CQUI_isAltDown = false;
         end
@@ -178,7 +178,7 @@ function DefaultKeyUpHandler( uiKey:number )
         CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), GameInfo.Improvements["IMPROVEMENT_MINE"].Hash);
         cquiHandledKey = true;
     end
-    
+
     if (action["NUKE"] or action["THERMO_NUKE"]) then
         local bCanStartWmdStrike = selectedUnit and UnitManager.CanStartOperation(selectedUnit, UnitOperationTypes.WMD_STRIKE, nil, true);
         if (bCanStartWmdStrike) then
@@ -246,6 +246,20 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
+    if (action["SPREAD_RELIGION"]
+        and
+        (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
+        CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash);
+        cquiHandledKey = true;
+    end
+
+    if (action["RELIGIOS_HEAL"]
+        and
+        (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
+        CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), GameInfo.UnitOperations["UNITOPERATION_RELIGIOUS_HEAL"].Hash);
+        cquiHandledKey = true;
+    end
+
     if uiKey == Keys.VK_SHIFT then
         -- We need to let the base function also handle the Shift Up action
         CQUI_isShiftDown = false;
@@ -282,7 +296,7 @@ function RealizeMovementPath(showQueuedPath:boolean, unitID:number)
     -- Largely the same as the base RealizeMovementPath, save for the additional unitID parameter
     -- The unitID allows CQUI to show the movement path when a unit is hovered over (base game returns because no unit is actually selected)
     -- Note: Adding the "show movement path on hover" mechanism means that this function cannot be extended and therefore must be replaced entirely
-    
+
     if not UI.IsMovementPathOn() or UI.IsGameCoreBusy() then
         return;
     end

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -258,9 +258,8 @@ function DefaultKeyUpHandler( uiKey:number )
         cquiHandledKey = true;
     end
 
-    if (action["RELIGIOUS_HEAL"]
-        and
-        (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
+    local bCanRestHeal = selectedUnit and UnitManager.CanStartOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REST_REPAIR"].Hash, nil, true);
+    if action["REST_HEAL"] and bCanRestHeal then
         UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REST_REPAIR"].Hash);
         cquiHandledKey = true;
     end

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -256,7 +256,7 @@ function DefaultKeyUpHandler( uiKey:number )
     if (action["RELIGIOS_HEAL"]
         and
         (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
-        UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_RELIGIOUS_HEAL"].Hash);
+        UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_REST_REPAIR"].Hash);
         cquiHandledKey = true;
     end
 

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -697,12 +697,6 @@ function CQUI_BuildImprovement (unit, improvementHash: number)
     UnitManager.RequestOperation( unit, UnitOperationTypes.BUILD_IMPROVEMENT, tParameters );
 end
 
--- you can get unit type by calling
--- GameInfo.Units[selectedUnit:GetUnitType()].UnitType;
-function CQUI_UnitSupportsSpreadingReligion(unitType)
-  return unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE"
-end
-
 -- ===========================================================================
 -- CQUI: Initialize Function
 -- ===========================================================================

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -249,14 +249,14 @@ function DefaultKeyUpHandler( uiKey:number )
     if (action["SPREAD_RELIGION"]
         and
         (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
-        CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash);
+        UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_SPREAD_RELIGION"].Hash);
         cquiHandledKey = true;
     end
 
     if (action["RELIGIOS_HEAL"]
         and
         (unitType == "UNIT_MISSIONARY" or unitType == "UNIT_APOSTLE")) then
-        CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), GameInfo.UnitOperations["UNITOPERATION_RELIGIOUS_HEAL"].Hash);
+        UnitManager.RequestOperation(selectedUnit, GameInfo.UnitOperations["UNITOPERATION_RELIGIOUS_HEAL"].Hash);
         cquiHandledKey = true;
     end
 

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -203,6 +203,7 @@ INSERT OR REPLACE INTO CQUI_Bindings -- Don't touch this line!
         ("NUKE", "N", "LOC_CQUI_NUKE"),
         ("THERMO_NUKE", "Alt+N", "LOC_CQUI_THERMO_NUKE"),
         ("SPREAD_RELIGION", "R", "LOC_CQUI_SPREAD_RELIGION"),
+        ("REMOVE_HERESY", "R", "LOC_CQUI_REMOVE_HERESY"),
         ("RELIGIOS_HEAL", "H", "LOC_CQUI_RELIGIOUS_HEAL"),
         ("REBASE", "Alt+R", "LOC_CQUI_REBASE"),
         ("PLACE_PIN", "Shift+P", "LOC_CQUI_PLACE_PIN");

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -202,5 +202,7 @@ INSERT OR REPLACE INTO CQUI_Bindings -- Don't touch this line!
         ("BUILD_MINE", "N", "LOC_CQUI_BUILD_MINE"),
         ("NUKE", "N", "LOC_CQUI_NUKE"),
         ("THERMO_NUKE", "Alt+N", "LOC_CQUI_THERMO_NUKE"),
+        ("SPREAD_RELIGION", "R", "LOC_CQUI_SPREAD_RELIGION"),
+        ("RELIGIOS_HEAL", "H", "LOC_CQUI_RELIGIOUS_HEAL"),
         ("REBASE", "Alt+R", "LOC_CQUI_REBASE"),
         ("PLACE_PIN", "Shift+P", "LOC_CQUI_PLACE_PIN");

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -204,6 +204,6 @@ INSERT OR REPLACE INTO CQUI_Bindings -- Don't touch this line!
         ("THERMO_NUKE", "Alt+N", "LOC_CQUI_THERMO_NUKE"),
         ("SPREAD_RELIGION", "R", "LOC_CQUI_SPREAD_RELIGION"),
         ("REMOVE_HERESY", "R", "LOC_CQUI_REMOVE_HERESY"),
-        ("RELIGIOS_HEAL", "H", "LOC_CQUI_RELIGIOUS_HEAL"),
+        ("RELIGIOUS_HEAL", "H", "LOC_CQUI_RELIGIOUS_HEAL"),
         ("REBASE", "Alt+R", "LOC_CQUI_REBASE"),
         ("PLACE_PIN", "Shift+P", "LOC_CQUI_PLACE_PIN");

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -204,6 +204,6 @@ INSERT OR REPLACE INTO CQUI_Bindings -- Don't touch this line!
         ("THERMO_NUKE", "Alt+N", "LOC_CQUI_THERMO_NUKE"),
         ("SPREAD_RELIGION", "R", "LOC_CQUI_SPREAD_RELIGION"),
         ("REMOVE_HERESY", "R", "LOC_CQUI_REMOVE_HERESY"),
-        ("RELIGIOUS_HEAL", "H", "LOC_CQUI_RELIGIOUS_HEAL"),
+        ("REST_HEAL", "H", "LOC_CQUI_REST_HEAL"),
         ("REBASE", "Alt+R", "LOC_CQUI_REBASE"),
         ("PLACE_PIN", "Shift+P", "LOC_CQUI_PLACE_PIN");


### PR DESCRIPTION
This adds the following hotkeys:
* R for Religious Spread (currently for Missionaries and Apostles, in Dec 2020)
* R for Inquisitors - remove heresy / spread religion
* H for "rest and heal"

tested this by selecting a missionary unit and pressing "R" next to a city - observed the unit spreading religion.
also, UnitOperations.log file has this log record:

`229, Adding, 0, UNIT_MISSIONARY (8716290), UNITOPERATION_SPREAD_RELIGION (38)
`

tested the religious heal by moving a damaged apostle unit next to a holy site and pressing "H" - observed the unit to go into sleeping (I assume healing) mode.
UnitOperations.log shows:
`229, Adding, 0, UNIT_APOSTLE (4063245), UNITOPERATION_REST_REPAIR (33)
`

similarly - spreading religion with an apostle unit: pressed "R" - 

`229, Adding, 0, UNIT_APOSTLE (3407891), UNITOPERATION_SPREAD_RELIGION (38)`
