### PR TITLE
Fix for crash in Barbarian Clans mode

### DIFF
--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -1931,14 +1931,18 @@ function UpdateTribeBannerConversionBar(barbarianTribeEntry : table)
             barbarianTribeEntry.BannerInstance.TribeRansomUnitBacking:SetToolTipString(Locale.Lookup("LOC_UNITCOMMAND_TREAT_WITH_CLAN_RANSOM_DESCRIPTION"));
         end
 
-        local bCanStartHire = UI.CanStartPlayerOperation(localPlayerID, PlayerOperations.HIRE_CLAN, tParameters, false);
-        if (bCanStartHire) then
-            -- I don't want an icon that shows on the bar like the others as this (you can hire a unit) would be something that is very common
-            -- As the gold icons and similar cannot be made smaller than they already are... use an asterisk, consider something better later on?
-            barbarianTribeEntry.BannerInstance.CanHireUnit:SetHide(false);
-            barbarianTribeEntry.BannerInstance.CanHireUnit:SetText("*");
-            -- TODO: Add a string for the tool tip - this just says "Hire Clan"
-            barbarianTribeEntry.BannerInstance.CanHireUnit:SetToolTipString(Locale.Lookup("LOC_UNITCOMMAND_TREAT_WITH_CLAN_HIRE_DESCRIPTION"));
+        -- Calling HIRE_CLAN if you do not have a city will result in the game crashing
+        local pActivePlayer = Players[localPlayerID];
+        if (pActivePlayer:GetCities():GetCount() >= 1) then
+            local bCanStartHire = UI.CanStartPlayerOperation(localPlayerID, PlayerOperations.HIRE_CLAN, tParameters, false);
+            if (bCanStartHire) then
+                -- I don't want an icon that shows on the bar like the others as this (you can hire a unit) would be something that is very common
+                -- As the gold icons and similar cannot be made smaller than they already are... use an asterisk, consider something better later on?
+                barbarianTribeEntry.BannerInstance.CanHireUnit:SetHide(false);
+                barbarianTribeEntry.BannerInstance.CanHireUnit:SetText("*");
+                -- TODO: Add a string for the tool tip - this just says "Hire Clan"
+                barbarianTribeEntry.BannerInstance.CanHireUnit:SetToolTipString(Locale.Lookup("LOC_UNITCOMMAND_TREAT_WITH_CLAN_HIRE_DESCRIPTION"));
+            end
         end
     end
 


### PR DESCRIPTION
CQUI: "Can the player hire a unit from that barbarian camp?"
Civ: "Does the player have a city yet?"
CQUI: "No..."
Civ: *crashes*

The UI.CanPlayerStartOperation code is based on Firaxis-authored code in TreatTribeWithPopup.lua -- basically the stuff that happens when you click on a barbarian banner.  There's a comment on that code that says only do the "Hire" stuff if the player has at least 1 city... which I thought was strange, so I didn't protect my call to see if "Hire" was available with that check.  Now I know why it was necessary. 

I have uploaded this change to the Workshop.

For reference, this is that Firaxis-authored code:
```lua
	-- Hire: show as long as the player has a city
	if (pActivePlayer:GetCities():GetCount() >= 1) then
		Controls.HireOption:SetHide(false);
		local bCanStartHire, tHireResults = UI.CanStartPlayerOperation(iActivePlayer, PlayerOperations.HIRE_CLAN, tParameters, bIsExclusionTest);
		Controls.TreatOptionButtonHire:SetDisabled(not bCanStartHire);
		local strGameplayText = FormatOperationGameplayText(tHireResults);
		Controls.TreatOptionHireDescription:SetText(strGameplayText);
	else
		Controls.HireOption:SetHide(true);
		Controls.TreatOptionButtonHire:SetDisabled(true);
	end
```
