### PR TITLE
City Panel polishing

### DIFF
--- a/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion1/Replacements/CityPanel_Expansion1.lua
@@ -1,37 +1,48 @@
 -- Copyright 2017-2019, Firaxis Games
 
 include("CityPanel");
-BASE_ViewMain = ViewMain;
+BASE_CQUI_ViewMain = ViewMain;
 
 -- ===========================================================================
 function ViewMain( kData:table )
-	BASE_ViewMain( kData );
-	
-	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-	--swarsele: change religious citizens to loyalty
+    BASE_CQUI_ViewMain( kData );
+    
+    -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+    -- swarsele: change religious citizens to loyalty
     local pCity = UI.GetHeadSelectedCity()
     if pCity ~= nil then
-		local pCulturalIdentity = pCity:GetCulturalIdentity();
-		local currentLoyalty = pCulturalIdentity:GetLoyalty();
-		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
+        local pCulturalIdentity = pCity:GetCulturalIdentity();
+        local currentLoyalty = pCulturalIdentity:GetLoyalty();
+        local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
 
-		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
-		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
-		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
+        Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
+        Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
+        if Controls.CQUI_Loyalty ~= nil then
+            local loyaltyValueSign = "";
+            if loyaltyPerTurn >= 0 then
+                loyaltyValueSign = "+";
+            end
+    
+            Controls.CQUI_Loyalty:SetText(Round(currentLoyalty, 1));
+            Controls.CQUI_LoyaltyPerTurn:SetText(" (" .. loyaltyValueSign .. Round(loyaltyPerTurn,1) .. ")");
+        end
 
+        -- m4a: Move the Religion tool tip to the City Size icon
+        local religionTooltip = Controls.ReligionGrid:GetToolTipString();
+        Controls.ReligionGrid:SetToolTipString("");
+        Controls.CitizensGrowthButton:SetToolTipString(religionTooltip);
     end
-	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
-	
+    -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
 -- ===========================================================================
 function OnCityLoyaltyChanged( ownerPlayerID:number, cityID:number )
-	if UI.IsCityIDSelected(ownerPlayerID, cityID) then
-		UI.DeselectCityID(ownerPlayerID, cityID);
-	end
+    if UI.IsCityIDSelected(ownerPlayerID, cityID) then
+        UI.DeselectCityID(ownerPlayerID, cityID);
+    end
 end
 
 -- ===========================================================================
 function LateInitialize()
-	Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
+    Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
 end

--- a/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
+++ b/Assets/Expansion2/Replacements/CityPanel_Expansion1.lua
@@ -1,37 +1,49 @@
--- Copyright 2017-2019, Firaxis Games
+-- NOTE: This is the correct file name.  Firaxis has a CityPanel_Expansion1.lua located in the Expansion2 folder.
+--       This file updates the actions found in CityPanel_Expansion1.lua.
 
 include("CityPanel");
-BASE_ViewMain = ViewMain;
+BASE_CQUI_ViewMain = ViewMain;
 
 -- ===========================================================================
 function ViewMain( kData:table )
-	BASE_ViewMain( kData );
-	
-	-- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
-	--swarsele: change religious citizens to loyalty
+    BASE_CQUI_ViewMain( kData );
+    
+    -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
+    -- swarsele: change religious citizens to loyalty
     local pCity = UI.GetHeadSelectedCity()
     if pCity ~= nil then
-		local pCulturalIdentity = pCity:GetCulturalIdentity();
-		local currentLoyalty = pCulturalIdentity:GetLoyalty();
-		local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
+        local pCulturalIdentity = pCity:GetCulturalIdentity();
+        local currentLoyalty = pCulturalIdentity:GetLoyalty();
+        local loyaltyPerTurn:number = pCulturalIdentity:GetLoyaltyPerTurn();
 
