### PR TITLE
Fixes in the City View: Update Tiles, Make Tile Purchase better

### DIFF
--- a/Integrations/ML/Lenses/CQUI_CitizenManagement/ModLens_CQUI_CitizenManagement.lua
+++ b/Integrations/ML/Lenses/CQUI_CitizenManagement/ModLens_CQUI_CitizenManagement.lua
@@ -98,21 +98,26 @@ function ShowCitizenManagementLens(cityID:number)
 end
 
 -- ===========================================================================
-function ClearCitizenManagementLens()
+function ClearCitizenManagementLens(clearBorder:boolean)
     if UILens.IsLayerOn(ML_LENS_LAYER) then
         UILens.ToggleLayerOff(ML_LENS_LAYER);
     end
+
     LuaEvents.MinimapPanel_SetActiveModLens("NONE");
 
-    local pOverlay:object = UILens.GetOverlay("CityBorders");
-    pOverlay:ClearPlotChannel();
-    pOverlay:SetVisible(false);
+    if (clearBorder == nil or clearBorder == true) then
+        local pOverlay:object = UILens.GetOverlay("CityBorders");
+        pOverlay:ClearPlotChannel();
+        pOverlay:SetVisible(false);
+    end
+
     m_cityID = -1;
 end
 
 -- ===========================================================================
 function RefreshCitizenManagementLens(cityID:number)
-    ClearCitizenManagementLens();
+    -- Do not redraw the border for the city, just refresh the tiles
+    ClearCitizenManagementLens(false);
     ShowCitizenManagementLens(cityID);
 end
 


### PR DESCRIPTION
Changes do two things:
1. When you lock a citizen, the lens updates properly
2. When you purchase a tile, you can now "drag" very slightly and still purchase.  Previously, the tile purchase would only happen if the mouse did not move (drag) when clicking to make that purchase.

**Lens Updates properly**
![img](https://imgur.com/kt936Qm.gif)

**Tile Purchasing**
Can now drag very slightly when purchasing a tile.  Note if you start the drag on the purchase button, go a significant distance, and then return to that same point you started at... it will NOT do the purchase.  Basically, once you move far enough from your original spot, it will assume you aren't wanting to purchase the tile.
![img](https://imgur.com/JvISw9m.gif)


