### PR TITLE
Fixes for the Feb 2021 patch

### DIFF
--- a/Assets/Expansion1/CityBanners/citybannermanager.xml
+++ b/Assets/Expansion1/CityBanners/citybannermanager.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Context>
     <!-- ====== CQUI CityBannerManager Replacement File ====== -->
-  <Include File="CityBannerInstances"/>
+    <Include File="CityBannerInstances"/>
     <!-- No changes to this file from the unmodified version, aside from adding a hidden container that is used to verify this file was loaded.  -->
     <!-- In Linux especially, the Modding.log file does not always show a failure to load this XML or any of the "Include" files below. -->
     <!-- To see if this file loaded in the Live Tuner, change the Lua State to CityBannerManager and then run the following command: -->
@@ -18,4 +18,19 @@
     <Container ID="CityDistrictIcons"/>
 
     <Container ID="CQUI_WorkedPlotContainer" />
+
+    <!-- Copied from the Barbarian Tribes DLC, so CQUI can work with it -->
+    <Instance Name="TribeBanner">
+        <ZoomAnchor ID="Anchor" ZoomOffsetNear="0,0,0" ZoomOffsetFar="0,0,-20">
+            <Container ID="TribeBannerContainer" Anchor="C,C" Size="106,34">
+                <Button ID="TribeBannerButton" Anchor="C,C" Size="parent,parent"/>
+
+                <Grid ID="Banner_Base" Size="Parent,Parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
+                <Image ID="TribeIcon" Anchor="L,C" Offset="0,0" Size="30,30" Icon="ICON_DISTRICT_CITY_CENTER"/>
+                <TextureBar Anchor="C,C" Offset="5,0" Size="60,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="40,64,82,200"/>
+                <TextureBar ID="ConversionBar" Anchor="C,C" Offset="5,0" Size="60,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
+
+            </Container>
+        </ZoomAnchor>
+    </Instance>
 </Context>

--- a/Assets/Expansion2/CityBanners/citybannermanager.xml
+++ b/Assets/Expansion2/CityBanners/citybannermanager.xml
@@ -17,4 +17,19 @@
     <Container ID="CityDistrictIcons"/>
 
     <Container ID="CQUI_WorkedPlotContainer" />
+
+    <!-- Copied from the Barbarian Tribes DLC, so CQUI can work with it -->
+    <Instance Name="TribeBanner">
+        <ZoomAnchor ID="Anchor" ZoomOffsetNear="0,0,0" ZoomOffsetFar="0,0,-20">
+            <Container ID="TribeBannerContainer" Anchor="C,C" Size="106,34">
+                <Button ID="TribeBannerButton" Anchor="C,C" Size="parent,parent"/>
+
+                <Grid ID="Banner_Base" Size="Parent,Parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
+                <Image ID="TribeIcon" Anchor="L,C" Offset="0,0" Size="30,30" Icon="ICON_DISTRICT_CITY_CENTER"/>
+                <TextureBar Anchor="C,C" Offset="5,0" Size="60,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="40,64,82,200"/>
+                <TextureBar ID="ConversionBar" Anchor="C,C" Offset="5,0" Size="60,7" Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
+
+            </Container>
+        </ZoomAnchor>
+    </Instance>
 </Context> 

--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -18,6 +18,8 @@
 g_bIsRiseAndFall    = Modding and Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9"); -- Rise & Fall
 g_bIsGatheringStorm = Modding and Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68"); -- Gathering Storm
 g_bIsBaseGame       = not g_bIsRiseAndFall and not g_bIsGatheringStorm;
+-- Required for Workaround for the Barbarian Clans Mode replacing UnitFlagManager.lua and PlotToolTip.lua via ReplaceUIScript
+g_bIsBarbarianClansMode = Modding and Modding.IsModActive("19ED1A36-D744-4A58-8F8B-0376C2BA86E5"); -- Barbarian Clans Mode
 
 -- ===========================================================================
 -- Debug support

--- a/Assets/UI/ToolTips/plottooltip_CQUI.lua
+++ b/Assets/UI/ToolTips/plottooltip_CQUI.lua
@@ -1,3 +1,6 @@
+print("*** CQUI: PlotToolTip_CQUI.lua loaded");
+include ("CQUICommon.lua");
+
 -- ===========================================================================
 -- Cached Base Functions
 -- ===========================================================================
@@ -341,6 +344,19 @@ function GetDetails(data)
                 improvementStr = improvementStr .. " " .. Locale.Lookup("LOC_TOOLTIP_PLOT_PILLAGED_TEXT");
             end
             table.insert(details, improvementStr)