-		Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
-		Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
-		Controls.ReligionNum:SetText(Round(currentLoyalty, 1) .. "/" .. Round(loyaltyPerTurn,1));
+        Controls.ReligionIcon:SetIcon("ICON_STAT_CULTURAL_FLAG");
+        Controls.ReligionLabel:SetText(Locale.Lookup("LOC_CULTURAL_IDENTITY_LOYALTY_SUBSECTION"));
+        if Controls.CQUI_Loyalty ~= nil then
+            local loyaltyValueSign = "";
+            if loyaltyPerTurn >= 0 then
+                loyaltyValueSign = "+";
+            end
+    
+            Controls.CQUI_Loyalty:SetText(Round(currentLoyalty, 1));
+            Controls.CQUI_LoyaltyPerTurn:SetText(" (" .. loyaltyValueSign .. Round(loyaltyPerTurn,1) .. ")");
+        end
 
+        -- m4a: Move the Religion tool tip to the City Size icon
+        local religionTooltip = Controls.ReligionGrid:GetToolTipString();
+        Controls.ReligionGrid:SetToolTipString("");
+        Controls.CitizensGrowthButton:SetToolTipString(religionTooltip);
     end
-	-- ==== CQUI CUSTOMIZATION END ======================================================================================== --
-	
+    -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
 -- ===========================================================================
 function OnCityLoyaltyChanged( ownerPlayerID:number, cityID:number )
-	if UI.IsCityIDSelected(ownerPlayerID, cityID) then
-		UI.DeselectCityID(ownerPlayerID, cityID);
-	end
+    if UI.IsCityIDSelected(ownerPlayerID, cityID) then
+        UI.DeselectCityID(ownerPlayerID, cityID);
+    end
 end
 
 -- ===========================================================================
 function LateInitialize()
-	Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
+    Events.CityLoyaltyChanged.Add(OnCityLoyaltyChanged);
 end

--- a/Assets/UI/Panels/citypanel.xml
+++ b/Assets/UI/Panels/citypanel.xml
@@ -24,7 +24,11 @@
                             <Label ID="BreakdownLabel" Anchor="R,C" Offset="4,1" Style="CityPanelHeader" String="{LOC_HUD_DISTRICTS}" />
                         </Grid>
                         <Grid ID="ReligionGrid" Anchor="R,T" Offset="4,45" Size="parent-100,20" Style="CityPanelSlotGrid">
-                            <Label ID="ReligionNum" Anchor="L,C" Offset="33,0" Style="CityPanelNumLarge" String="-" />
+                            <Label ID="ReligionNum" Anchor="L,C" Offset="33,0" Style="CityPanelNumLarge" String="-" Hidden="1"/>
+                            <Stack ID="CQUI_LoyaltyLabels" Offset="33,0" StackGrowth="Right">
+                                <Label ID="CQUI_Loyalty" Anchor="L,C" Offset="0,0" Style="CityPanelNumLarge" String="-" />
+                                <Label ID="CQUI_LoyaltyPerTurn" Anchor="R,C" Offset="0,0" Style="CityPanelNumSmall" String="-" />
+                            </Stack>
                             <Label ID="ReligionLabel" Anchor="R,C" Offset="4,1" Style="CityPanelHeader" String="{LOC_HUD_CITY_RELIGIOUS_CITIZENS}" />
                         </Grid>
                         <Grid ID="AmenitiesGrid" Anchor="R,T" Offset="4,71" Size="parent-100,20" Style="CityPanelSlotGrid">

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -436,8 +436,8 @@
                 <File>Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua</File>
             </Items>
         </ImportFiles>
-		
-		<ImportFiles id="CQUI_IMPORT_FILES_EXP1_CITYPANEL" criteria="Expansion1">
+
+        <ImportFiles id="CQUI_IMPORT_FILES_EXP1_CITYPANEL" criteria="Expansion1">
             <Properties>
                 <LoadOrder>100</LoadOrder>
                 <Context>InGame</Context>
@@ -571,13 +571,14 @@
                 <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
             </Items>
         </ImportFiles>
