### PR TITLE
Show all tiles owned by City on mouse-over, show city borders, slide Minimap when in City View

### DIFF
--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -107,7 +107,7 @@ local CQUI_ShowCityDetailAdvisor :boolean = false;
 
 -- ===========================================================================
 function CQUI_OnSettingsUpdate()
-        CQUI_ShowCityDetailAdvisor = GameConfiguration.GetValue("CQUI_ShowCityDetailAdvisor") == 1
+    CQUI_ShowCityDetailAdvisor = GameConfiguration.GetValue("CQUI_ShowCityDetailAdvisor") == 1
 end
 
 LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
@@ -115,13 +115,13 @@ LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 
 -- ====================CQUI Cityview==========================================
 function CQUI_OnCityviewEnabled()
-        OnShowOverviewPanel(true)
+    OnShowOverviewPanel(true)
 end
 
 -- ===========================================================================
 function CQUI_OnCityviewDisabled()
-        OnShowOverviewPanel(false);
-        LuaEvents.CQUI_ClearCitizenManagement();
+    OnShowOverviewPanel(false);
+    LuaEvents.CQUI_ClearCitizenManagement();
 end
 
 LuaEvents.CQUI_CityPanelOverview_CityviewEnable.Add( CQUI_OnCityviewEnabled);

--- a/Assets/UI/ToolTips/plottooltip_CQUI.lua
+++ b/Assets/UI/ToolTips/plottooltip_CQUI.lua
@@ -9,6 +9,7 @@ BASE_CQUI_View = View;
 -- ===========================================================================
 -- CQUI Members
 -- ===========================================================================
+local m_ShowPlotXY = false;
 
 -- ===========================================================================
 --  CQUI modified GetDetails functiton
@@ -17,6 +18,12 @@ BASE_CQUI_View = View;
 function GetDetails(data)
     local details = {};
     local iTourism:number = 0; -- #75
+
+    if (m_ShowPlotXY == true) then
+        local plotXY = Map.GetPlotByIndex(data.Index);
+        local xystring = "X:"..plotXY:GetX().." Y:"..plotXY:GetY().."[NEWLINE]";
+        table.insert(details,xystring);
+    end
 
     --Civilization and city ownership line
     if (data.Owner ~= nil) then

--- a/Integrations/ML/DLC/Expansion1/UI/Replacements/minimappanel.xml
+++ b/Integrations/ML/DLC/Expansion1/UI/Replacements/minimappanel.xml
@@ -35,55 +35,57 @@
     </Grid>
 
     <Container Size="300,200" ID="MiniMap" Anchor="L,B" Offset="-3,0">
-        <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
-            <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
-                <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
-                    <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
-                </Grid>
-                <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
-                    <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
+        <SlideAnim Size="300,200" ID="MiniMapAnimSideways" Begin="0,0" End="300,0" Function="OutQuint" Speed="3.5" Cycle="Once" Stopped="1">
+            <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
+                <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
+                    <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
+                        <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
+                    </Grid>
+                    <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
+                        <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
 
-                    <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
-                    <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
+                        <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
+                        <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
 
-                    <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
-                    <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
-                        <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
-                        </CheckBox>
-                        <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
-                        </CheckBox>
-                        <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
-                            <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapPinListPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
-                            <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapSearchPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <!-- ==== BEGIN CQUI: Integration Modification ================================================================= -->
-                        <!-- ==== CQUI: Add CQUI Options button -->
-                        <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
-                        </CheckBox>
-                        <!-- ==== END CQUI: Integration Modification =================================================================== -->
-                        <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
-                            <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                        <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
-                            <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                    </Stack>
-                </Image>
-                <Container Anchor="L,B" Offset="7,8">
-                    <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
-                    <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
-                </Container>
+                        <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
+                        <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
+                            <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
+                            </CheckBox>
+                            <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
+                            </CheckBox>
+                            <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
+                                <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapPinListPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
+                                <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapSearchPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <!-- ==== BEGIN CQUI: Integration Modification ================================================================= -->
+                            <!-- ==== CQUI: Add CQUI Options button -->
+                            <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
+                            </CheckBox>
+                            <!-- ==== END CQUI: Integration Modification =================================================================== -->
+                            <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
+                                <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                            <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
+                                <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                        </Stack>
+                    </Image>
+                    <Container Anchor="L,B" Offset="7,8">
+                        <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
+                        <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
+                    </Container>
+                </SlideAnim>
             </SlideAnim>
         </SlideAnim>
     </Container>

--- a/Integrations/ML/DLC/Expansion2/UI/Replacements/minimappanel.xml
+++ b/Integrations/ML/DLC/Expansion2/UI/Replacements/minimappanel.xml
@@ -36,55 +36,57 @@
     </Grid>
 
     <Container Size="300,200" ID="MiniMap" Anchor="L,B" Offset="-3,0">
