### PR TITLE
Fix CityPanel + Enhancement (remove Religious Followers, add Loyalty status)

### DIFF
--- a/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
@@ -6,6 +6,22 @@ BASE_ViewMain = ViewMain;
 -- ===========================================================================
 function ViewMain( kData:table )
 	BASE_ViewMain( kData );
+	
+	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+	--swarsele: change religious citizens to loyalty
+    local pCity = UI.GetHeadSelectedCity()
+    if pCity ~= nil then
+		local pCulturalIdentity = pCity:GetCulturalIdentity();
+		local currentLoyalty = pCulturalIdentity:GetLoyalty();
+		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
+
+		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
+		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
+		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
+
+    end
+	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
+	
 end
 
 -- ===========================================================================

--- a/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
@@ -1,0 +1,21 @@
+-- Copyright 2017-2019, Firaxis Games
+
+include("CityPanel");
+BASE_ViewMain = ViewMain;
+
+-- ===========================================================================
+function ViewMain( kData:table )
+	BASE_ViewMain( kData );
+end
+
+-- ===========================================================================
+function OnCityLoyaltyChanged( ownerPlayerID:number, cityID:number )
+	if UI.IsCityIDSelected(ownerPlayerID, cityID) then
+		UI.DeselectCityID(ownerPlayerID, cityID);
+	end
+end
+
+-- ===========================================================================
+function LateInitialize()
+	Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
+end

--- a/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
@@ -6,6 +6,22 @@ BASE_ViewMain = ViewMain;
 -- ===========================================================================
 function ViewMain( kData:table )
 	BASE_ViewMain( kData );
+	
+	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+	--swarsele: change religious citizens to loyalty
+    local pCity = UI.GetHeadSelectedCity()
+    if pCity ~= nil then
+		local pCulturalIdentity = pCity:GetCulturalIdentity();
+		local currentLoyalty = pCulturalIdentity:GetLoyalty();
+		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
+
+		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
+		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
+		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
+
+    end
+	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
+	
 end
 
 -- ===========================================================================

--- a/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
@@ -1,0 +1,21 @@
+-- Copyright 2017-2019, Firaxis Games
+
+include("CityPanel");
+BASE_ViewMain = ViewMain;
+
+-- ===========================================================================
+function ViewMain( kData:table )
+	BASE_ViewMain( kData );
+end
+
+-- ===========================================================================
+function OnCityLoyaltyChanged( ownerPlayerID:number, cityID:number )
+	if UI.IsCityIDSelected(ownerPlayerID, cityID) then
+		UI.DeselectCityID(ownerPlayerID, cityID);
+	end
+end
+
+-- ===========================================================================
+function LateInitialize()
+	Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
+end

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -761,7 +761,7 @@ function ViewMain( data:table )
     Controls.AmenitiesButton:SetOffsetX(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].x);
     Controls.AmenitiesButton:SetOffsetY(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].y);
     m_CurrentPanelLine = m_CurrentPanelLine + 1;
-	
+
     Controls.ReligionNum:SetText( data.ReligionFollowers );
 
     Controls.HousingNum:SetText( data.Population );

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -762,7 +762,7 @@ function ViewMain( data:table )
     Controls.AmenitiesButton:SetOffsetY(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].y);
     m_CurrentPanelLine = m_CurrentPanelLine + 1;
 	
-	Controls.ReligionNum:SetText( data.ReligionFollowers );
+    Controls.ReligionNum:SetText( data.ReligionFollowers );
 
     Controls.HousingNum:SetText( data.Population );
     colorName = GetPercentGrowthColor( data.HousingMultiplier );

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -762,21 +762,8 @@ function ViewMain( data:table )
     Controls.AmenitiesButton:SetOffsetY(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].y);
     m_CurrentPanelLine = m_CurrentPanelLine + 1;
 	
-	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-	--swarsele: change religious citizens to loyalty
-    local pCity = UI.GetHeadSelectedCity()
-    if pCity ~= nil then
-		local pCulturalIdentity = pCity:GetCulturalIdentity();
-		local currentLoyalty = pCulturalIdentity:GetLoyalty();
-		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
+	Controls.ReligionNum:SetText( data.ReligionFollowers );
 
