### PR TITLE
Fixed issue where Barbarian Banners did not clear when dispersed

### DIFF
--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -266,7 +266,7 @@ function GetTurnsToCompleteStrings( turnsToComplete:number )
     if turnsToComplete == -1 then
         turnsStr = "999+[ICON_Turn]";
         turnsStrTT = TXT_HUD_CITY_WILL_NOT_COMPLETE;
-    elseif turnsToComplete == -2 then
+    elseif turnsToComplete == CQUI_FAITH_ONLY_TURNS_LEFT then
         turnsStr = "[ICON_Faith][ICON_Turn]";
         -- TODO: Build a better string for this?  Or since one isn't needed
         turnsStrTT = Locale.Lookup("LOC_PRODPANEL_PURCHASE_FAITH");

--- a/Assets/cqui_main.lua
+++ b/Assets/cqui_main.lua
@@ -3,6 +3,6 @@
 --include("CQUICommon.lua");
 
 function Initialize()
-    print("CQUI Loaded! Update for v1.0.9.9 (2021-01-28)");
+    print("CQUI Loaded! Update for v1.0.10.15 (2021-02-25)");
 end
 Initialize();


### PR DESCRIPTION
Finally figured out what was going on - calling _Reload()_ when updating settings caused all of the _OnImprovementAddedToMap()_ events to be called, which in turn would add a new instance of the Barbarian Banner over the top of the existing one.  As such, when the camp was cleared, one of the banners would also clear, but because they all did not clear it looks like nothing happened.

I made one other minor fix and updated the CQUI version number that appears in the log, as that number actually helped me solve a different issue for someone on Reddit.