-		
-		<ImportFiles id="CQUI_IMPORT_FILES_EXP2_CITYPANEL" criteria="Expansion2">
+
+        <ImportFiles id="CQUI_IMPORT_FILES_EXP2_CITYPANEL" criteria="Expansion2">
             <Properties>
                 <LoadOrder>200</LoadOrder>
                 <Context>InGame</Context>
             </Properties>
             <Items>
+                <!-- This replaces the Firaxis CityPanel_Expansion1 found in the Expansion2 folder -->
                 <File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
             </Items>
         </ImportFiles>
@@ -1063,7 +1064,7 @@
                 <LuaReplace>Assets/UI/Choosers/ResearchChooser_CQUI.lua</LuaReplace>
             </Properties>
         </ReplaceUIScript>
-        
+
         <ReplaceUIScript id="CQUI_ResearchChooser_EXP2"  criteria="Expansion2">
             <Properties>
                 <LoadOrder>200</LoadOrder>
@@ -1395,6 +1396,7 @@
         <File>Assets/Expansion1/CityBanners/citybannermanager.xml</File>
         <File>Assets/Expansion1/CityBanners/citybannerinstances.xml</File>
         <File>Assets/Expansion1/CityBanners/cityreligioninstances.xml</File>
+        <File>Assets/Expansion1/Replacements/CityPanel_Expansion1.lua</File>
         <File>Assets/Expansion1/Replacements/citypanelculture_CQUI.lua</File>
         <File>Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua</File>
         <File>Assets/Expansion1/Replacements/citystates.xml</File>
@@ -1407,9 +1409,9 @@
         <File>Assets/Expansion1/Replacements/toppanel_CQUI_expansion1.lua</File>
         <File>Assets/Expansion1/Replacements/unitpanel_CQUI_expansion1.lua</File>
         <File>Assets/Expansion1/Replacements/worldinput_CQUI_expansion1.lua</File>
-		<File>Assets/Expansion1/Replacements/CityPanel_Expansion1.lua</File>
 
         <!-- EXP 2 -->
+        <File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
         <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
         <File>Assets/Expansion2/Replacements/citystates.xml</File>
         <File>Assets/Expansion2/Replacements/citystates_CQUI_expansion2.lua</File>
@@ -1424,7 +1426,6 @@
         <File>Assets/Expansion2/Replacements/toppanel_CQUI_expansion2.lua</File>
         <File>Assets/Expansion2/Replacements/unitpanel_CQUI_expansion2.lua</File>
         <File>Assets/Expansion2/Replacements/worldinput_CQUI_expansion2.lua</File>
-		<File>Assets/Expansion2/Replacements/CityPanel_Expansion1.lua</File>
         <File>Assets/Expansion2/CityBanners/citybannermanager.xml</File>
         <File>Assets/Expansion2/CityBanners/citybannerinstances.xml</File>
         <File>Assets/Expansion2/CityBanners/cityreligioninstances.xml</File>
@@ -1487,7 +1488,7 @@
         <File>Assets/Texture/CQUI_Heroes_Background_Repeat_Bottom.dds</File>
         <File>Assets/Texture/CQUI_Heroes_Background_Repeat_Top.dds</File>
         <File>Assets/Texture/CQUI_Heroes_Background_Top.dds</File>
-        
+
         <!-- BASE -->
         <File>Assets/UI/actionpanel.lua</File>
         <File>Assets/UI/diplomacyactionview_CQUI_basegame.lua</File>


### PR DESCRIPTION
This implements the changes I requested in the PR for #293

+/- for Loyalty is smaller font
Religion tooltip is moved to the Population icon (it doesn't make sense to be attached to the loyalty and the population icon did not have a tooltip otherwise)
Spaces, no tabs

![image](https://user-images.githubusercontent.com/8787640/122631524-19f86580-d081-11eb-9eb5-eb6d6b8d6914.png)

Mouse pointer is hovering over the "7" 
![image](https://user-images.githubusercontent.com/8787640/122631541-30062600-d081-11eb-9c05-82c4bee98c3e.png)
