### PR TITLE
More minor fixes from the January Update

### DIFF
--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -110,7 +110,7 @@ function CQUI_ClearDistrictBuildingLayers()
         RealizePlotArtForWonderPlacement();
     end
     LuaEvents.CQUI_RefreshPurchasePlots();
-    LuaEvents.CQUI_DistrictPlotIconManager_ClearEveything();
+    LuaEvents.CQUI_DistrictPlotIconManager_ClearEverything();
     LuaEvents.CQUI_Realize2dArtForDistrictPlacement();
 end
 
@@ -217,7 +217,6 @@ function GetData()
     for row in GameInfo.Units() do
         if row.MustPurchase and buildQueue:CanProduce( row.Hash, true ) and row.PurchaseYield == "YIELD_FAITH" then
             local isCanProduceExclusion, results     = buildQueue:CanProduce( row.Hash, false, true );
-            
             -- If a unit is purchase only, then "isDisabled" needs to be True, as that disables the button control that
             -- allows the religious units to be enqueued
             -- TODO: It'd be nice to remove the unnecessary part about the production cost from the Tooltip string

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -21,6 +21,8 @@ BASE_CQUI_ZoneDistrict = ZoneDistrict;
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
+-- Show a faith icon instead of the turns-left for the faith-only units
+local CQUI_FAITH_ONLY_TURNS_LEFT = -2;
 local CQUI_PurchaseTable = {}; -- key = item Hash
 local CQUI_ProductionQueue :boolean = true;
 local CQUI_ShowProductionRecommendations :boolean = false;
@@ -215,13 +217,13 @@ function GetData()
     for row in GameInfo.Units() do
         if row.MustPurchase and buildQueue:CanProduce( row.Hash, true ) and row.PurchaseYield == "YIELD_FAITH" then
             local isCanProduceExclusion, results     = buildQueue:CanProduce( row.Hash, false, true );
-            local isDisabled  :boolean = not isCanProduceExclusion;
+            
+            -- If a unit is purchase only, then "isDisabled" needs to be True, as that disables the button control that
+            -- allows the religious units to be enqueued
+            -- TODO: It'd be nice to remove the unnecessary part about the production cost from the Tooltip string
+            local isDisabled  :boolean = row.MustPurchase -- not isCanProduceExclusion;
             local sAllReasons :string = ComposeFailureReasonStrings( isDisabled, results );
             local sToolTip    :string = ToolTipHelper.GetUnitToolTip( row.Hash, MilitaryFormationTypes.STANDARD_MILITARY_FORMATION, buildQueue ) .. sAllReasons;