+            -- ==== CQUI WORKAROUND: Incorporate inforamtion from  the Barbarian Clans Mode to enable CQUI and that mode to work together ====
+            -- ==== Firaxis added a ReplaceUIScript for PlotToolTip with the Barbarian Clans mode; incorporating this code allows CQUI to load its PlotToolTip
+            if (g_bIsBarbarianClansMode and data.ImprovementType == "IMPROVEMENT_BARBARIAN_CAMP") then
+                local pBarbManager = Game.GetBarbarianManager();
+                local iTribeIndex = pBarbManager:GetTribeIndexAtLocation(data.X, data.Y);
+                if (iTribeIndex >= 0) then
+                    local eTribeName = pBarbManager:GetTribeNameType(iTribeIndex);
+                    if (GameInfo.BarbarianTribeNames[eTribeName] ~= nil) then
+                        local tribeNameStr = Locale.Lookup("LOC_TOOLTIP_BARBARIAN_CLAN_NAME", GameInfo.BarbarianTribeNames[eTribeName].TribeDisplayName);
+                        table.insert(details, tribeNameStr);
+                    end
+                end
+            end
         end
 
         for yieldType, v in pairs(data.Yields) do
@@ -423,7 +439,7 @@ function View(data:table, bIsUpdate:boolean)
     Controls.PlotName:SetHide(true)
 end
 
-function Initialize()
+function Initialize_PlotTooltip_CQUI()
     Controls.TooltipMain:SetSpeed(8);  -- CQUI : tooltip spawn faster
 end
-Initialize();
+Initialize_PlotTooltip_CQUI();

--- a/Assets/UI/WorldView/CityBannerInstances.xml
+++ b/Assets/UI/WorldView/CityBannerInstances.xml
@@ -1,0 +1,2 @@
+<!-- TODO: Firaxis made changes to the City Banner Files for vanilla, using the file layout they use with the Expansions.  -->
+<!--       This is a placeholder for now; updates can be incorporated after the fixes for the 2/25 game update are completed -->

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -1261,17 +1261,7 @@ end
 
 -- ===========================================================================
 function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :number, districtX : number, districtY : number, districtType:number, percentComplete:number )
