### PR TITLE
Check for CQUI-created controls before accessing them; other minor changes

### DIFF
--- a/Assets/Expansion2/CityBanners/CityBannerInstances.xml
+++ b/Assets/Expansion2/CityBanners/CityBannerInstances.xml
@@ -2,7 +2,7 @@
     <!-- CQUI CityBannerInstances Replacement File -->
     <!-- Note: This file only loads in Linux if naming and casing is CityBannerInstances.xml -->
     <!-- See note in citybannermanager.xml regarding this hidden container below -->
-    <Container ID="CQUI_EmptyContainer_CityBannerInstances_Exp2" />
+    <Container ID="CQUI_EmptyContainer_CityBannerInstances_Exp2" Hidden="1"/>
 
     <!-- Include info panels that attach to the bottom of CityBanner -->
     <Include File="CityLoyaltyInstances"/>

--- a/Assets/UI/DiplomacyDealView_CQUI.lua
+++ b/Assets/UI/DiplomacyDealView_CQUI.lua
@@ -219,11 +219,9 @@ function CQUI_RenderResourceButton(resource, resourceCategory, iconList, howAcqu
     icon.AmountText:SetColor(UI.GetColorValue(194/255,194/255,204/255)); -- Color : BodyTextCool
     icon.SelectButton:SetTexture("Controls_DraggableButton");
     icon.SelectButton:SetTextureOffsetVal(0, 0);
-    local hideImportantIcon = true;
 
     if (resourceCategory == 'scarce') then
         icon.AmountText:SetColor(UI.GetColorValue(224/255,124/255,124/255,230/255));
-        hideImportantIcon = false;
     elseif (resourceCategory == 'duplicate') then
         icon.SelectButton:SetAlpha(.8);
         icon.AmountText:SetColor(UI.GetColorValue(124/255,154/255,224/255,230/255));
@@ -235,11 +233,6 @@ function CQUI_RenderResourceButton(resource, resourceCategory, iconList, howAcqu
         buttonDisabled = true;
     else
         icon.SelectButton:SetTextureOffsetVal(0, 50);
-    end
-
-    -- CQUI added the "Important" icon, it will not be nil if the CQUI version of the XML is loaded
-    if (icon.Important ~= nil) then
-        icon.Important:SetHide(hideImportantIcon);
     end
 
     SetIconToSize(icon.Icon, "ICON_" .. resourceDesc.ResourceType);
@@ -746,7 +739,7 @@ function PopulateAvailableGreatWorks(player : table, iconList : table)
 end
 
 -- ===========================================================================
-    -- We need to clear hide the important icon and reset the text color (properties only CQUI will set)
+    -- We need to reset the text color as it does not get reset if an instance is next used for gold or diplomatic favor
     -- Note: Calling ResetInstances just puts the already-allocated instances into an available list and does NOT reset these properties changed by CQUI
 function CQUI_CleanAllocatedInstances()
     for i=1, #g_IconOnlyIM.m_AllocatedInstances, 1 do
@@ -756,10 +749,6 @@ function CQUI_CleanAllocatedInstances()
         -- Reset these as well, because it appears it is not always cleared as it should be if that instance ends up as the diplomatic favor or gold button
         inst.UnacceptableIcon:SetHide(true);
         inst.RemoveButton:SetHide(true);
-        -- Important only exists if the CQUI DiplomacyDealView XML was loaded
-        if (inst.Important ~= nil) then
-            inst.Important:SetHide(true);
-        end
     end
 end
 
@@ -784,6 +773,7 @@ function CQUI_OnShowMakeDemand(otherPlayerID)
 end
 
 -- ===========================================================================
+local CQUI_IssuedMissingXMLWarning = false;
 function CQUI_IsCQUIXmlLoaded()
     -- Check and see if the Controls unique to CQUI are not-nil, and if so, the CQUI DiplomacyDealView XML must be loaded
     isCquiXmlActive = true;
@@ -793,6 +783,12 @@ function CQUI_IsCQUIXmlLoaded()
     isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerCivIcon ~= nil);
     isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerLeaderName ~= nil);
     isCquiXmlActive = isCquiXmlActive and (Controls.OtherPlayerCivName ~= nil);
