### PR TITLE
Hotkeys for Modded Lenses

### DIFF
--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -72,6 +72,12 @@
     </ActionCriteria>
 
     <!-- ============================== CQUI specific settings ============================== -->
+    <FrontEndActions>
+        <UpdateDatabase id="MoreLenses_KeyBinding_Options">
+            <File>Integrations/ML/UI/hotkey_config.xml</File>
+        </UpdateDatabase>
+    </FrontEndActions>
+
     <InGameActions>
         <UpdateDatabase id="CQUI_Settings">
             <Properties>
@@ -1584,6 +1590,7 @@
         <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
         <File>Integrations/ML/Text/morelenses_text_ru.xml</File>
         <File>Integrations/ML/Text/morelenses_text_zh.xml</File>
+        <File>Integrations/ML/UI/hotkey_config.xml</File>
         <File>Integrations/ML/UI/minimappanel.lua</File>
         <File>Integrations/ML/UI/minimappanel.xml</File>
         <File>Integrations/ML/UI/Panels/modallenspanel.lua</File>

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -76,6 +76,22 @@
         <UpdateDatabase id="MoreLenses_KeyBinding_Options">
             <File>Integrations/ML/UI/hotkey_config.xml</File>
         </UpdateDatabase>
+
+        <LocalizedText id="CQUI_MORELENSES_TEXT">
+            <Items>
+                <File Priority="1">Integrations/ML/Text/morelenses_text.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_de.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_es.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_fr.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_it.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_ja.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_ko.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_pl.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_ru.xml</File>
+                <File>Integrations/ML/Text/morelenses_text_zh.xml</File>
+            </Items>
+        </LocalizedText>
     </FrontEndActions>
 
     <InGameActions>

--- a/Integrations/ML/UI/hotkey_config.xml
+++ b/Integrations/ML/UI/hotkey_config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameInfo>
+    <InputActions>
+        <Row ActionId="LensArchaeologist" Name="LOC_HUD_ARCHAEOLOGIST_LENS" Description="LOC_HUD_ARCHAEOLOGIST_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensBarbarian" Name="LOC_HUD_BARBARIAN_LENS" Description="LOC_HUD_BARBARIAN_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensBuilder" Name="LOC_HUD_BUILDER_LENS" Description="LOC_HUD_BUILDER_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensCityOverlap" Name="LOC_HUD_CITYOVERLAP_LENS" Description="LOC_HUD_CITYOVERLAP_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensNaturalist" Name="LOC_HUD_NATURALIST_LENS" Description="LOC_HUD_NATURALIST_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensResource" Name="LOC_HUD_RESOURCE_LENS" Description="LOC_HUD_RESOURCE_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensRoutes" Name="LOC_HUD_ROUTES_LENS" Description="LOC_HUD_ROUTES_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensWonder" Name="LOC_HUD_WONDER_LENS" Description="LOC_HUD_WONDER_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+        <Row ActionId="LensScout" Name="LOC_HUD_SCOUT_LENS" Description="LOC_HUD_SCOUT_LENS_TOOLTIP" CategoryId="LENSES" ContextId="World" LayoutType="PC"/>
+    </InputActions>
+
+    <InputActionDefaultGestures>
+        <Row ActionId="LensArchaeologist" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_1" />
+        <Row ActionId="LensBarbarian" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_2" />
+        <Row ActionId="LensBuilder" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_3" />
+        <Row ActionId="LensCityOverlap" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_4" />
+        <Row ActionId="LensNaturalist" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_5" />
+        <Row ActionId="LensResource" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_6" />
+        <Row ActionId="LensRoutes" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_7" />
+        <Row ActionId="LensScout" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_8" />
+        <Row ActionId="LensWonder" Index="0" GestureType="KBMouse" GestureData="LOC_OPTIONS_KEY_SHIFT+LOC_OPTIONS_KEY_9" />
+    </InputActionDefaultGestures>
+</GameInfo>

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -979,6 +979,46 @@ function OnInputActionTriggered( actionId )
         UI.PlaySound("Play_UI_Click");
         Toggle2DView();
     end