-        <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
-            <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
-                <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
-                    <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
-                </Grid>
-                <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
-                    <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
+        <SlideAnim Size="300,200" ID="MiniMapAnimSideways" Begin="0,0" End="300,0" Function="OutQuint" Speed="3.5" Cycle="Once" Stopped="1">
+            <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
+                <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
+                    <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
+                        <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
+                    </Grid>
+                    <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
+                        <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
 
-                    <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
-                    <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
+                        <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
+                        <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
 
-                    <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
-                    <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
-                        <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
-                        </CheckBox>
-                        <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
-                        </CheckBox>
-                        <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
-                            <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapPinListPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
-                            <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapSearchPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <!-- ==== BEGIN CQUI: Integration Modification ================================================================= -->
-                        <!-- ==== CQUI: Add CQUI Options to MinimapPanel -->
-                        <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
-                        </CheckBox>
-                        <!-- ==== END CQUI: Integration Modification =================================================================== -->
-                        <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
-                            <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                        <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
-                            <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                    </Stack>
-                </Image>
-                <Container Anchor="L,B" Offset="7,8">
-                    <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
-                    <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
-                </Container>
+                        <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
+                        <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
+                            <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
+                            </CheckBox>
+                            <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
+                            </CheckBox>
+                            <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
+                                <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapPinListPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
+                                <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapSearchPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <!-- ==== BEGIN CQUI: Integration Modification ================================================================= -->
+                            <!-- ==== CQUI: Add CQUI Options to MinimapPanel -->
+                            <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
+                            </CheckBox>
+                            <!-- ==== END CQUI: Integration Modification =================================================================== -->
+                            <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
+                                <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                            <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
+                                <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                        </Stack>
+                    </Image>
+                    <Container Anchor="L,B" Offset="7,8">
+                        <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
+                        <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
+                    </Container>
+                </SlideAnim>
             </SlideAnim>
         </SlideAnim>
     </Container>

--- a/Integrations/ML/Text/morelenses_text.xml
+++ b/Integrations/ML/Text/morelenses_text.xml
@@ -198,6 +198,9 @@
         <Row Tag="LOC_HUD_CITY_PLOT_LENS_CULTURE">
             <Text>Next Culture Plot Growth</Text>
         </Row>
+        <Row Tag="LOC_HUD_CITY_PLOT_LENS_OTHER">
+            <Text>Other Plot</Text>
+        </Row>
 
         <Row Tag="LOC_HUD_ROUTES_LENS">
             <Text>Routes</Text>

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -1441,7 +1441,32 @@ end
 -- ===========================================================================
 function OnStartObserverMode()
     Controls.MapPinListButton:SetHide(true);
-  end
+end
+
+-- ===========================================================================
+function CQUI_OnCityviewEnabled()
+    -- Slide the minimap over
+    Controls.MiniMapAnimSideways:SetToBeginning();
+    Controls.MiniMapAnimSideways:Play();
+    -- Disable the buttons that do not work well while in City View
+    ToggleButtonsWhenCityViewShown(true);
+end
+
+-- ===========================================================================
+function CQUI_OnCityviewDisabled()
+    -- Slide the minimap back
+    Controls.MiniMapAnimSideways:Reverse();
+    -- Enable the buttons that were disabled
+    ToggleButtonsWhenCityViewShown(false);
+end
+
+-- ===========================================================================
+function ToggleButtonsWhenCityViewShown(isHidden)
+    Controls.LensButton:SetHide(isHidden);
+    Controls.MapPinListButton:SetHide(isHidden);
+    Controls.CQUI_OptionsButton:SetHide(isHidden);
+    Controls.FullscreenMapButton:SetHide(isHidden);
+end
 
 -- ===========================================================================
 function LateInitialize( isReload:boolean )
@@ -1551,6 +1576,8 @@ function LateInitialize( isReload:boolean )
     -- CQUI Handlers
     LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
     LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
+    LuaEvents.CQUI_CityPanelOverview_CityviewEnable.Add( CQUI_OnCityviewEnabled );
+    LuaEvents.CQUI_CityPanelOverview_CityviewDisable.Add( CQUI_OnCityviewDisabled );
     -- ==== END CQUI Modification ======================================
 
     -- Game Events

--- a/Integrations/ML/UI/minimappanel.xml
+++ b/Integrations/ML/UI/minimappanel.xml
@@ -34,55 +34,57 @@
     </Grid>
 
     <Container Size="300,200" ID="MiniMap" Anchor="L,B" Offset="-3,0">
-        <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
-            <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
-                <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
-                    <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
-                </Grid>
-                <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
-                    <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
+        <SlideAnim Size="300,200" ID="MiniMapAnimSideways" Begin="0,0" End="300,0" Function="OutQuint" Speed="3.5" Cycle="Once" Stopped="1">
+            <SlideAnim Size="parent,parent" ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2" Cycle="Once" Stopped="1">
+                <SlideAnim Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2" Cycle="Once" Stopped="1">
+                    <Grid ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
+                        <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
+                    </Grid>
+                    <Image ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
+                        <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
 