+
+    if (isCquiXmlActive == false and CQUI_IssuedMissingXMLWarning == false) then
+        -- Prints in the log once, so we don't spam the thing
+        print("****** CQUI ERROR: It appears the CQUI version of the DiplomacyDealView XML file did not load properly!  CQUI effects cannot be applied!");
+        CQUI_IssuedMissingXMLWarning = true;
+    end
 
     return isCquiXmlActive;
 end

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -43,7 +43,7 @@ function CQUI_SelectRightTab()
     end
 end
 
-function CQUI_ToogleManager()
+function CQUI_ToggleManager()
     if CQUI_ManagerShowing then
         CQUI_ManagerShowing = false;
         OnTabChangeQueue();
@@ -262,7 +262,10 @@ end
 function PopulateGenericItemData( kInstance:table, kItem:table )
     BASE_PopulateGenericItemData(kInstance, kItem);
 
-    local notEnoughGoldColor = UI.GetColorValueFromHexLiteral(0x9F1F1FFF);
+    local purchaseGoldFaithColor = UI.GetColorValueFromHexLiteral(0xFFFFFFFF);
+    local notEnoughGoldFaithColor = UI.GetColorValueFromHexLiteral(0xCF0000FF);
+    local enabledButtonColor = UI.GetColorValueFromHexLiteral(0xFFF38FFF);
+    local disabledButtonColor = UI.GetColorValueFromHexLiteral(0xDD3366FF);
     local purchaseButtonPadding = 15;
 
   -- CQUI show recommandations check
@@ -272,22 +275,22 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
 
   -- CQUI Reset the color
     if kInstance.PurchaseButton then
-        kInstance.PurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.PurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
     if kInstance.CorpsPurchaseButton then
-        kInstance.CorpsPurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.CorpsPurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
     if kInstance.ArmyPurchaseButton then
-        kInstance.ArmyPurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.ArmyPurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
     if kInstance.FaithPurchaseButton then
-        kInstance.FaithPurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.FaithPurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
     if kInstance.CorpsFaithPurchaseButton then
-        kInstance.CorpsFaithPurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.CorpsFaithPurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
     if kInstance.ArmyFaithPurchaseButton then
-        kInstance.ArmyFaithPurchaseButton:GetTextControl():SetColor(UI.GetColorValueFromHexLiteral(0xFFFFFFFF));
+        kInstance.ArmyFaithPurchaseButton:GetTextControl():SetColor(purchaseGoldFaithColor);
     end
   
     -- Gold purchase button for building, district and units
@@ -295,18 +298,19 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
         if CQUI_PurchaseTable[kItem.Hash] and CQUI_PurchaseTable[kItem.Hash]["gold"] then
             kInstance.PurchaseButton:SetText(CQUI_PurchaseTable[kItem.Hash]["gold"] .. "[ICON_GOLD]");
             kInstance.PurchaseButton:SetSizeX(kInstance.PurchaseButton:GetTextControl():GetSizeX() + purchaseButtonPadding);
-            kInstance.PurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xFFF38FFF));
+            kInstance.PurchaseButton:SetColor(enabledButtonColor);
             kInstance.PurchaseButton:SetHide(false);
             kInstance.PurchaseButton:SetDisabled(false);
             kInstance.PurchaseButton:RegisterCallback(Mouse.eLClick, CQUI_PurchaseTable[kItem.Hash]["goldCallback"]);
             
             if CQUI_PurchaseTable[kItem.Hash]["goldCantAfford"] or CQUI_PurchaseTable[kItem.Hash]["goldDisabled"] then
                 kInstance.PurchaseButton:SetDisabled(true);
-                kInstance.PurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
+                kInstance.PurchaseButton:SetColor(disabledButtonColor);
+                kInstance.PurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
 
             if CQUI_PurchaseTable[kItem.Hash]["goldCantAfford"] then
-                kInstance.PurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.PurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.PurchaseButton:SetHide(true);
@@ -324,8 +328,8 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
 
             if CQUI_PurchaseTable[kItem.Hash]["corpsGoldDisabled"] then
                 kInstance.CorpsPurchaseButton:SetDisabled(true);
-                kInstance.CorpsPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
-                kInstance.CorpsPurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.CorpsPurchaseButton:SetColor(disabledButtonColor);
+                kInstance.CorpsPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.CorpsPurchaseButton:SetHide(true);
@@ -343,8 +347,8 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
 
             if CQUI_PurchaseTable[kItem.Hash]["armyGoldDisabled"] then
                 kInstance.ArmyPurchaseButton:SetDisabled(true);
