### PR TITLE
CQUI Monopoly++ integration

### DIFF
--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -282,7 +282,6 @@ function GetData()
                 ArmyTurnsLeft       = 1,
                 ArmyTooltip         = "",
                 ArmyName            = "",
-                IsCurrentProduction = row.Hash == m_CurrentProductionHash,
                 ReligiousStrength   = row.ReligiousStrength,
                 IsCurrentProduction = row.Hash == m_CurrentProductionHash
             };

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -282,6 +282,8 @@ function GetData()
                 ArmyTurnsLeft       = 1,
                 ArmyTooltip         = "",
                 ArmyName            = "",
+                IsCurrentProduction = row.Hash == m_CurrentProductionHash,
+                ReligiousStrength   = row.ReligiousStrength,
                 IsCurrentProduction = row.Hash == m_CurrentProductionHash
             };
 


### PR DESCRIPTION
I've tried to add compatibility for a Monopoly++ by adding another type of checking similar to FAITH based on GOLD instead. But for some reason, production doesn't show up when the city should be able for buying them. Maybe somebody could follow it up.