+
+    -- ==== BEGIN CQUI Modification ====================================
+    if m_LensArchaeologistLensId ~= nil and (actionId == m_LensArchaeologistLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_ARCHAEOLOGIST", "LOC_HUD_ARCHAEOLOGIST_LENS");
+    end
+    if m_LensBarbarianLensId ~= nil and (actionId == m_LensBarbarianLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_BARBARIAN", "LOC_HUD_BARBARIAN_LENS");
+    end
+    if m_LensBuilderLensId ~= nil and (actionId == m_LensBuilderLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_BUILDER", "LOC_HUD_BUILDER_LENS");
+    end
+    if m_LensCityOverlapLensId ~= nil and (actionId == m_LensCityOverlapLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_CITYOVERLAP", "LOC_HUD_CITYOVERLAP_LENS");
+    end
+    if m_LensNaturalistLensId ~= nil and (actionId == m_LensNaturalistLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_NATURALIST", "LOC_HUD_NATURALIST_LENS");
+    end
+    if m_LensResourceLensId ~= nil and (actionId == m_LensResourceLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_RESOURCE", "LOC_HUD_RESOURCE_LENS");
+    end
+    if m_LensRoutesLensId ~= nil and (actionId == m_LensRoutesLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_ROUTES", "LOC_HUD_ROUTES_LENS");
+    end
+    if m_LensScoutLensId ~= nil and (actionId == m_LensScoutLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_SCOUT", "LOC_HUD_SCOUT_LENS");
+    end
+    if m_LensWonderLensId ~= nil and (actionId == m_LensWonderLensId) then
+        UI.PlaySound("Play_UI_Click");
+        ToggleModLensKeyboardShortcut("ML_WONDER", "LOC_HUD_WONDER_LENS");
+    end
+    -- ==== END CQUI Modification ====================================
+
     if m_OpenMapSearchId ~= nil and (actionId == m_OpenMapSearchId) then
         UI.PlaySound("Play_UI_Click");
 
@@ -1050,8 +1090,33 @@ function GetLensPanelOffsets(offsets:table)
 end
 
 -- ===========================================================================
-function ToggleModLens(buttonControl:table, lensName:string)
-    if buttonControl:IsChecked() then
+function ToggleModLensButton(buttonControl:table, lensName:string)
+    ToggleModLens(buttonControl:IsChecked(), lensName);
+end
+
+-- ===========================================================================
+function ToggleModLensKeyboardShortcut(lensName:string, lensDisplayName:string)
+    -- find the button for this lens
+    local i = 1
+    local lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
+    while lensButtonInstance ~= nil do
+        if lensButtonInstance.LensButton:GetTextButton():GetText() == Locale.Lookup(lensDisplayName) then
+            break
+        end
+
+        i = i + 1
+        lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
+    end
+
+    if lensButtonInstance ~= nil then
+        LensPanelHotkeyControl( lensButtonInstance.LensButton );
+        ToggleModLens(lensButtonInstance.LensButton:IsChecked(), lensName);
+    end
+end
+
+-- ===========================================================================
+function ToggleModLens(showLens:boolean, lensName:string)
+    if showLens then
         SetActiveModdedLens(lensName);
 
         -- Check if the appeal lens is already active. Needed to clear any modded lens
@@ -1099,7 +1164,7 @@ function InitLens(lensName, modLens)
     modLensToggle.LensButton:SetToolTipString(pToolTip)
     modLensToggle.LensButton:RegisterCallback(Mouse.eLClick,
         function()
-            ToggleModLens(modLensToggle.LensButton, lensName);
+            ToggleModLensButton(modLensToggle.LensButton, lensName);
         end
         )
 end
@@ -1482,6 +1547,19 @@ function LateInitialize( isReload:boolean )
         m_TogglePoliticalLensId = Input.GetActionId("LensPolitical");
         m_ToggleTourismLensId   = Input.GetActionId("LensTourism");
         m_ToggleEmpireLensId    = Input.GetActionId("LensEmpire");
+
+        -- ==== BEGIN CQUI Modification ====================================
+        -- Modded Lenses
+        m_LensArchaeologistLensId = Input.GetActionId("LensArchaeologist");
+        m_LensBarbarianLensId     = Input.GetActionId("LensBarbarian");
+        m_LensBuilderLensId       = Input.GetActionId("LensBuilder");
+        m_LensCityOverlapLensId   = Input.GetActionId("LensCityOverlap");
+        m_LensNaturalistLensId    = Input.GetActionId("LensNaturalist");
+        m_LensResourceLensId      = Input.GetActionId("LensResource");
+        m_LensRoutesLensId        = Input.GetActionId("LensRoutes");
+        m_LensScoutLensId         = Input.GetActionId("LensScout");
+        m_LensWonderLensId        = Input.GetActionId("LensWonder");
+        -- ==== END CQUI Modification ======================================
     end
 
     Controls.ReligionLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_RELIGION"));


### PR DESCRIPTION
Requsted in #320
Adds configurable hotkeys for the modded lenses: Archaeologist, Barbarian, Builder, City Overlap, Naturalist, Resource, Routes, Wonder, and Scout.  The hot keys are configured in the Civ6 standard key bindings menu.  They work like the current lens hot keys (pressing "1" for the religion lens).  By default I assigned them all to SHIFT+someNumber.

I did look into moving the CQUI hot keys here, but we run into an issue where a single key is assigned to multiple actions (like "R" or "H"), and the KeyBindings UI does not allow you to do that.  A bunch of CQUI things ended up blank, so I abandoned that effort.

![image](https://user-images.githubusercontent.com/8787640/122635287-d78e5300-d097-11eb-9b8c-65656179c6d4.png)