-                kInstance.ArmyPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
-                kInstance.ArmyPurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.ArmyPurchaseButton:SetColor(disabledButtonColor);
+                kInstance.ArmyPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.ArmyPurchaseButton:SetHide(true);
@@ -356,18 +360,19 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
         if CQUI_PurchaseTable[kItem.Hash] and CQUI_PurchaseTable[kItem.Hash]["faith"] then
             kInstance.FaithPurchaseButton:SetText(CQUI_PurchaseTable[kItem.Hash]["faith"] .. "[ICON_FAITH]");
             kInstance.FaithPurchaseButton:SetSizeX(kInstance.FaithPurchaseButton:GetTextControl():GetSizeX() + purchaseButtonPadding);
-            kInstance.FaithPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xFFF38FFF));
+            kInstance.FaithPurchaseButton:SetColor(enabledButtonColor);
             kInstance.FaithPurchaseButton:SetHide(false);
             kInstance.FaithPurchaseButton:SetDisabled(false);
             kInstance.FaithPurchaseButton:RegisterCallback(Mouse.eLClick, CQUI_PurchaseTable[kItem.Hash]["faithCallback"]);
         
             if CQUI_PurchaseTable[kItem.Hash]["faithCantAfford"] or CQUI_PurchaseTable[kItem.Hash]["faithDisabled"] then
                 kInstance.FaithPurchaseButton:SetDisabled(true);
-                kInstance.FaithPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
+                kInstance.FaithPurchaseButton:SetColor(disabledButtonColor);
+                kInstance.FaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
 
             if CQUI_PurchaseTable[kItem.Hash]["faithCantAfford"] then
-                kInstance.FaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.FaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.FaithPurchaseButton:SetHide(true);
@@ -385,8 +390,8 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
 
             if CQUI_PurchaseTable[kItem.Hash]["corpsFaithDisabled"] then
                 kInstance.CorpsFaithPurchaseButton:SetDisabled(true);
-                kInstance.CorpsFaithPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
-                kInstance.CorpsFaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.CorpsFaithPurchaseButton:SetColor(disabledButtonColor);
+                kInstance.CorpsFaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.CorpsFaithPurchaseButton:SetHide(true);
@@ -404,8 +409,8 @@ function PopulateGenericItemData( kInstance:table, kItem:table )
 
             if CQUI_PurchaseTable[kItem.Hash]["armyFaithDisabled"] then
                 kInstance.ArmyFaithPurchaseButton:SetDisabled(true);
-                kInstance.ArmyFaithPurchaseButton:SetColor(UI.GetColorValueFromHexLiteral(0xDD3366FF));
-                kInstance.ArmyFaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldColor);
+                kInstance.ArmyFaithPurchaseButton:SetColor(disabledButtonColor);
+                kInstance.ArmyFaithPurchaseButton:GetTextControl():SetColor(notEnoughGoldFaithColor);
             end
         else
             kInstance.ArmyFaithPurchaseButton:SetHide(true);
@@ -629,7 +634,7 @@ function Initialize()
 
     Controls.CloseButton:ClearCallback(Mouse.eLClick);
     Controls.CloseButton:RegisterCallback(Mouse.eLClick, OnClose);
-    Controls.CQUI_ShowManagerButton:RegisterCallback(Mouse.eLClick, CQUI_ToogleManager);
+    Controls.CQUI_ShowManagerButton:RegisterCallback(Mouse.eLClick, CQUI_ToggleManager);
     
     LuaEvents.CQUI_ProductionPanel_CityviewEnable.Add( CQUI_OnCityviewEnabled);
     LuaEvents.CQUI_ProductionPanel_CityviewDisable.Add( CQUI_OnCityviewDisabled);

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -262,7 +262,7 @@ end
 function PopulateGenericItemData( kInstance:table, kItem:table )
     BASE_PopulateGenericItemData(kInstance, kItem);
 
-    local notEnoughGoldColor = UI.GetColorValueFromHexLiteral(0xFF222258);
+    local notEnoughGoldColor = UI.GetColorValueFromHexLiteral(0x9F1F1FFF);
     local purchaseButtonPadding = 15;
 
   -- CQUI show recommandations check
