### PR TITLE
Fix issue with Wonder Video playing Multiplayer Mode

### DIFF
--- a/Assets/UI/Popups/wonderbuiltpopup_CQUI.lua
+++ b/Assets/UI/Popups/wonderbuiltpopup_CQUI.lua
@@ -15,9 +15,9 @@ BASE_CQUI_OnWonderCompleted = OnWonderCompleted;
 local m_kPopupMgr :table = ExclusivePopupManager:new("WonderBuiltPopup");
 local m_kCurrentPopup :table = nil;
 local m_kQueuedPopups :table = {};
+local m_IsSinglePlayerGame = not GameConfiguration.IsAnyMultiplayer();
 local CQUI_wonderBuiltVisual = m_IsSinglePlayerGame;
 local CQUI_wonderBuiltAudio = m_IsSinglePlayerGame;
-local m_IsSinglePlayerGame = not GameConfiguration.IsAnyMultiplayer();
 
 -- ===========================================================================
 function CQUI_OnSettingsInitialized(isUpdate)

--- a/Assets/UI/Popups/wonderbuiltpopup_CQUI.lua
+++ b/Assets/UI/Popups/wonderbuiltpopup_CQUI.lua
@@ -9,19 +9,39 @@ include( "ToolTipHelper" );  -- For AddBuildingYieldTooltip()
 -- ===========================================================================
 BASE_CQUI_OnWonderCompleted = OnWonderCompleted;
 
-local m_kPopupMgr :table = ExclusivePopupManager:new("WonderBuiltPopup");
-local m_kCurrentPopup :table = nil;
-local m_kQueuedPopups :table = {};
-
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
-local CQUI_wonderBuiltVisual = true;
-local CQUI_wonderBuiltAudio = true;
+local m_kPopupMgr :table = ExclusivePopupManager:new("WonderBuiltPopup");
+local m_kCurrentPopup :table = nil;
+local m_kQueuedPopups :table = {};
+local CQUI_wonderBuiltVisual = m_IsSinglePlayerGame;
+local CQUI_wonderBuiltAudio = m_IsSinglePlayerGame;
+local m_IsSinglePlayerGame = not GameConfiguration.IsAnyMultiplayer();
 
-function CQUI_OnSettingsUpdate()
+-- ===========================================================================
+function CQUI_OnSettingsInitialized(isUpdate)
     CQUI_wonderBuiltVisual = GameConfiguration.GetValue("CQUI_WonderBuiltPopupVisual");
     CQUI_wonderBuiltAudio = GameConfiguration.GetValue("CQUI_WonderBuiltPopupAudio");
+
+    if (isUpdate == nil) then
+        -- The only time isUpdate should be nil is when CQUI_SettingsInitialized is called by cqui_settingselement.
+        -- If it is multiplayer, we want to default to false.  Otherwise we can accept the Game Config.
+        CQUI_wonderBuiltVisual = CQUI_wonderBuiltVisual and m_IsSinglePlayerGame;
+        CQUI_wonderBuiltAudio = CQUI_wonderBuiltAudio and m_IsSinglePlayerGame;
+
+        GameConfiguration.SetValue("CQUI_WonderBuiltPopupVisual", CQUI_wonderBuiltVisual);
+        GameConfiguration.SetValue("CQUI_WonderBuiltPopupAudio", CQUI_wonderBuiltAudio);
+        -- The checkboxes were registered to react to this callback, so this will cause them to visually match whatever value was applied here
+        LuaEvents.CQUI_SettingsUpdate();
+    end
+end
+
+-- ===========================================================================
+function CQUI_OnSettingsUpdate()
+    -- print("CityBannerManager_CQUI: CQUI_OnSettingsUpdate ENTRY")
+    -- Pass 'true' to indicate this was triggered from the CQUI Settings
+    CQUI_OnSettingsInitialized(true);
 end
 
 -- ===========================================================================
@@ -266,13 +286,11 @@ function Close()
 end
 
 -- ===========================================================================
-function Initialize()
-    if GameConfiguration.IsAnyMultiplayer() then return; end -- Do not use if a multiplayer mode.
-
+function Initialize_WonderBuiltPopup_CQUI()
     Events.WonderCompleted.Remove( BASE_CQUI_OnWonderCompleted );
     Events.WonderCompleted.Add( OnWonderCompleted );
 
     LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
-    LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsUpdate );
+    LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsInitialized );
 end
-Initialize();
+Initialize_WonderBuiltPopup_CQUI();

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -500,10 +500,10 @@ function Initialize()
     --Populating/binding checkboxes...
     PopulateCheckBox(Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue");
     PopulateCheckBox(Controls.InlineCityStateQuest, "CQUI_InlineCityStateQuest");
-    RegisterControl(Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue", UpdateCheckbox);
+    RegisterControl (Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue", UpdateCheckbox);
     PopulateCheckBox(Controls.ShowLuxuryCheckbox, "CQUI_ShowLuxuries");
     PopulateCheckBox(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH_TOOLTIP"));
-    RegisterControl(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", UpdateCheckbox);
+    RegisterControl (Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", UpdateCheckbox);
     PopulateCheckBox(Controls.SmartbannerCheckbox, "CQUI_Smartbanner", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP"));
     PopulateCheckBox(Controls.SmartbannerUnlockedCitizenCheckbox, "CQUI_Smartbanner_UnlockedCitizen", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP"));
     PopulateCheckBox(Controls.SmartbannerDistrictsCheckbox, "CQUI_Smartbanner_Districts", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_TOOLTIP"));
@@ -518,7 +518,9 @@ function Initialize()
     PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
     PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
     PopulateCheckBox(Controls.WonderBuiltVisualCheckbox, "CQUI_WonderBuiltPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTVISUAL_TOOLTIP"));
+    RegisterControl (Controls.WonderBuiltVisualCheckbox, "CQUI_WonderBuiltPopupVisual", UpdateCheckbox);
     PopulateCheckBox(Controls.WonderBuiltAudioCheckbox, "CQUI_WonderBuiltPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTAUDIO_TOOLTIP"));
+    RegisterControl (Controls.WonderBuiltAudioCheckbox, "CQUI_WonderBuiltPopupAudio", UpdateCheckbox);
     PopulateCheckBox(Controls.TrimGossipCheckbox, "CQUI_TrimGossip", Locale.Lookup("LOC_CQUI_GOSSIP_TRIMMESSAGE_TOOLTIP"));
 
     -- Lenses


### PR DESCRIPTION
When in Multiplayer, the Wonder video would play and there was effectively no way to get out of it, as reported in #253 .

This change will make the play Wonder video and audio default to off when in Multiplayer mode; in single player it retains the default, which is to play the video and the audio.

I tested this by "faking" that I was in a Multiplayer game, by forcing the m_IsSinglePlayerGame to false (instead of using whatever value GameConfiguration.IsAnyMultiplayer() returned).  Verified that when the code thought I was in Multiplayer, the Wonder Video and Audio defaulted to false and that those things didn't play, etc.

Aside: I like that we're our own project now, and I don't have to set the target branch for PRs anymore.  Yay!