-
-            local nProductionCost     :number = buildQueue:GetUnitCost( row.Index );
-            local nProductionProgress :number = buildQueue:GetUnitProgress( row.Index );
-            sToolTip = sToolTip .. ComposeProductionCostString( nProductionProgress, nProductionCost );
 
             local kUnit :table = {
                 Type                = row.UnitType, 
@@ -229,11 +231,11 @@ function GetData()
                 ToolTip             = sToolTip, 
                 Hash                = row.Hash, 
                 Kind                = row.Kind, 
-                TurnsLeft           = buildQueue:GetTurnsLeft( row.Hash ), 
+                TurnsLeft           = CQUI_FAITH_ONLY_TURNS_LEFT,
                 Disabled            = isDisabled, 
                 Civilian            = row.FormationClass == "FORMATION_CLASS_CIVILIAN",
-                Cost                = nProductionCost, 
-                Progress            = nProductionProgress, 
+                Cost                = 0, 
+                Progress            = 0, 
                 Corps               = false,
                 CorpsCost           = 0,
                 CorpsTurnsLeft      = 1,
@@ -253,6 +255,29 @@ function GetData()
     end
 
     return new_data
+end
+
+-- ===========================================================================
+--    CQUI modified GetTurnsToCompleteStrings functiton
+--    add gold and faith purchase in the same list
+-- ===========================================================================
+function GetTurnsToCompleteStrings( turnsToComplete:number )
+    local turnsStr:string = "";
+    local turnsStrTT:string = "";
+
+    if turnsToComplete == -1 then
+        turnsStr = "999+[ICON_Turn]";
+        turnsStrTT = TXT_HUD_CITY_WILL_NOT_COMPLETE;
+    elseif turnsToComplete == -2 then
+        turnsStr = "[ICON_Faith][ICON_Turn]";
+        -- TODO: Build a better string for this?  Or since one isn't needed
+        turnsStrTT = Locale.Lookup("LOC_PRODPANEL_PURCHASE_FAITH");
+    else
+        turnsStr = turnsToComplete .. "[ICON_Turn]";
+        turnsStrTT = turnsToComplete .. Locale.Lookup("LOC_HUD_CITY_TURNS_TO_COMPLETE", turnsToComplete);
+    end
+    
+    return turnsStr, turnsStrTT;
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -1395,6 +1395,8 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
                 end
             else
                 miniBanner:UpdateStats();
+                -- Force the position to update as there's some weirdness on gameload
+                miniBanner:UpdatePosition();
                 -- Vanilla/Basegame uses SetColor, Expansions use UpdateColor
                 if (miniBanner.UpdateColor ~= nil) then
                     miniBanner:UpdateColor();

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -135,15 +135,15 @@ end
 -- CityBanner.Initialize --  Register additional actions for both BaseGame and Expansions
 function CityBanner.Initialize(self, playerID, cityID, districtID, bannerType, bannerStyle)
     -- print("CityBannerManager_CQUI: CityBanner:Initialize ENTRY: playerID:"..tostring(playerID).." cityID:"..tostring(cityID).." districtID:"..tostring(districtID).." bannerType:"..tostring(bannerType).." bannerStyle:"..tostring(bannerStyle));
-    -- TODO: LateInitialize is defined by Firaxis for overriding, should we just use that?
     BASE_CQUI_CityBanner_Initialize(self, playerID, cityID, districtID, bannerType, bannerStyle);
 
     if (self.m_Instance.CityNameButton == nil) then
+        -- print("CityBannerManager_CQUI: CityBanner:Initalize EXIT (CityNameButton nil)");
         return;
     end
 
     -- Register the MouseOver callbacks
-    if (bannerType == BANNERTYPE_CITY_CENTER) then
+    if (IsBannerTypeCityCenter(bannerType)) then
         -- Register the callbacks 
         self.m_Instance.CityNameButton:RegisterCallback( Mouse.eMouseEnter, CQUI_OnBannerMouseEnter );
         self.m_Instance.CityNameButton:RegisterCallback( Mouse.eMouseExit,  CQUI_OnBannerMouseExit );
@@ -157,6 +157,8 @@ function CityBanner.Initialize(self, playerID, cityID, districtID, bannerType, b
             self.CQUI_DistrictBuiltIM = InstanceManager:new( "CQUI_DistrictBuilt", "Icon", self.m_Instance.CQUI_Districts );
         end
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner:Initalize EXIT");
 end
 
 -- ===========================================================================
@@ -167,6 +169,7 @@ function CityBanner.UpdateProduction(self)
     if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
         -- The Expansions version of this function include a City object parameter
         local pCity:table = self:GetCity();
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateProduction EXIT (Expansions)");
         return BASE_CQUI_CityBanner_UpdateProduction(self, pCity);
     end
 
@@ -185,6 +188,8 @@ function CityBanner.UpdateProduction(self)
             self.m_Instance.ProductionIndicator:SetHide(false);
         end
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner.UpdateProduction EXIT");
 end
 
 -- ===========================================================================
@@ -210,18 +215,22 @@ function CQUI_CityBanner_UpdateStats_BaseGame(self)
     local localPlayerID :number = Game.GetLocalPlayer();
 
     if (IsBannerTypeCityCenter(self.m_Type) == false) then
+        -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_BaseGame EXIT (Not City Center)");
         return;
     end
 
     if (self.m_Player ~= Players[localPlayerID]) then
+        -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_BaseGame EXIT (Not LocalPlayerID)");
         return;
     end
 
     if (IsCQUI_CityBannerXMLLoaded() == false) then
+        -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_BaseGame EXIT (CQUI XML not loaded)");
         return;
     end
 
     if (IsCQUI_SmartBannerEnabled() == false) then
+        -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_BaseGame EXIT (SmartBannerNotEnabled)");
         return;
     end
 
@@ -279,6 +288,8 @@ function CQUI_CityBanner_UpdateStats_BaseGame(self)
     else
         self.m_Instance.CityPopTurnsLeft:SetHide(true);
     end
+
+    -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_BaseGame EXIT");
 end
 
 -- ============================================================================
@@ -288,6 +299,7 @@ function CQUI_CityBanner_UpdateStats_Expansions(self)
     -- BASE_CQUI_CityBanner_UpdateStats function was called by CityBanner.UpdateStats
 
     if (IsCQUI_CityBannerXMLLoaded() == false) then
+        -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_Expansions EXIT (CQUI XML not loaded)");
         return;
     end
 
@@ -353,6 +365,8 @@ function CQUI_CityBanner_UpdateStats_Expansions(self)
             end
         end
     end
+
+    -- print("CityBannerManager_CQUI: CQUI_CityBanner_UpdateStats_Expansions EXIT");
 end
 
 -- ============================================================================
@@ -365,19 +379,22 @@ function CityBanner.Uninitialize(self)
     if self.CQUI_DistrictBuiltIM then
         self.CQUI_DistrictBuiltIM:DestroyInstances();
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner.Uninitialize EXIT");
 end
 
 -- ============================================================================
--- CityBanner.Uninitialize is called in Expansions only
 function CityBanner.UpdateInfo(self, pCity : table )
     -- print("CityBannerManager_CQUI: CityBanner.UpdateInfo ENTRY  pCity:"..tostring(pCity));
     BASE_CQUI_CityBanner_UpdateInfo(self, pCity);
 
     if (pCity == nil) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateInfo EXIT (pCity nil)");
         return;
     end
 
     if (IsCQUI_CityBannerXMLLoaded() == false) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateInfo EXIT (CQUI XML not loaded)");
         return;
     end
 
@@ -414,6 +431,7 @@ function CityBanner.UpdateInfo(self, pCity : table )
     -- this piece of code is taken from CityBannerManager.lua to allow an extra line inside a tooltip
     local pPlayer:table = Players[playerID];
     if pPlayer == nil then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateInfo EXIT (original city owner)");
         return;
     end
     
@@ -463,19 +481,22 @@ function CityBanner.UpdateInfo(self, pCity : table )
     cityIconInstance.Button:SetToolTipString(tooltip);
 
     self:Resize();
+    -- print("CityBannerManager_CQUI: CityBanner.UpdateInfo EXIT");
 end
 
 -- ============================================================================
 -- CityBanner.UpdatePopulation is called in Expansions only
 function CityBanner.UpdatePopulation(self, isLocalPlayer:boolean, pCity:table, pCityGrowth:table)
-    -- print("CityBannerManager_CQUI: CityBanner:UpdatePopulation:  pCity: "..tostring(pCity).."  pCityGrowth:"..tostring(pCityGrowth));
+    -- print("CityBannerManager_CQUI: CityBanner:UpdatePopulation: ENTRY pCity: "..tostring(pCity).."  pCityGrowth:"..tostring(pCityGrowth));
     BASE_CQUI_CityBanner_UpdatePopulation(self, isLocalPlayer, pCity, pCityGrowth);
 
     if (isLocalPlayer == false) then
+        -- print("CityBannerManager_CQUI: CityBanner:UpdatePopulation EXIT (not localplayer)");
         return;
     end
 
     if (IsCQUI_CityBannerXMLLoaded() == false) then
+        -- print("CityBannerManager_CQUI: CityBanner:UpdatePopulation EXIT (CQUI XML not loaded)");
         return;
     end
 
@@ -518,6 +539,8 @@ function CityBanner.UpdatePopulation(self, isLocalPlayer:boolean, pCity:table, p
     else
         populationInstance.CityCultureTurnsLeft:SetHide(true);
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner:UpdatePopulation EXIT");
 end
 
 -- ============================================================================
@@ -529,6 +552,7 @@ function CityBanner.UpdateRangeStrike(self)
 
     local banner = self.m_Instance;
     if (banner == nil) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateRangeStrike EXIT (banner nil)");
         return;
     end
 
@@ -548,6 +572,8 @@ function CityBanner.UpdateRangeStrike(self)
             CQUI_SetCityStrikeButtonLocation(banner, 0, CQUI_EncampmentRangeStrikeBottomYOffset, "C,B");
         end
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner.UpdateRangeStrike EXIT");
 end
 
 -- ===========================================================================
@@ -570,6 +596,8 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
       CQUI_CityManageAreaShown = false;
       CQUI_CityManageAreaShouldShow = false;
     end
+
+    -- print("CityBannerManager_CQUI: OnInterfaceModeChanged EXIT");
 end
 
 -- ===========================================================================
@@ -581,7 +609,9 @@ end
 -- ===========================================================================
 function OnShutdown()
     -- print("CityBannerManager_CQUI: OnShutdown ENTRY");
-    CQUI_PlotIM:DestroyInstances();
+    if (IsCQUI_CityBannerXMLLoaded()) then
+        CQUI_PlotIM:DestroyInstances();
+    end
 
     BASE_CQUI_OnShutdown();
 end
@@ -604,6 +634,8 @@ function Reload()
             end
         end
     end
+
+    -- print("CityBannerManager_CQUI: Reload EXIT");
 end
 
 -- ===========================================================================
@@ -616,15 +648,18 @@ function CityBanner.UpdateName( self )
 
     -- This code applies to vanilla/basegame only (early return from function!)
     if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateName EXIT (Expansions)");
         return BASE_CQUI_CityBanner_UpdateName(self);
     end
 
     if (IsBannerTypeCityCenter(self.m_Type) == false) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateName EXIT (Not IsBannerTypeCityCenter)");
         return;
     end
 
     local pCity : table = self:GetCity();
     if (pCity == nil) then
+        -- print("CityBannerManager_CQUI: CityBanner.UpdateName EXIT (city is nil)");
         return;
     end
 
@@ -818,6 +853,7 @@ function CityBanner.UpdateName( self )
     self.m_Instance.CityNameStack:ReprocessAnchoring();
     self.m_Instance.ContentStack:ReprocessAnchoring();
     self:Resize();
+    -- print("CityBannerManager_CQUI: CityBanner.UpdateName EXIT");
 end
 
 -- ===========================================================================
@@ -840,6 +876,8 @@ function CityBanner.SetHealthBarColor( self )
     elseif (percent <= 0.40) then
         self.m_Instance.CityHealthBar:SetColor( COLOR_CITY_RED );
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner.SetHealthBarColor EXIT");
 end
 
 -- ===========================================================================
@@ -902,6 +940,7 @@ function CityBanner.UpdateReligion(self)
         elseif ((g_bIsRiseAndFall or g_bIsGatheringStorm) and religionInfo ~= nil and religionInfo.ReligionInfoContainer ~= nil) then
             religionInfo.ReligionInfoContainer:SetHide(true);
         end
+        -- print("CityBannerManager_CQUI: CityBanner:UpdateReligion EXIT (Lens not active)");
         return;
     end
 
@@ -1000,7 +1039,7 @@ function CityBanner.UpdateReligion(self)
         local iconIM:table = cityInst[DATA_FIELD_RELIGION_ICONS_IM];
         if (iconIM == nil) then
             -- TODO what happens if this is a thing that does not exist?
-            -- TODO update: it seeed to be okay maybe this just failed and we're proected later
+            -- TODO update: it seemed to be okay maybe this just failed and we're protected later
             iconIM = InstanceManager:new("ReligionIconInstance", "ReligionIconContainer", religionInfo.ReligionInfoIconStack);
             cityInst[DATA_FIELD_RELIGION_ICONS_IM] = iconIM;
         else
@@ -1143,6 +1182,8 @@ function CityBanner.UpdateReligion(self)
 
         religionInfo.ReligionInfoContainer:SetHide(false);
     end
+
+    -- print("CityBannerManager_CQUI: CityBanner:UpdateReligion EXIT");
 end
 
 -- ============================================================================
@@ -1218,8 +1259,14 @@ function OnCityStrikeButtonClick( playerID, cityID )
 end
 
 -- ===========================================================================
-function OnDistrictAddedToMap( playerID, districtID, cityID, districtX, districtY, districtType, percentComplete )
+function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :number, districtX : number, districtY : number, districtType:number, percentComplete:number )
     -- print("CityBannerManager_CQUI: OnDistrictAddedToMap ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID).." cityID:"..tostring(cityID).." districtXY:"..tostring(districtX)..","..tostring(districtY).." districtType:"..tostring(districtType).." pctComplete:"..tostring(percentComplete));
+    -- The call from Reload() passes in the value meant for districtX as cityID, and the value meant for districtY as districtX... and this is in the base Firaxis code and makes no sense?
+    if (districtY == nil) then
+        districtY = districtX;
+        districtX = cityID;
+    end
+
     local locX = districtX;
     local locY = districtY;
     local type = districtType;
@@ -1227,11 +1274,13 @@ function OnDistrictAddedToMap( playerID, districtID, cityID, districtX, district
     local pPlayer = Players[playerID];
 
     if (pPlayer == nil) then
+        -- print("CityBannerManager_CQUI: OnDistrictAddedToMap playerID:"..tostring(playerID).." EXIT (player nil)");
         return;
     end
 
     local pDistrict = pPlayer:GetDistricts():FindID(districtID);
     if (pDistrict == nil) then
+        -- print("CityBannerManager_CQUI: OnDistrictAddedToMap playerID:"..tostring(playerID).." EXIT (district nil)");
         return;
     end
 
@@ -1239,6 +1288,7 @@ function OnDistrictAddedToMap( playerID, districtID, cityID, districtX, district
     local cityID = pCity:GetID();
     if (pCity == nil) then
         -- It is possible that the city is not there yet. e.g. city-center district is placed, the city is placed immediately afterward.
+        -- print("CityBannerManager_CQUI: OnDistrictAddedToMap playerID:"..tostring(playerID).." EXIT (city nil)");
         return;
     end
 
@@ -1278,21 +1328,23 @@ function OnDistrictAddedToMap( playerID, districtID, cityID, districtX, district
             miniBanner:UpdateRangeStrike();
         end
     end -- else not city center
+
+    -- print("CityBannerManager_CQUI: OnDistrictAddedToMap playerID:"..tostring(playerID).." EXIT");
 end
 
-
-m4atemp = nil;
 -- ===========================================================================
 function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
     -- print("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
     if eImprovementType == -1 then
         UI.DataError("Received -1 eImprovementType for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
+        -- print("CityBannerManager_CQUI: OnImprovementAddedToMap EXIT (invalid improvement type)");
         return;
     end
 
     local improvementData:table = GameInfo.Improvements[eImprovementType];
 
     if improvementData == nil then
+        -- print("CityBannerManager_CQUI: OnImprovementAddedToMap EXIT (invalid improvement data)");
         UI.DataError("No database entry for eImprovementType #"..tostring(eImprovementType).." for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
         return;
     end
@@ -1352,6 +1404,8 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
             end
         end
     end
+
+    -- print("CityBannerManager_CQUI: OnImprovementAddedToMap EXIT");
 end
 
 -- ===========================================================================
@@ -1467,7 +1521,7 @@ end
 -- When a banner is moused over, display the relevant yields and next culture plot
 function CQUI_OnBannerMouseEnter(playerID: number, cityID: number)
     -- print("CityBannerManager_CQUI: CQUI_OnBannerMouseEnter ENTRY playerID:"..tostring(playerID).." cityID:"..tostring(cityID));
-    if (CQUI_ShowYieldsOnCityHover == false or playerID ~= Game.GetLocalPlayer()) then
+    if (CQUI_ShowYieldsOnCityHover == false or playerID ~= Game.GetLocalPlayer() or IsCQUI_CityBannerXMLLoaded() == false) then
         -- Doesn't make sense to show when not self; if wanting to show an allied player is desired, then code needs some cleanup 
         -- as it currently shows tiles for the local player city by that city ID value (cityID values are only unique per player, not universally)
         return;
@@ -1698,7 +1752,7 @@ end
 -- ===========================================================================
 function CQUI_OnDiplomacyDeclareWarMakePeace( firstPlayerID, secondPlayerID )
     local localPlayerID = Game.GetLocalPlayer();
-    if (localPlayerID == nil) then
+    if (localPlayerID == nil or IsCQUI_CityBannerXMLLoaded() == false) then
         -- print("CQUI_OnDiplomacyDeclareWarMakePeace: Game.GetLocalPlayer returned nil!")
         return;
     end
@@ -1803,10 +1857,12 @@ end
 function CQUI_UpdateCityStateBannerSuzerain( pPlayer:table, bannerInstance )
     -- print("CityBannerManager_CQUI: CQUI_UpdateCityStateBannerSuzerain ENTRY  pPlayer:"..tostring(pPlayer).."  bannerInstance:"..tostring(bannerInstance));
     if (bannerInstance == nil) then
+        -- print("CityBannerManager_CQUI: CQUI_UpdateCityStateBannerSuzerain EXIT (bannerInstance is nil)");
         return;
     end
 
     if (IsCQUI_CityBannerXMLLoaded() == false) then
+        -- print("CityBannerManager_CQUI: CQUI_UpdateCityStateBannerSuzerain EXIT (CQUI XML not loaded)");
         return;
     end
 
@@ -1859,6 +1915,16 @@ function CQUI_UpdateCityStateBannerSuzerain( pPlayer:table, bannerInstance )
     else
         bannerInstance.m_Instance.CQUI_CivSuzerain:SetHide(true);
     end
+
+    -- print("CityBannerManager_CQUI: CQUI_UpdateCityStateBannerSuzerain EXIT");
+end
+
+-- ===========================================================================
+function CQUI_OnLoadGameViewStateDone()
+    -- Called when the LoadGame View is completed
+    -- Workaround the weirdness with the City Banners showing up in the wrong place by calling the OnRefreshBannerPositions function,
+    -- which finds all of the banners and updates their positions
+    OnRefreshBannerPositions();
 end
 
 -- ===========================================================================
@@ -1958,7 +2024,7 @@ end
 -- CQUI Initialize Function
 -- ===========================================================================
 function Initialize_CityBannerManager_CQUI()
-    -- print("CityBannerManager_CQUI: Initialize CQUI CityBannerManager");
+    -- print("CityBannerManager_CQUI: Initialize CQUI CityBannerManager ENTRY");
     if (IsCQUI_CityBannerXMLLoaded()) then
         CQUI_PlotIM = InstanceManager:new( "CQUI_WorkedPlotInstance", "Anchor", Controls.CQUI_WorkedPlotContainer );
     end
@@ -1975,8 +2041,11 @@ function Initialize_CityBannerManager_CQUI()
     Events.InfluenceGiven.Add(CQUI_OnInfluenceGiven);
     Events.LensLayerOff.Add(CQUI_OnLensLayerOff);
     Events.LensLayerOn.Add(CQUI_OnLensLayerOn);
+    -- Workaround for issue where the Banners appear in weird places or not at all
+    Events.LoadGameViewStateDone.Add(CQUI_OnLoadGameViewStateDone);
 
     Events.DiplomacyDeclareWar.Add(CQUI_OnDiplomacyDeclareWarMakePeace);
     Events.DiplomacyMakePeace.Add(CQUI_OnDiplomacyDeclareWarMakePeace);
+    -- print("CityBannerManager_CQUI: Initialize CQUI CityBannerManager EXIT");
 end
 Initialize_CityBannerManager_CQUI();

--- a/Assets/UI/WorldView/districtploticonmanager_CQUI.lua
+++ b/Assets/UI/WorldView/districtploticonmanager_CQUI.lua
@@ -2,9 +2,69 @@
 -- Base File
 -- ===========================================================================
 include("DistrictPlotIconManager");
+include("GameCapabilities");
 
-function Initialize()
-    LuaEvents.CQUI_DistrictPlotIconManager_ClearEveything.Add(ClearEveything);
+-- ===========================================================================
+-- Everything except the Initialize function at the end is copied from
+-- the KublaiKhan / Vietnam file DistrictPlotIconManager_KublaiKhan_Vietnam.lua.
+-- Firaxis implemented their own ReplaceUIScript for DistrictPlotIconManager
+-- ===========================================================================
+-- ===========================================================================
+-- CACHED BASE FUNCTIONS
+-- ===========================================================================
+BASE_Realize2dArtForCityDistricts = Realize2dArtForCityDistricts;
+
+-- ===========================================================================
+-- CONSTANTS
+-- ===========================================================================
+local PADDING_X :number = 18;
+local PADDING_Y :number = 16;
+
+-- ===========================================================================
+-- OVERRIDE
+-- ===========================================================================
+
+function Realize2dArtForCityDistricts( pCity:table )
+    local districtHash:number   = UI.GetInterfaceModeParameter(CityOperationTypes.PARAM_DISTRICT_TYPE);
+    local district:table        = GameInfo.Districts[districtHash];
+
+    --Is vietnam trying to place a district?
+    if(HasTrait("TRAIT_CIVILIZATION_VIETNAM") and district ~= nil)then
+        -- Show information for a district about to be placed
+        local plots			:table = GetCityRelatedPlotIndexesDistrictsAlternative( pCity, districtHash );		
+        for i,plotID in pairs(plots) do
+            local kPlot:table =  Map.GetPlotByIndex(plotID);
+            if kPlot == nil then
+                UI.DataError("Bad plot index; could not get plot #"..tostring(plotID));
+            else
+                -- All plots that are valid for this district
+                if kPlot:CanHaveDistrict(district.Index, pCity:GetOwner(), pCity:GetID()) then
+                    local yieldBonus:string, yieldTooltip:string, requirementText:string = GetAdjacentYieldBonusString( district.Index, pCity, kPlot );
+                    local showIfPurchaseable:boolean = IsShownIfPlotPurchaseable(district.Index, pCity, kPlot);
+                    if showIfPurchaseable then
+                        local instance:table = GetInstanceAt( plotID );
+                        instance.PlotBonus:SetHide( yieldBonus == "" );
+                        instance.BonusText:SetText(yieldBonus);
+                        instance.BonusText:SetToolTipString(yieldTooltip);
+
+                        --Hide the PrereqIcon since Vietnam does not have to remove features to build districts
+                        instance.PrereqIcon:SetHide( true );
+
+                        local x:number,y:number = instance.BonusText:GetSizeVal();
+                        instance.PlotBonus:SetSizeVal( x+PADDING_X, y+PADDING_Y );
+                        RealizeIconStack(instance);
+                    end					
+                end
+            end
+        end
+    else
+        BASE_Realize2dArtForCityDistricts(pCity);
+    end
+end
+
+-- ===========================================================================
+function Initialize_DistrictPlotIconManager_CQUI()
+    LuaEvents.CQUI_DistrictPlotIconManager_ClearEverything.Add(ClearEveything);
     LuaEvents.CQUI_Realize2dArtForDistrictPlacement.Add(Realize2dArtForDistrictPlacement);
 end
-Initialize();
+Initialize_DistrictPlotIconManager_CQUI();

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -23,6 +23,8 @@
         <Mod id="c9d28cde-61ee-459c-93f5-c734cd392553" title="NQ Enhanced User Interface" />
         <!-- Better Trade Screen is already integrated -->
         <Mod id="8d4fa23a-ef43-440c-8422-2bec11f8f5d7" title="Better Trade Screen" />
+        <!-- CQUI implements the same functionality (current load order is 105) -->
+        <Mod id="5fa339e0-1cef-4a63-abdb-549fadbd670d" title="Suzerain At A Glance" />
     </Blocks>
 
     <!-- ==============================  Modinfo Specific LOC ============================== -->

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -726,6 +726,8 @@
 
         <ReplaceUIScript id="CQUI_DistrictPlotIconManager">
             <Properties>
+                <!-- Ensure CQUI loads after the Vietnam / Kublai Khan mod -->
+                <LoadOrder>50</LoadOrder>
                 <LuaContext>DistrictPlotIconManager</LuaContext>
                 <LuaReplace>Assets/UI/WorldView/districtploticonmanager_CQUI.lua</LuaReplace>
             </Properties>


### PR DESCRIPTION
**WHAT WAS BROKEN?**
- Could produce Missionaries and the like with production
- Plot icons would not update when switching to a different District to build (when Vietnam mod was also loaded)
- City Banners would show up in weird spots on the map when reloading a save game
- Industry/Corp banners were not showing up when reloading a save game

**WHAT IS HERE IN THESE CHANGES?**
productionpanel_CQUI.lua:
- Undid the change that made Faith units able to be built using production
- Added a bit of code so the "number of turns to produce" for those faith units now shows a faith icon instead of some number that doesn't actually apply
CityBannerManager_CQUI.lua:
- Force banners to refresh at the end of Game Load to deal with the issue where the banners would just be off the map because the calculation made while the game was loading was wacky and it somehow works better when the game loading screen completes
- Force minibanners to call UpdatePosition() so that the Industry/Corporation banners appear on reloads
- Pretty much all of the functions in CityBannerManager_CQUI.lua now have a commented out print statement for entry and exit, because troubleshooting errors in the CityBannerManager files with this new Firaxis "include" stuff is brutal (errors in the CQUI file won't always bubble up and show on the LiveTuner)
districtploticonmanager_CQUI.lua:
- Incorporate the code from the Vietnam/Kublai Khan mod (DistrictPlotIconManager_KublaiKhan_Vietnam.lua) that handles the Plot icon logic for Vietnam.
- Set LoadOrder to 50 for districtploticonmanager_CQUI.lua so our version loads and the Firaxis DistrictPlotIconManager_KublaiKhan_Vietnam.lua does not.

**TESTED THINGS**
Banners thing with Vanilla/Exp1/Exp2.  The 