@@ -649,30 +649,30 @@ print("Hero MODE is:", bIsHeroMODE and "ON" or "off");
 
 if bIsHeroMODE then
 
-include("ToolTipHelper")
-include("ToolTipHelper_Babylon_Heroes");
+    include("ToolTipHelper")
+    include("ToolTipHelper_Babylon_Heroes");
 
-local RightClickProductionItem_BASE = RightClickProductionItem;
+    local RightClickProductionItem_BASE = RightClickProductionItem;
 
--- ===========================================================================
--- Override: when clicking a Hero Devotion project, view the Hero info rather than
--- the project info
-function RightClickProductionItem(sItemType:string)
-	
-	local pProjectInfo = GameInfo.Projects[sItemType];
-	if (pProjectInfo ~= nil) then
-		for row in GameInfo.HeroClasses() do
-			if (row.CreationProjectType == sItemType) then
-				-- View the Hero UnitType instead
-				if (row.UnitType ~= "") then
-					return RightClickProductionItem_BASE(row.UnitType);
-				end
-			end
-		end
-	end
+    -- ===========================================================================
+    -- Override: when clicking a Hero Devotion project, view the Hero info rather than
+    -- the project info
+    function RightClickProductionItem(sItemType:string)
+        
+        local pProjectInfo = GameInfo.Projects[sItemType];
+        if (pProjectInfo ~= nil) then
+            for row in GameInfo.HeroClasses() do
+                if (row.CreationProjectType == sItemType) then
+                    -- View the Hero UnitType instead
+                    if (row.UnitType ~= "") then
+                        return RightClickProductionItem_BASE(row.UnitType);
+                    end
+                end
+            end
+        end
 
-	-- Default
-	return RightClickProductionItem_BASE(sItemType);
-end
+        -- Default
+        return RightClickProductionItem_BASE(sItemType);
+    end
 
 end -- bIsHeroMODE

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -215,14 +215,14 @@ function GetData()
     for row in GameInfo.Units() do
         if row.MustPurchase and buildQueue:CanProduce( row.Hash, true ) and row.PurchaseYield == "YIELD_FAITH" then
             local isCanProduceExclusion, results     = buildQueue:CanProduce( row.Hash, false, true );
-            local isDisabled  :boolean = row.MustPurchase;
+            local isDisabled  :boolean = not isCanProduceExclusion;
             local sAllReasons :string = ComposeFailureReasonStrings( isDisabled, results );
             local sToolTip    :string = ToolTipHelper.GetUnitToolTip( row.Hash, MilitaryFormationTypes.STANDARD_MILITARY_FORMATION, buildQueue ) .. sAllReasons;
 
             local nProductionCost     :number = buildQueue:GetUnitCost( row.Index );
             local nProductionProgress :number = buildQueue:GetUnitProgress( row.Index );
             sToolTip = sToolTip .. ComposeProductionCostString( nProductionProgress, nProductionCost );