-                    <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
-                    <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
+                        <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
+                        <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3" Size="47,16" Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
 
-                    <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
-                    <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
-                        <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
-                        </CheckBox>
-                        <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
-                        </CheckBox>
-                        <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
-                            <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapPinListPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
-                            <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
-                                <LuaContext FileName="MapSearchPanel"/>
-                            </Container>
-                        </CheckBox>
-                        <!-- ==== BEGIN CQUI Customization ======================================================== -->
-                        <!-- ==== Add CQUI Options button -->
-                        <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
-                            <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
-                        </CheckBox>
-                        <!-- ==== END CQUI Customization ========================================================== -->
-                        <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
-                            <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                        <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
-                            <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
-                        </Button>
-                    </Stack>
-                </Image>
-                <Container Anchor="L,B" Offset="7,8">
-                    <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
-                    <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
-                </Container>
+                        <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
+                        <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-6">
+                            <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44" ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
+                            </CheckBox>
+                            <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
+                            </CheckBox>
+                            <CheckBox ID="MapPinListButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_TOGGLE_MAP_PIN_LIST" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_MapPins" Size="24,24" Anchor="C,C"/>
+                                <Container ID="MapPinListPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapPinListPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <CheckBox ID="MapSearchButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_SEARCH" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="MiniMap_Search" Size="24,24" Anchor="C,C" Offset="0,-1"/>
+                                <Container ID="MapSearchPanel" Anchor="L,T" Offset="-9,-35" Size="auto,auto" Hidden="1">
+                                    <LuaContext FileName="MapSearchPanel"/>
+                                </Container>
+                            </CheckBox>
+                            <!-- ==== BEGIN CQUI Customization ======================================================== -->
+                            <!-- ==== Add CQUI Options button -->
+                            <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40" ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+                                <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
+                            </CheckBox>
+                            <!-- ==== END CQUI Customization ========================================================== -->
+                            <Button ID="StrategicSwitcherButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_TOGGLE_STRATEGY_VIEW">
+                                <Image ID="SwitcherImage" Texture="MiniMap_StrategicSwitcher" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                            <Button ID="FullscreenMapButton" Anchor="L,C" Size="40,40" Texture="LaunchBar_Hook_ButtonMinimap" Style="ButtonNormalText" ToolTip="LOC_HUD_FULLSCREEN_MAP">
+                                <Image Texture="MiniMap_Full" Size="24,24" Anchor="C,C"/>
+                            </Button>
+                        </Stack>
+                    </Image>
+                    <Container Anchor="L,B" Offset="7,8">
+                        <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds" Percent=".25" Follow="1" Speed="4" Size="320,320"/>
+                        <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds" />
+                    </Container>
+                </SlideAnim>
             </SlideAnim>
         </SlideAnim>
     </Container>

--- a/Integrations/ML/morelenses_colors.sql
+++ b/Integrations/ML/morelenses_colors.sql
@@ -106,7 +106,9 @@ VALUES                  (   'COLOR_CITY_PLOT_LENS_WORKING',     '1',        '0.5
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_CITY_PLOT_LENS_LOCKED',      '0',        '1',        '0',        '0.2');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_CITY_PLOT_LENS_CULTURE',     '0.89',     '0.431',   '0.862',    '0.5');
+VALUES                  (   'COLOR_CITY_PLOT_LENS_CULTURE',     '0.89',     '0.431',   '0.862',     '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_CITY_PLOT_LENS_OTHER',       '0.4',     '0.4',      '0.4',       '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_AREA_LENS_NEUTRAL',          '0',        '0',        '0',        '0.0');
 


### PR DESCRIPTION
**Note: When reviewing this PR enable the ignore whitespace option** -- because of the control added to minimappanel.xml causing most things to be indented another 4 spaces.

These changes cover the stuff requested in #303:
- Show the city boundaries (like the Empire Lens does) when in the City Management view (or hovering on a City Banner)
- Add an "other" color, used for plots owned by the city that do not have a citizen assigned or locked
- When opening the City View, slide the minimap so that it remains in view, but disable the buttons that do not make sense to use in the City View.

**Pictures:**
In this image my mouse cursor is hovering over the banner for Jenne, you can see the borders of the city and the "owned" but not used tiles.
![image](https://user-images.githubusercontent.com/8787640/121769095-8e2d8900-cb16-11eb-8ffe-6afd6fcff6b1.png)

And here, I've clicked on Jenne to show the City Management page, which also moved the Minimap over.
![image](https://user-images.githubusercontent.com/8787640/121769147-d51b7e80-cb16-11eb-9305-8793b9d31b11.png)

I cut the end off a little bit but it shows the map sliding in and out when opening and closing the City View:
Link to an MP4, because I can't figure out why this won't upload as .gif and I'm tired: https://imgur.com/SoYt9e9