-		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
-		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
-		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
-
-    end
-	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
-	
     Controls.HousingNum:SetText( data.Population );
     colorName = GetPercentGrowthColor( data.HousingMultiplier );
     Controls.HousingNum:SetColorByName( colorName );

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -761,9 +761,22 @@ function ViewMain( data:table )
     Controls.AmenitiesButton:SetOffsetX(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].x);
     Controls.AmenitiesButton:SetOffsetY(PANEL_BUTTON_LOCATIONS[m_CurrentPanelLine].y);
     m_CurrentPanelLine = m_CurrentPanelLine + 1;
+	
+	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+	--swarsele: change religious citizens to loyalty
+    local pCity = UI.GetHeadSelectedCity()
+    if pCity ~= nil then
+		local pCulturalIdentity = pCity:GetCulturalIdentity();
+		local currentLoyalty = pCulturalIdentity:GetLoyalty();
+		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
 
-    Controls.ReligionNum:SetText( data.ReligionFollowers );
+		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
+		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
+		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
 
+    end
+	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
+	
     Controls.HousingNum:SetText( data.Population );
     colorName = GetPercentGrowthColor( data.HousingMultiplier );
     Controls.HousingNum:SetColorByName( colorName );

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -434,6 +434,16 @@
                 <File>Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua</File>
             </Items>
         </ImportFiles>
+		
+		<ImportFiles id="CQUI_IMPORT_FILES_EXP1_CITYPANEL" criteria="Expansion1">
+            <Properties>
+                <LoadOrder>100</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/Expansion1/Replacements/CityPanel_Expansion1.lua</File>
+            </Items>
+        </ImportFiles>
 
         <ImportFiles id="CQUI_IMPORT_FILES_EXP1_CITYSTATES" criteria="Expansion1">
             <Properties>
@@ -557,6 +567,16 @@
             </Properties>
             <Items>
                 <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
+            </Items>
+        </ImportFiles>
+		
+		<ImportFiles id="CQUI_IMPORT_FILES_EXP2_CITYPANEL" criteria="Expansion2">
+            <Properties>
+                <LoadOrder>200</LoadOrder>
+                <Context>InGame</Context>
+            </Properties>
+            <Items>
+                <File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
             </Items>
         </ImportFiles>
 
@@ -1374,6 +1394,7 @@
         <File>Assets/Expansion1/Replacements/toppanel_CQUI_expansion1.lua</File>
         <File>Assets/Expansion1/Replacements/unitpanel_CQUI_expansion1.lua</File>
         <File>Assets/Expansion1/Replacements/worldinput_CQUI_expansion1.lua</File>
+		<File>Assets/Expansion1/Replacements/CityPanel_Expansion1.lua</File>
 
         <!-- EXP 2 -->
         <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
@@ -1390,6 +1411,7 @@
         <File>Assets/Expansion2/Replacements/toppanel_CQUI_expansion2.lua</File>
         <File>Assets/Expansion2/Replacements/unitpanel_CQUI_expansion2.lua</File>
         <File>Assets/Expansion2/Replacements/worldinput_CQUI_expansion2.lua</File>
+		<File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
         <File>Assets/Expansion2/CityBanners/citybannermanager.xml</File>
         <File>Assets/Expansion2/CityBanners/citybannerinstances.xml</File>
         <File>Assets/Expansion2/CityBanners/cityreligioninstances.xml</File>


### PR DESCRIPTION
Something changed during the recent updates that made CQUI not load its changes to CityPanel (despite no apparent change from Firaxis' side nor CQUI's), resulting in the unchanged CityPanel despite CQUI's customizations:

![current](https://user-images.githubusercontent.com/32304731/117480765-4db07d80-af62-11eb-8193-00a4a25dbe86.PNG)

This PR for one fixes this problem.
On the other hand, I find that the information about religious citizens is of nearly no use - instead, I replaced it with the current loyalty status, and also show the current change per round at a glance:

![new](https://user-images.githubusercontent.com/32304731/117481056-ba2b7c80-af62-11eb-8ad8-89167ca3b1be.PNG)