-                
+
             local kUnit :table = {
                 Type                = row.UnitType, 
                 Name                = row.Name, 

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -6,31 +6,6 @@
 include("CQUICommon.lua");
 
 -- ===========================================================================
--- Used for checking to see if the XML is actually loaded
-local CQUI_IssuedMissingXMLWarning = false;
-function IsCQUI_CityBannerXMLLoaded()
-    retVal = true;
-
-    if (g_bIsGatheringStorm) then
-        retVal = retVal and (Controls.CQUI_EmptyContainer_CityBannerInstances_Exp2 ~= nil);
-        retVal = retVal and (Controls.CQUI_EmptyContainer_CityReligionInstances_Exp2 ~= nil);
-    elseif (g_bIsRiseAndFall) then
-        retVal = retVal and (Controls.CQUI_EmptyContainer_CityBannerInstances_Exp1 ~= nil);
-        retVal = retVal and (Controls.CQUI_EmptyContainer_CityReligionInstances_Exp1 ~= nil);
-    end
-
-    -- This control is in basegame and the expansions, in CityBannerManager.xml
-    retVal = retVal and (Controls.CQUI_WorkedPlotContainer ~= nil);
-
-    if (retVal == false and CQUI_IssuedMissingXMLWarning == false) then
-        print("****** CQUI ERROR: One or more of the CQUI version of the City Bannner XML files did not load properly!  CQUI affects cannot apply!");
-        CQUI_IssuedMissingXMLWarning = true;
-    end
-
-    return retVal;
-end
-
--- ===========================================================================
 -- Cached Base Functions
 -- ===========================================================================
 BASE_CQUI_CityBanner_Initialize = CityBanner.Initialize;
@@ -88,11 +63,8 @@ local COLOR_RELIGION_DEFAULT            :number = UI.GetColorValueFromHexLiteral
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
+-- Instantiated in the Initialize function
 local CQUI_PlotIM        = {};
-if (IsCQUI_CityBannerXMLLoaded()) then
-    CQUI_PlotIM = InstanceManager:new( "CQUI_WorkedPlotInstance", "Anchor", Controls.CQUI_WorkedPlotContainer );
-end
-
 local CQUI_UIWorldMap    = {};
 local CQUI_YieldsOn      = false;
 local CQUI_Hovering      = false;
@@ -1925,6 +1897,32 @@ function IsCQUI_ShowWarIconInCityStateBannerEnabled()
 end
 
 -- ===========================================================================
+-- Used for checking to see if the XML is actually loaded
+local CQUI_IssuedMissingXMLWarning = false;
+function IsCQUI_CityBannerXMLLoaded()
+    retVal = true;
+
+    if (g_bIsGatheringStorm) then
+        retVal = retVal and (Controls.CQUI_EmptyContainer_CityBannerInstances_Exp2 ~= nil);
+        retVal = retVal and (Controls.CQUI_EmptyContainer_CityReligionInstances_Exp2 ~= nil);
+    elseif (g_bIsRiseAndFall) then
+        retVal = retVal and (Controls.CQUI_EmptyContainer_CityBannerInstances_Exp1 ~= nil);
+        retVal = retVal and (Controls.CQUI_EmptyContainer_CityReligionInstances_Exp1 ~= nil);
+    end
+
+    -- This control is in basegame and the expansions, in CityBannerManager.xml
+    retVal = retVal and (Controls.CQUI_WorkedPlotContainer ~= nil);
+
+    if (retVal == false and CQUI_IssuedMissingXMLWarning == false) then
+        -- Prints in the log once, so we don't spam the thing
+        print("****** CQUI ERROR: One or more of the CQUI version of the City Bannner XML files did not load properly!  CQUI effects cannot applied!");
+        CQUI_IssuedMissingXMLWarning = true;
+    end
+
+    return retVal;
+end
+
+-- ===========================================================================
 -- Game Engine EVENT
 -- ===========================================================================
 function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
@@ -1939,7 +1937,11 @@ end
 -- ===========================================================================
 function Initialize_CityBannerManager_CQUI()
     -- print("CityBannerManager_CQUI: Initialize CQUI CityBannerManager");
-    -- CQUI related events
+    if (IsCQUI_CityBannerXMLLoaded()) then
+        CQUI_PlotIM = InstanceManager:new( "CQUI_WorkedPlotInstance", "Anchor", Controls.CQUI_WorkedPlotContainer );
+    end
+
+    -- CQUI related events, which still have some function even if the XML is not loaded
     LuaEvents.CQUI_CityLostTileToCultureBomb.Add(CQUI_OnCityLostTileToCultureBomb);    -- CQUI update close to a culture bomb cities data and real housing from improvements
     LuaEvents.CQUI_CityRangeStrike.Add(CQUI_OnCityRangeStrikeButtonClick); -- AZURENCY : to acces it in the actionpannel on the city range attack button
     LuaEvents.CQUI_DistrictRangeStrike.Add(CQUI_OnDistrictRangeStrikeButtonClick); -- AZURENCY : to acces it in the actionpannel on the district range attack button
@@ -1952,7 +1954,7 @@ function Initialize_CityBannerManager_CQUI()
     Events.LensLayerOff.Add(CQUI_OnLensLayerOff);
     Events.LensLayerOn.Add(CQUI_OnLensLayerOn);
 
-    Events.DiplomacyDeclareWar.Add( CQUI_OnDiplomacyDeclareWarMakePeace );
-    Events.DiplomacyMakePeace.Add( CQUI_OnDiplomacyDeclareWarMakePeace );
+    Events.DiplomacyDeclareWar.Add(CQUI_OnDiplomacyDeclareWarMakePeace);
+    Events.DiplomacyMakePeace.Add(CQUI_OnDiplomacyDeclareWarMakePeace);
 end
 Initialize_CityBannerManager_CQUI();

--- a/Assets/UI/diplomacydealview.xml
+++ b/Assets/UI/diplomacydealview.xml
@@ -22,16 +22,14 @@
             <Label ID="AmountText" Style="FontNormalBold16" Anchor="R,B" Offset="-5,-9" FontStyle="Stroke" />
             <Button ID="RemoveButton" Anchor="L,B" Offset ="-10,-10" Texture="Controls_RemoveDealSmall" Size="16,16" ToolTip="LOC_DIPLO_DEAL_REMOVE_ITEM" Hidden="1"/>
             <Button ID="StopAskingButton" Anchor="C,C" Offset ="0,0" Texture="Controls_DontAskAgainSmall" Size="16,16" ToolTip="LOC_DIPLO_DEAL_REMOVE_ITEM" Hidden="1"/>
-            <!-- CQUI : Added Important -->
-            <Label ID="Important" String="[ICON_Exclamation]" Anchor="L,T" Offset="-11,-11" Hidden="1" />
             <!-- CQUI: Workaround for Extended Diplomacy Ribbon (EDR) by Aristos, which adds a TradableIndicator and references it in their ReplaceUIScript -->
-            <!--       This shares the location with the Important icon, but it appears they have different criteria when deciding to show -->
+            <!--       When the CQUI Lua is loaded, this will not show.  If EDR Lua loads with the CQUI XML, this prevents the Diplomacy Deal Screen from becoming non-functional -->
             <Label ID="TradeableIndicator" String="[ICON_New]" Anchor="L,T" Offset="-11,-11" Hidden="1"/>
             <Image ID="UnacceptableIcon" Anchor="R,T" Offset="-8,-8" Texture="Alert18" Size="18,18" ToolTip="LOC_DIPLO_DEAL_UNACCEPTABLE_ITEM_TOOLTIP" Hidden="1"/>
         </GridButton>
     </Instance>
 
-    <!-- Instance for Cities which includes details on population, food, prod, and science -->
+    <!-- CQUI: Instance for Cities which includes details on population, food, prod, and science -->
     <Instance Name="IconAndTextForCities">
         <GridButton ID="SelectButton" Style="ButtonDraggableGrid" Size="parent,58" Anchor="L,T">
             <Stack Size="parent,0" StackGrowth="Right">
@@ -77,7 +75,7 @@
         </GridButton>
     </Instance>
 
-    <!-- Instance for Great Work that include the type icon -->
+    <!-- CQUI: Instance for Great Work that include the type icon -->
     <Instance Name="IconAndTextForGreatWork">
         <GridButton ID="SelectButton" Style="ButtonDraggableGrid" Size="parent,56" Anchor="L,T">
             <Stack Size="parent,0" StackGrowth="Right">


### PR DESCRIPTION
**CHANGES**
- The CQUI CityBanner code checks to see if the CQUI CityBanner XMLs are loaded before accessing any controls unique to CQUI.  
  - This basically means someone else's CityBannerInstances.xml or CityBannerManager.xml could be loaded and the CQUI code is still able to run, though none of the CQUI controls will appear (like the districts in the banner, or CityState war icon, etc...).  
  - This is good as the CQUI version of CityBanner lua code now always is loaded (with the "include" change by Firaxis), but we are not guaranteed to have the CQUI XML load with it.
- The color of the text shown for not-affordable items on the production panel is now a brighter and easier to read red color
- If the CQUI DiplomacyDealView XML is not loaded, an error message is logged to the Lua Log file a single time the first time one of those CQUI controls is attempted to be accessed
- Removed the "Important" label (represented by the "!" icon) from the DiplomacyDealView buttons entirely.  It just didn't make sense, especially with the coloring of the labels on the buttons now correct.
- Industry and Corporation minibanners should now show properly
- Religious units should now have proper "Background" in the production panel list
![image](https://user-images.githubusercontent.com/8787640/107933787-0fdc2400-6f34-11eb-9b4d-b487981c9901.png)


**TESTING**
I replaced the CQUI versions of the CityBannerInstances, CityReligionInstances, and CityBannerManager XML files with the Firaxis unmodified version and verified the banners were still visible (albeit with out the CQUI elements).  Tested on Exp2, Exp1, and Vanilla.