-    -- print("CityBannerManager_CQUI: OnDistrictAddedToMap ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID).." cityID:"..tostring(cityID).." districtXY:"..tostring(districtX)..","..tostring(districtY).." districtType:"..tostring(districtType).." pctComplete:"..tostring(percentComplete));
-    -- The call from Reload() passes in the value meant for districtX as cityID, and the value meant for districtY as districtX... and this is in the base Firaxis code and makes no sense?
-    if (districtY == nil) then
-        districtY = districtX;
-        districtX = cityID;
-    end
-
-    local locX = districtX;
-    local locY = districtY;
-    local type = districtType;
-
+    print("CityBannerManager_CQUI: OnDistrictAddedToMap ENTRY playerID:"..tostring(playerID).." districtID:"..tostring(districtID).." cityID:"..tostring(cityID).." districtXY:"..tostring(districtX)..","..tostring(districtY).." districtType:"..tostring(districtType).." pctComplete:"..tostring(percentComplete));
     local pPlayer = Players[playerID];
 
     if (pPlayer == nil) then
@@ -1335,12 +1325,11 @@ end
 
 -- ===========================================================================
 function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
-    -- print("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
+   -- print("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
     BASE_CQUI_OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner);
 
     -- Get the minibanner to force its position to update in order to work around some weirdness happening when the game is loaded
     local pPlayer:table = Players[eOwner];
-    local localPlayerID:number = Game.GetLocalPlayer();
     if (pPlayer ~= nil) then
         local plotID = Map.GetPlotIndex(locX, locY);
         if (plotID ~= nil) then
@@ -1962,7 +1951,7 @@ end
 -- CQUI Initialize Function
 -- ===========================================================================
 function Initialize_CityBannerManager_CQUI()
-    -- print("CityBannerManager_CQUI: Initialize CQUI CityBannerManager ENTRY");
+    -- print("CityBannerManager_CQUI: Initialize_CityBannerManager_CQUI ENTRY");
     if (IsCQUI_CityBannerXMLLoaded()) then
         CQUI_PlotIM = InstanceManager:new( "CQUI_WorkedPlotInstance", "Anchor", Controls.CQUI_WorkedPlotContainer );
     end

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -18,6 +18,7 @@ BASE_CQUI_OnGameDebugReturn = OnGameDebugReturn;
 BASE_CQUI_OnInterfaceModeChanged = OnInterfaceModeChanged;
 BASE_CQUI_OnShutdown = OnShutdown;
 BASE_CQUI_Reload = Reload;
+BASE_CQUI_OnImprovementAddedToMap = OnImprovementAddedToMap;
 
 -- These functions only exist in the Expansions
 BASE_CQUI_CityBanner_Uninitialize = nil;
@@ -1335,74 +1336,17 @@ end
 -- ===========================================================================
 function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
     -- print("CityBannerManager_CQUI: OnImprovementAddedToMap ENTRY locXY:"..tostring(locX)..","..tostring(locY).." eImprovementType:"..tostring(eImprovementType).." eOwner:"..tostring(eOwner));
-    if eImprovementType == -1 then
-        UI.DataError("Received -1 eImprovementType for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
-        -- print("CityBannerManager_CQUI: OnImprovementAddedToMap EXIT (invalid improvement type)");
-        return;
-    end
+    BASE_CQUI_OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner);
 
-    local improvementData:table = GameInfo.Improvements[eImprovementType];
-
-    if improvementData == nil then
-        -- print("CityBannerManager_CQUI: OnImprovementAddedToMap EXIT (invalid improvement data)");
-        UI.DataError("No database entry for eImprovementType #"..tostring(eImprovementType).." for ("..tostring(locX)..","..tostring(locY)..") and owner "..tostring(eOwner));
-        return;
-    end
-
-    -- Check if the improvement is an Industry or Corporation (note: code copied from Firaxis CityBannerManager_KublaiKhanVietnam_MODE.lua)
-    local bIsIndustry:boolean = false;
-    local bIsCorporation:boolean = false;
-    local improvementDataMODE:table = GameInfo.Improvements_MODE[improvementData.Hash];
-    if (improvementDataMODE ~= nil) then
-        if (improvementDataMODE.Industry) then
-            bIsIndustry = true;
-        elseif (improvementDataMODE.Corporation) then
-            bIsCorporation = true;
-        end
-    end
-
+    -- Get the minibanner to force its position to update in order to work around some weirdness happening when the game is loaded
     local pPlayer:table = Players[eOwner];
     local localPlayerID:number = Game.GetLocalPlayer();
     if (pPlayer ~= nil) then
         local plotID = Map.GetPlotIndex(locX, locY);
         if (plotID ~= nil) then
             local miniBanner = GetMiniBanner( eOwner, plotID );
-            if (miniBanner == nil) then
-                if (improvementData.AirSlots > 0) then
-                    --we're passing -1 as the cityID and the plotID as the districtID argument since Airstrips aren't associated with a city or a district
-                    AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_AERODROME );
-                elseif (improvementData.WeaponSlots > 0) then
-                    local ownerCity = Cities.GetPlotPurchaseCity(locX, locY);
-                    local cityID = ownerCity:GetID();
-                    -- we're passing the plotID as the districtID argument because we need the location of the improvement
-                    AddMiniBannerToMap( eOwner, cityID, plotID, BANNERTYPE_MISSILE_SILO );
-                elseif (improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_TUNNEL") then
-                    --we're passing -1 as the cityID and the plotID as the districtID argument since Mountain Tunnels aren't associated with a city or a district
-                    AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_MOUNTAIN_TUNNEL );
-                elseif (improvementData.ImprovementType == "IMPROVEMENT_MOUNTAIN_ROAD") then
-                    --we're passing -1 as the cityID and the plotID as the districtID argument since Qhapaq Nans aren't associated with a city or a district
-                    AddMiniBannerToMap( eOwner, -1, plotID, BANNERTYPE_QHAPAQ_NAN);
-                elseif ( bIsIndustry ) then
-                    local ownerCity = Cities.GetPlotPurchaseCity(locX, locY);
-                    local cityID = ownerCity:GetID();
-                    -- we're passing the plotID as the districtID argument because we need the location of the improvement
-                    AddMiniBannerToMap( eOwner, cityID, plotID, BANNERTYPE_INDUSTRY );
-                elseif ( bIsCorporation ) then
-                    local ownerCity = Cities.GetPlotPurchaseCity(locX, locY);
-                    local cityID = ownerCity:GetID();
-                    -- we're passing the plotID as the districtID argument because we need the location of the improvement
-                    AddMiniBannerToMap( eOwner, cityID, plotID, BANNERTYPE_CORPORATION );
-                end
-            else
-                miniBanner:UpdateStats();
-                -- Force the position to update as there's some weirdness on gameload
+            if (miniBanner ~= nil) then
                 miniBanner:UpdatePosition();
-                -- Vanilla/Basegame uses SetColor, Expansions use UpdateColor
-                if (miniBanner.UpdateColor ~= nil) then
-                    miniBanner:UpdateColor();
-                else
-                    miniBanner:SetColor();
-                end
             end
         end
     end
@@ -1824,17 +1768,9 @@ end
 
 -- ===========================================================================
 function CQUI_SetCityStrikeButtonLocation(cityBannerInstance, rotate, offsetY, anchor)
-    cityStrikeImage = nil;
-    if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
-        cityStrikeImage = cityBannerInstance.CityStrike;
-    else
-        -- Basegame calls this CityAttackContainer
-        cityStrikeImage = cityBannerInstance.CityAttackContainer;
-    end
-
-    cityStrikeImage:Rotate(rotate);
-    cityStrikeImage:SetOffsetVal(0, offsetY);
-    cityStrikeImage:SetAnchor(anchor);
+    cityBannerInstance.CityStrike:Rotate(rotate);
+    cityBannerInstance.CityStrike:SetOffsetVal(0, offsetY);
+    cityBannerInstance.CityStrike:SetAnchor(anchor);
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/CityReligionInstances.xml
+++ b/Assets/UI/WorldView/CityReligionInstances.xml
@@ -1,0 +1,2 @@
+<!-- TODO: Firaxis made changes to the City Banner Files for vanilla, using the file layout they use with the Expansions.  -->
+<!--       This is a placeholder for now; updates can be incorporated after the fixes for the 2/25 game update are completed -->

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -1,3 +1,6 @@
+<!-- TODO: Firaxis made changes to the City Banner Files for vanilla, using the file layout they use with the Expansions.  -->
+<!--       There appear to be no significant changes with that move, aside from renaming the "CityAttackContainer" to "CityStrike" and "CityRangeStrikeButton" to "CityStrikeButton"  -->
+
 <?xml version="1.0" encoding="utf-8" ?>
 
 <Context>
@@ -128,8 +131,8 @@
                     </Container>
                 </Stack>
 
-                <Image ID="CityAttackContainer" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" AnchorSide="I,O" Offset="0,-6">
-                    <Button ID="CityRangeStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_CITY_RANGE_STRIKE"/>
+                <Image ID="CityStrike" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" AnchorSide="I,O" Offset="0,-6">
+                    <Button ID="CityStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_CITY_RANGE_STRIKE"/>
                 </Image>
 
                 <Grid ID="BannerStrengthBacking" Texture="Banner_StrengthBacking" Size="55,15" Anchor="C,T" SliceTextureSize="42,15" SliceCorner="21,7" AnchorSide="I,O" Color="255,255,255,150">
@@ -237,8 +240,8 @@
 
                 <Grid ID="CityStateQuest" Texture="CityStateQuest28" SliceTextureSize="28,23" SliceCorner="14,6" Size="28,30" Hidden="1" Offset="-5,-22" />
 
-                <Image ID="CityAttackContainer" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" AnchorSide="I,O" Offset="0,-6">
-                    <Button ID="CityRangeStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_CITY_RANGE_STRIKE"/>
+                <Image ID="CityStrike" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" AnchorSide="I,O" Offset="0,-6">
+                    <Button ID="CityStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_CITY_RANGE_STRIKE"/>
                 </Image>
 
                 <Grid ID="BannerStrengthBacking" Texture="Banner_StrengthBacking" Size="55,15" Anchor="C,T" SliceTextureSize="42,15" SliceCorner="21,7" AnchorSide="I,O" Color="255,255,255,150">
@@ -396,8 +399,8 @@
                 </Grid>
 
                 <!-- District ranged strike button -->
-                <Image ID="CityAttackContainer" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" Offset="0,-4" AnchorSide="I,O">
-                    <Button ID="CityRangeStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_DISTRICT_RANGE_STRIKE"/>
+                <Image ID="CityStrike" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" Offset="0,-4" AnchorSide="I,O">
+                    <Button ID="CityStrikeButton" Style="CityBannerRangeAttack" Anchor="C,B" Offset="0,10" StateOffsetIncrement="0,25" ConsumeMouse="1" ToolTip="LOC_CITY_BANNER_DISTRICT_RANGE_STRIKE"/>
                 </Image>
             </Container>
         </ZoomAnchor>
@@ -529,4 +532,19 @@
         </ZoomAnchor>
     </Instance>
 
+    <!-- Barbarian Tribe Minibanner -->
+    <!-- This is in place in order to allow CQUI and the new Barbarian Tribes Mode to co-exist.  This is a copy of the Instance object Firaxis defined in the CityBannerManager.xml that accompanies that new mode. -->
+    <Instance	Name="TribeBanner">
+        <ZoomAnchor ID="Anchor" ZoomOffsetNear="0,0,0" ZoomOffsetFar="0,0,-20">
+            <Container ID="TribeBannerContainer" Anchor="C,C" Size="106,34">
+                <Button ID="TribeBannerButton" Anchor="C,C" Size="parent,parent"/>
+                
+                <Grid ID="Banner_Base"    Size="Parent,Parent" Texture="BannerMini_Base_Combo" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
+                <Image ID="TribeIcon" Anchor="L,C" Offset="0,0" Size="30,30" Icon="ICON_DISTRICT_CITY_CENTER"/>
+                <TextureBar Anchor="C,C" Offset="5,0" Size="60,7"	Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="40,64,82,200"/>
+                <TextureBar ID="ConversionBar" Anchor="C,C" Offset="5,0"	Size="60,7"	Texture="CityBannerShieldsBar1" Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
+
+            </Container>
+        </ZoomAnchor>
+    </Instance>
 </Context>

--- a/Assets/UI/unitflagmanager.xml
+++ b/Assets/UI/unitflagmanager.xml
@@ -7,6 +7,7 @@
     <Container ID="TradeFlags"/>
     <Container ID="SupportFlags"/>
     <Container ID="NavalFlags"/>
+    <Container ID="CQUI_UnitFlagManager_HiddenContainer" Hidden="1"/>
 
     <Instance Name="UnitFlag">
         <!-- TODO clamp zoom level from 0.6 to 1 -->
@@ -58,6 +59,10 @@
                         <Image ID="New_Promotion_Flag" Size="20,25" Texture="UnitFlag_Promo.dds" Hidden="1" Color="255,255,0,255" />
                     </AlphaAnim>
                     <Label ID="UnitNumPromotions" Anchor="C,C" Offset="-1,1" Style="FontFlair20" Color="0,0,0,255"/>
+                </Image>
+                <!-- Imported from the Barbarian Tribes Mode -->
+                <Image ID="TribeStatusFlag" Anchor="R,C" Size="20,25" Offset="-8,0" Texture="UnitFlag_Promo.dds" Hidden="1">
+                    <Image ID="TribeStatusIcon" Anchor="C,C" Offset="-1,0" Size="22,22" Texture="Bribe22"/>
                 </Image>
                 <!-- Corps and Army Indicators -->
                 <Container ID="CorpsMarker" Size="10,10" Anchor="C,T" Hidden="1" Offset="1,4">

--- a/Assets/UI/unitflagmanager_CQUI.lua
+++ b/Assets/UI/unitflagmanager_CQUI.lua
@@ -2,6 +2,7 @@
 -- Base File
 -- ===========================================================================
 include("UnitFlagManager");
+include("CQUICommon.lua");
 
 -- ===========================================================================
 -- Cached Base Functions
@@ -15,7 +16,10 @@ BASE_CQUI_UpdateFlagType = UnitFlag.UpdateFlagType;
 BASE_CQUI_OnLensLayerOn = OnLensLayerOn;
 BASE_CQUI_OnLensLayerOff = OnLensLayerOff;
 BASE_CQUI_ShouldHideFlag = ShouldHideFlag;
+BASE_CQUI_Subscribe = Subscribe;
+BASE_CQUI_Unsubscribe = Unsubscribe;
 BASE_CQUI_UpdateIconStack = UpdateIconStack;
+BASE_CQUI_UpdateName = UnitFlag.UpdateName;
 BASE_CQUI_Refresh = Refresh;
 
 local m_HexColoringReligion:number = UILens.CreateLensLayerHash("Hex_Coloring_Religion");
@@ -286,6 +290,45 @@ function UnitFlag.UpdatePromotions( self )
                 end
             end
         end
+
+        -- WORKAROUND: The Barbarian Clans Mode also uses ReplaceUIScript for UnitFlagManager
+        --             This code is copied from the UnitFlagManager_BarbarianClansMode.lua
+        if (g_bIsBarbarianClansMode) then
+            self.m_Instance.TribeStatusFlag:SetHide(true);
+            local tribeIndex : number = pUnit:GetBarbarianTribeIndex();
+            if(tribeIndex >= 0)then
+    
+                local pBarbarianTribeManager : table = Game.GetBarbarianManager();
+                local bribedTurnsRemaining : number = pBarbarianTribeManager:GetTribeBribeTurnsRemaining(tribeIndex, localPlayerID);
+                self.m_Instance.Promotion_Flag:SetHide(true);
+    
+                --Show any Barbarian Tribe specific status icons (bribed, incited)
+                if(bribedTurnsRemaining > 0)then
+                    --Show bribe icon w/ turns remaining tooltip
+                    self.m_Instance.TribeStatusFlag:SetHide(false);
+                    self.m_Instance.TribeStatusIcon:SetTexture(BRIBE_STATUS_ICON_NAME);
+                    return;
+                else
+                    local inciteTargetID : number = pBarbarianTribeManager:GetTribeInciteTargetPlayer(tribeIndex);
+                    if (inciteTargetID >= 0) then
+                        if(inciteTargetID == localPlayerID)then
+                            --Show incited against us icon
+                            self.m_Instance.TribeStatusFlag:SetHide(false);
+                            self.m_Instance.TribeStatusIcon:SetTexture(INCITE_AGAINST_PLAYER_STATUS_ICON_NAME);
+                            return;
+                        else
+                            local inciteSourceID : number = pBarbarianTribeManager:GetTribeInciteSourcePlayer(tribeIndex);
+                            if(inciteSourceID == localPlayerID)then
+                                --Show we incited them icon
+                                self.m_Instance.TribeStatusFlag:SetHide(false);
+                                self.m_Instance.TribeStatusFlag:SetTexture(INCITE_BY_PLAYER_STATUS_ICON_NAME);
+                                return;
+                            end
+                        end
+                    end
+                end
+            end
+        end -- BarbarianClansMode Loaded
     end
 end
 
@@ -499,7 +542,103 @@ function UpdateIconStack( plotX:number, plotY:number )
 end
 
 -- ===========================================================================
-function Initialize()
+-- IMPORTS FROM THE BARBARIAN CLANS MODE
+-- Firaxis implemented the Barbarian Clans Mode using a ReplaceUIScript with UnitFlagManager
+-- ReplaceUIScript can only happen once, so in order to get their additions to work with CQUI, we have to copy that code
+-- The functions below pull those changes from Barbarian Clans mode in to CQUI so they can work together
+-- ===========================================================================
+function UnitFlag.UpdateName( self )
+    BASE_CQUI_UpdateName(self);
+
+    -- WORKAROUND: This implements the extension to UnitFlag.UpdateName that Firaxis put into
+    -- their UnitFlagManager_BarbarianClansMode.lua.  Copying that code here allows CQUI to load its UnitFlagManager
+    -- changes with the Barbarian Clans mode.
+    if (g_bIsBarbarianClansMode) then
+        local localPlayerID : number = Game.GetLocalPlayer();
+        if (localPlayerID == -1) then
+            return;
+        end
+    
+        local pUnit : table = self:GetUnit();
+        if(pUnit ~= nil)then
+            local tribeIndex : number = pUnit:GetBarbarianTribeIndex();
+            if(tribeIndex >= 0)then
+                
+                local pBarbarianTribeManager : table = Game.GetBarbarianManager();
+                local bribedTurnsRemaining : number = pBarbarianTribeManager:GetTribeBribeTurnsRemaining(tribeIndex, localPlayerID);
+                local nameString = self.m_Instance.UnitIcon:GetToolTipString();
+    
+                local barbType : number = pBarbarianTribeManager:GetTribeNameType(tribeIndex);
+                if(barbType >= 0)then
+                    local pBarbTribe : table = GameInfo.BarbarianTribeNames[barbType];
+                    nameString = nameString .. "[NEWLINE]" .. Locale.Lookup(pBarbTribe.TribeDisplayName);
+    
+                    --Add any Barbarian Tribe specific statuses (bribed, incited) to the unit tooltip
+                    if(bribedTurnsRemaining > 0)then
+                        --Add bribe turns remaining to the unit tooltip
+                        nameString = nameString .. "[NEWLINE]" .. Locale.Lookup("LOC_BARBARIAN_STATUS_BRIBED", bribedTurnsRemaining);
+                    else
+                        local inciteTargetID : number = pBarbarianTribeManager:GetTribeInciteTargetPlayer(tribeIndex);
+                        if (inciteTargetID >= 0) then
+                            if(inciteTargetID == localPlayerID)then
+                                --Add incited against us to the unit tooltip
+                                local inciteSourcePlayer : table = PlayerConfigurations[pBarbarianTribeManager:GetTribeInciteSourcePlayer(tribeIndex)];
+                                local inciteSourcePlayerName : string = inciteSourcePlayer:GetPlayerName();
+                                nameString = nameString .. "[NEWLINE]" .. Locale.Lookup("LOC_BARBARIAN_STATUS_INCITED_AGAINST_YOU", inciteSourcePlayerName);
+                            else
+                                local inciteSourceID : number = pBarbarianTribeManager:GetTribeInciteSourcePlayer(tribeIndex);
+                                if(inciteSourceID == localPlayerID)then
+                                    --Add incited by us to the unit tooltip
+                                    local inciteTargetPlayer : table = PlayerConfigurations[pBarbarianTribeManager:GetTribeInciteTargetPlayer(tribeIndex)];
+                                    local inciteTargetPlayerName : string = inciteTargetPlayer:GetPlayerName();
+                                    nameString = nameString .. "[NEWLINE]" .. Locale.Lookup("LOC_BARBARIAN_STATUS_INCITED_BY_YOU", inciteTargetPlayerName);
+                                end
+                            end
+                        end
+                    end
+    
+                    self.m_Instance.UnitIcon:SetToolTipString( nameString );
+                end
+            end
+        end
+    end -- if Barbarian Clans Mode loaded
+end
+
+-- ===========================================================================
+function OnPlayerOperationComplete(playerID : number, operation : number)
+    --Update Barbarian UnitFlag tooltip and status icons in case we have Bribed or Incited them
+    if(operation == PlayerOperations.BRIBE_CLAN or operation == PlayerOperations.INCITE_CLAN)then
+        local pBarbarianPlayer = Players[PlayerTypes.BARBARIAN]
+        local pBarbarianUnits:table = pBarbarianPlayer:GetUnits();
+        for i, pUnit in pBarbarianUnits:Members() do
+            local flag:table = GetUnitFlag(PlayerTypes.BARBARIAN, pUnit:GetID());
+            flag:UpdateName();
+            flag:UpdatePromotions();
+        end
+    end
+end
+
+-- ===========================================================================
+function Subscribe()
+    BASE_CQUI_Subscribe();
+    Events.PlayerOperationComplete.Add(OnPlayerOperationComplete);
+end
+
+-- ===========================================================================
+function Unsubscribe()
+    if BASE_CQUI_Unsubscribe ~= nil then
+        BASE_CQUI_Unsubscribe();
+    end
+
+    Events.PlayerOperationComplete.Remove(OnPlayerOperationComplete);
+end
+
+-- ===========================================================================
+-- END Imports from Barbarian Clans Mode
+-- ===========================================================================
+
+-- ===========================================================================
+function Initialize_UnitFlagManager_CQUI()
     ContextPtr:SetRefreshHandler(CQUI_Refresh);
 
     Events.DiplomacyMakePeace.Add(OnDiplomacyWarStateChange);
@@ -518,4 +657,4 @@ function Initialize()
     LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
     LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 end
-Initialize();
+Initialize_UnitFlagManager_CQUI();

--- a/Assets/UI/unitflagmanager_CQUI.lua
+++ b/Assets/UI/unitflagmanager_CQUI.lua
@@ -26,6 +26,11 @@ local m_HexColoringReligion:number = UILens.CreateLensLayerHash("Hex_Coloring_Re
 local m_IsReligionLensOn:boolean = false;
 local m_CQUIInitiatedRefresh = false;
 
+-- Constants (from Barbarian Clans mode)
+local BRIBE_STATUS_ICON_NAME				: string = "Bribe22";
+local INCITE_AGAINST_PLAYER_STATUS_ICON_NAME: string = "Incite22";
+local INCITE_BY_PLAYER_STATUS_ICON_NAME		: string = "InciteByMe22";	--TODO: Asset requested
+
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
@@ -572,7 +577,7 @@ function UnitFlag.UpdateName( self )
                 if(barbType >= 0)then
                     local pBarbTribe : table = GameInfo.BarbarianTribeNames[barbType];
                     nameString = nameString .. "[NEWLINE]" .. Locale.Lookup(pBarbTribe.TribeDisplayName);
-    
+
                     --Add any Barbarian Tribe specific statuses (bribed, incited) to the unit tooltip
                     if(bribedTurnsRemaining > 0)then
                         --Add bribe turns remaining to the unit tooltip

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -165,8 +165,6 @@
                 <File>Assets/UI/productionpanel.xml</File>
                 <File>Assets/UI/toppanel_CQUI_basegame.lua</File>
                 <File>Assets/UI/toppanel_CQUI.lua</File>
-                <File>Assets/UI/unitflagmanager_CQUI.lua</File>
-                <File>Assets/UI/unitflagmanager.xml</File>
                 <File>Assets/UI/worldinput_CQUI_basegame.lua</File>
                 <File>Assets/UI/worldinput_CQUI.lua</File>
                 <File>Assets/UI/WorldTracker_CQUI.lua</File>
@@ -196,8 +194,6 @@
                 <File>Assets/UI/Screens/CivicsTree_CQUI.lua</File>
                 <File>Assets/UI/Screens/governmentscreen_CQUI_basegame.lua</File>
                 <File>Assets/UI/Screens/governmentscreen_CQUI.lua</File>
-                <File>Assets/UI/ToolTips/plottooltip_CQUI_basegame.lua</File>
-                <File>Assets/UI/ToolTips/plottooltip_CQUI.lua</File>
                 <File>Assets/UI/Utilities/extendedrelationship.lua</File>
                 <File>Assets/UI/WorldView/districtploticonmanager_CQUI.lua</File>
                 <File>Assets/UI/WorldView/plotinfo_CQUI.lua</File>
@@ -232,9 +228,17 @@
         </ImportFiles>
 
         <ImportFiles id="CQUI_IMPORT_FILES_CITYBANNERMANAGER_BASEGAME">
+            <Properties>
+                <!-- We need to ensure that the CQUI CityBannerManager.xml loads instead of say, the one from the Barbarian Tribes mode -->
+                <LoadOrder>50</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
             <Items>
                 <File>Assets/UI/WorldView/CityBannerManager_CQUI.lua</File>
                 <File>Assets/UI/WorldView/citybannermanager.xml</File>
+                <!-- Placeholder for future work -->
+                <!-- <File>Assets/UI/WorldView/CityBannerInstances.xml</File> -->
+                <!-- <File>Assets/UI/WorldView/CityReligionInstances.xml</File> -->
             </Items>
         </ImportFiles>
 
@@ -259,6 +263,40 @@
                 <File>Assets/Expansion2/CityBanners/citybannermanager.xml</File>
                 <File>Assets/Expansion2/CityBanners/CityBannerInstances.xml</File>
                 <File>Assets/Expansion2/CityBanners/CityReligionInstances.xml</File>
+            </Items>
+        </ImportFiles>
+
+        <!-- Firaxis added a ReplaceUIScript for PlotToolTip with LoadOrder 0; CQUI incorporated those changes so both could work together -->
+        <ImportFiles id="CQUI_PLOTTOOLTIP_BASEGAME">
+            <Properties>
+                <LoadOrder>50</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/UI/ToolTips/plottooltip_CQUI_basegame.lua</File>
+                <File>Assets/UI/ToolTips/plottooltip_CQUI.lua</File>
+            </Items>
+        </ImportFiles>
+
+        <ImportFiles id="CQUI_PLOTTOOLTIP_EXP2" criteria="Expansion2">
+            <Properties>
+                <LoadOrder>200</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/Expansion2/Replacements/plottooltip_CQUI_expansion2.lua</File>
+            </Items>
+        </ImportFiles>
+
+        <!-- Firaxis added a ReplaceUIScript for UnitFlagManager with LoadOrder 0; CQUI incorporated those changes so both could work together -->
+        <ImportFiles id="CQUI_UNITFLAGMANAGER">
+            <Properties>
+                <LoadOrder>50</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/UI/unitflagmanager_CQUI.lua</File>
+                <File>Assets/UI/unitflagmanager.xml</File>
             </Items>
         </ImportFiles>
 
@@ -315,7 +353,6 @@
                 <File>Assets/Expansion2/Replacements/ingame.lua</File>
                 <File>Assets/Expansion2/Replacements/launchbar_CQUI_expansion2.lua</File>
                 <File>Assets/Expansion2/Replacements/partialscreenhooks_CQUI_expansion2.lua</File>
-                <File>Assets/Expansion2/Replacements/plottooltip_CQUI_expansion2.lua</File>
                 <File>Assets/Expansion2/Replacements/toppanel_CQUI_expansion2.lua</File>
                 <File>Assets/Expansion2/Replacements/unitpanel_CQUI_expansion2.lua</File>
                 <File>Assets/Expansion2/Replacements/worldinput_CQUI_expansion2.lua</File>
@@ -605,6 +642,8 @@
 
         <ReplaceUIScript id="CQUI_UnitFlagManager">
             <Properties>
+                <!-- Firaxis Barbarians Clans Mode has a LoadOrder 0 for their ReplaceUIScript of UnitFlagManager; files load at 50 above -->
+                <LoadOrder>50</LoadOrder>
                 <LuaContext>UnitFlagManager</LuaContext>
                 <LuaReplace>Assets/UI/unitflagmanager_CQUI.lua</LuaReplace>
             </Properties>
@@ -658,6 +697,8 @@
 
         <ReplaceUIScript id="CQUI_PlotToolTip">
             <Properties>
+                <!-- LoadOrder of 50 to ensure it loads after the Firaxis replacement for PlotToolTip bundled with the Barbarian Clans Mode -->
+                <LoadOrder>50</LoadOrder>
                 <LuaContext>PlotToolTip</LuaContext>
                 <LuaReplace>Assets/UI/ToolTips/plottooltip_CQUI_basegame.lua</LuaReplace>
             </Properties>
@@ -1135,6 +1176,9 @@
         <File>Assets/UI/Utilities/extendedrelationship.lua</File>
         <File>Assets/UI/WorldView/CityBannerManager_CQUI.lua</File>
         <File>Assets/UI/WorldView/citybannermanager.xml</File>
+        <!-- Placeholder for future work -->
+        <!-- <File>Assets/UI/WorldView/CityBannerInstances.xml</File> -->
+        <!-- <File>Assets/UI/WorldView/CityReligionInstances.xml</File> -->
         <File>Assets/UI/WorldView/districtploticonmanager_CQUI.lua</File>
         <File>Assets/UI/WorldView/plotinfo_CQUI.lua</File>
         <File>Assets/UI/WorldView/plotinfo.xml</File>


### PR DESCRIPTION
Note: The changes in this code have already been uploaded to the Steam Workshop.

Makes CQUI work with the Feb 2021 patch and the new Barbarian Clans mode.
The BClans mode replaces a few of the files that CQUI also replaces, CityBannerManager.xml, UnitFlagManager.lua and PlotTooltip.lua.
 - CQUI now loads each of these files later, to ensure the CQUI version is loaded (LoadOrder is set to 50; Firaxis files have a LoadOrder of 0).
 - The code that Firaxis put into their various files is incorporated into the CQUI versions of those files, meaning that CQUI enables all of the new things that come along with the Clans mode when both are loaded.

Firaxis also changed a minor thing with the CityBanners for vanilla, I added some placeholders that I'll tackle when this is done.

I tested on XP1, XP2, and vanilla and things looked okay.
