### PR TITLE
Moved Luxury Resources into separate UI group

### DIFF
--- a/Assets/UI/toppanel.xml
+++ b/Assets/UI/toppanel.xml
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Context >
+
+  <Grid						ID="Backing"				Anchor="C,T" Size="parent+100,29" Texture="TopBar_Bar" SliceCorner="28,8" SliceTextureSize="57,29">
+    <Image Texture="Controls_GradientSmall" Color="0,0,0,255" AnchorSide="I,O" Size="parent,21" Anchor="L,B"/>
+    <Grid Texture="SelectionPanel_TopRim" TextureSize="14,5" Anchor="L,B" Size="parent,5" SliceCorner="7,2" AnchorSide="I,O" Offset="0,-1" Color="255,255,255,200"/>
+  </Grid>
+  <Image					ID="Backing2"				Style="DropShadow3" Size="300,120" Offset="-50,-80" Anchor="R,T"/>
+  <Stack					ID="RightContents"	StackGrowth="Left" Anchor="R,T" Padding="3">
+    <Button				ID="MenuButton"			Size="29,29" Texture="TopBar_MenuButton" ToolTip="LOC_TOP_PANEL_MENU_TOOLTIP"  />
+    <Button				ID="CivpediaButton" Size="29,29" Texture="TopBar_CivilopediaButton" ToolTip="LOC_TOP_PANEL_HELP_TOOLTIP" />
+    <Container												Size="2,1" />
+    <Stack				ID="TimeArea"				Anchor="R,T" Offset="14,8"		StackGrowth="Right" >
+      <AlphaAnim	ID="TimeCallback" Cycle="Once" Speed="0.5" />
+      <Label			ID="Time" Style="TopBarMeta" String="1" />
+    </Stack>
+    <Stack StackGrowth="Down" Offset="0,2">
+      <Stack StackGrowth="Right" Padding="3">
+        <Label  Style="TopBarMeta" String="{LOC_TOP_PANEL_CURRENT_TURN:upper}"  />
+        <Label	ID="Turns"   Style="TopBarMeta" String="1" />
+      </Stack>
+      <Label	ID="CurrentDate"		 Style="TopBarMeta" String="LOC_TOP_PANEL_CURRENT_DATE"/>
+    </Stack>
+  </Stack>
+  
+  <!-- Civ Yields Display -->
+  <Stack					ID="InfoStack" Offset="10,2"  StackGrowth="Right" Padding="2">
+    <Stack				ID="YieldStack"						  StackGrowth="Right" Padding="2"/>
+    <Stack ID="StaticInfoStack" StackGrowth="Right" Padding="2">
+      <Grid				ID="TradeRoutes"					Style="SubContainerSmall2" Size="48,24" ToolTip="LOC_HUD_TRADEROUTES_TOOLTIP">
+        <Stack		ID="TradeStack"						Anchor="L,C"	Offset="0,4" StackGrowth="Right">
+          <Label	ID="TradeIcon"						Anchor="L,C"	Style="FontNormal10" ColorSet="ResGoldLabelCS" String="[ICON_TradeRouteLarge]" />
+          <Label	ID="TradeRoutesActive"									Offset="0,-3" Style="FontNormal14" ColorSet="TopBarValueCS" String="?"	WrapWidth="45" />
+          <Label																					Offset="0,-3" Style="FontNormal14" ColorSet="TopBarValueCS" String="/"	WrapWidth="45" />
+          <Label	ID="TradeRoutesCapacity"								Offset="0,-3"	Style="FontNormal14" ColorSet="TopBarValueCS" String="?"	WrapWidth="45" />
+        </Stack>
+
+        <Tutorial  ID="TutTradeRoutes" Style="TutorialContainer" Anchor="C,B" AnchorSide="I,O" Offset="0,24" TriggerBy="TutorialTradeRoutes" >
+          <SlideAnim Anchor="C,T" Start="0,-30" EndOffset="0,10" Cycle="Bounce" Function="OutQuad" >
+            <Image Texture="Tutorial_ArrowV" Offset="-22,0" Size="44,58" FlipY="true"/>
+          </SlideAnim>
+        </Tutorial>
+      </Grid>
+
+      <Grid		ID="Envoys" Style="SubContainerSmall2" Size="48,24" ToolTip="LOC_TOP_PANEL_INFLUENCE">
+        <Stack			ID="EnvoysStack"				Anchor="L,C"	Offset="0,0" StackGrowth="Right" >
+          <Image	  ID="EnvoysBacking" Size="24,24" Texture="Controls_MeterTinyBacking">
+            <Label	Offset="1,1" Anchor="L,C"	Style="FontNormal14" ColorSet="TopBarValueCS" String="[ICON_Envoy]" />
+            <Meter  ID="EnvoysMeter" Size="24,24" Texture="Controls_MeterTinyFill" Speed="1" Follow="1"/>
+          </Image>
+          <Label	ID="EnvoysNumber"	Offset="1,0" Anchor="L,C"	Style="FontNormal14" ColorSet="TopBarValueCS" String="0" />
+        </Stack>
+      </Grid>
+
+      <Grid ID="NuclearDevices" Style="SubContainerSmall2" Size="48,24" ToolTip="LOC_WMD_NUCLEAR_DEVICE_NAME">
+        <Stack StackGrowth="Right" Anchor="L,C">
+          <Label String="[ICON_Nuclear]" Anchor="C,C" Offset="0,-1" />
+          <Label ID="NuclearDeviceCount" Offset="2,2" String="0" Style="FontNormal14" Align="C,C" />
+        </Stack>
+      </Grid>
+
+      <Grid ID="ThermoNuclearDevices"  Style="SubContainerSmall2" Size="48,24" ToolTip="LOC_WMD_THERMONUCLEAR_DEVICE_NAME">
+        <Stack StackGrowth="Right" Anchor="L,C">
+          <Label String="[ICON_ThermoNuclear]" Anchor="C,C" />
+          <Label ID="ThermoNuclearDeviceCount" Offset="1,2" String="0" Style="FontNormal14"  Align="C,C" />
+        </Stack>
+      </Grid>
+    </Stack>
+
+    <Grid    ID="Resources" Style="SubContainerSmall2"  Size="48,24">
+      <Stack ID="ResourceStack" StackGrowth="Right" StackPadding="4" Anchor="L,C" />
+    </Grid>
+
+    <Grid    ID="LuxuryResources" Style="SubContainerSmall2"  Size="48,24">
+      <Stack ID="ResourceStackLuxury" StackGrowth="Right" StackPadding="4" Anchor="L,C" />
+    </Grid>
+	</Stack>
+
+	<Tutorial ID="TechYieldPointer" Style="TutorialContainer" Anchor="L,T" Offset="46, 70" TriggerBy="TutorialTechYieldPointer">
+		<SlideAnim Anchor="L,T" Start="0,-30" EndOffset="0,10" Cycle="Bounce" Function="OutQuad" >
+			<Image Texture="Tutorial_ArrowV" Offset="-22,-20" Size="44,58" FlipY="true"/>
+		</SlideAnim>
+	</Tutorial>
+
+	<Tutorial ID="FaithYieldPointer" Style="TutorialContainer" Anchor="L,T" Offset="46, 70" TriggerBy="TutorialFaithYieldPointer">
+		<SlideAnim Anchor="L,T" Start="0,-30" EndOffset="0,10" Cycle="Bounce" Function="OutQuad" >
+			<Image Texture="Tutorial_ArrowV" Offset="110,-20" Size="44,58" FlipY="true"/>
+		</SlideAnim>
+	</Tutorial>
+
+	<Tutorial ID="TutCivilopediaPointer" Style="TutorialContainer" Anchor="R,T" Offset="46, 70" TriggerBy="TutorialCivilopediaPointer">
+		<SlideAnim Anchor="R,T" Start="0,-30" EndOffset="0,10" Cycle="Bounce" Function="OutQuad" >
+			<Image Texture="Tutorial_ArrowV" Offset="-24,-20" Size="44,58" FlipY="true"/>
+		</SlideAnim>
+	</Tutorial>
+
+	<Instance			Name="ResourceInstance">
+    <Container	ID="Top"								Anchor="L,C" Offset="0,2" Size="auto,auto">
+      <Label		ID="ResourceText" Style="FontNormal14" ColorSet="TopBarValueCS"/>
+      <Image		ID="ResourceVelocity"		Anchor="L,B" Offset="10,-1" Size="12,12" Hidden="1"/>
+    </Container>		
+	</Instance>
+	
+	<Instance Name="TopBarButtonInstance">
+		<Container	ID="Top"																		Size="50,36" > 
+			<Image									Anchor="C,C" Offset="0,2"			Size="39,39"		Texture="TopBarRingOtherBG.dds"		/>
+			<Image									Anchor="C,C" Offset="0,0"			Size="49,53"		Texture="TopBarRingOther.dds"		/>
+		</Container>
+	</Instance>
+  
+  <Instance Name="YieldButton_SingleLabel">
+    <Container ID="Top" Size="auto,auto">
+      <GridButton	ID="YieldBacking" Size="auto,24" AutoSizePadding="1,0" Style="YieldBacking" Color="24,156,216,255">
+        <Stack		ID="YieldButtonStack" Anchor="L,C" Offset="0,2"	StackGrowth="Right">
+          <Label	ID="YieldIconString" Anchor="L,B" Offset="0,4"/>
+          <Label	ID="YieldPerTurn" Anchor="C,T" Style="FontNormal18" ColorSet="ResScienceLabelCS" FontStyle="Stroke" String="0"/>
+        </Stack>
+      </GridButton>
+    </Container>
+  </Instance>
+
+  <Instance Name="YieldButton_DoubleLabel">
+    <Container ID="Top" Size="auto,auto">
+      <Image Anchor="C,C" Offset="45,0" Size="auto,24" Texture="TopBar_YieldBacking.dds"		/>
+      <GridButton	ID="YieldBacking" Size="auto,24" AutoSizePadding="1,0" Style="YieldBacking" Color="24,156,216,255">
+        <Stack		ID="YieldButtonStack" Anchor="L,C" Offset="0,2"	StackGrowth="Right">
+          <Label	ID="YieldIconString" Anchor="L,B" Offset="0,3"/>
+          <Label	ID="YieldBalance" Anchor="C,T" Offset="0,-1" Style="FontNormal18" ColorSet="ResFaithLabelCS" String="?"/>
+          <Label	ID="YieldPerTurn" Offset="2,-2" Style="FontNormal14" ColorSet="ResFaithLabelCS" FontStyle="Stroke" String="0"/>
+        </Stack>
+      </GridButton>
+    </Container>
+  </Instance>
+  
+</Context>

--- a/Assets/UI/toppanel_CQUI.lua
+++ b/Assets/UI/toppanel_CQUI.lua
@@ -8,6 +8,7 @@ BASE_CQUI_RefreshResources = RefreshResources;
 -- CQUI Members
 -- ===========================================================================
 local CQUI_showLuxury = true;
+local m_kResourceLuxuryIM = InstanceManager:new("ResourceInstance", "Top", Controls.ResourceStackLuxury);
 
 function CQUI_OnSettingsInitialized()
     CQUI_showLuxury = GameConfiguration.GetValue("CQUI_ShowLuxuries"); -- Infixo, issue #44
@@ -27,13 +28,15 @@ function RefreshResources()
 
     local localPlayerID = Game.GetLocalPlayer();
     if localPlayerID == PlayerTypes.NONE or localPlayerID == PlayerTypes.OBSERVER then return; end
-    
+
+    m_kResourceLuxuryIM:ResetInstances();
     local pPlayerResources:table = Players[localPlayerID]:GetResources();
     local yieldStackX:number = Controls.YieldStack:GetSizeX();
     local infoStackX:number = Controls.StaticInfoStack:GetSizeX();
     local metaStackX:number = Controls.RightContents:GetSizeX();
     local screenX, _:number = UIManager:GetScreenSizeVal();
-    local maxSize:number = math.max(screenX - yieldStackX - infoStackX - metaStackX - META_PADDING, 0);
+    local resourceStackX:number = Controls.ResourceStack:GetSizeX();
+    local maxSize:number = math.max(screenX - yieldStackX - infoStackX - metaStackX - resourceStackX - META_PADDING, 0);
     local currSize:number = 0;
     local isOverflow:boolean = false;
     local overflowString:string = "";
@@ -49,14 +52,14 @@ function RefreshResources()
                     local numDigits:number = (amount >= 10 and 4 or 3);
                     local guessinstanceWidth:number = math.ceil(numDigits * FONT_MULTIPLIER);
                     if currSize + guessinstanceWidth < maxSize and not isOverflow then
-                        local instance:table = m_kResourceIM:GetInstance();
+                        local instance:table = m_kResourceLuxuryIM:GetInstance();
                         instance.ResourceText:SetText(resourceText);
                         instance.ResourceText:SetToolTipString(Locale.Lookup(resource.Name).."[NEWLINE]"..Locale.Lookup("LOC_TOOLTIP_LUXURY_RESOURCE"));
                         currSize = currSize + instance.ResourceText:GetSizeX();
                     else
                         if not isOverflow then
                             overflowString = amount.. "[ICON_"..resource.ResourceType.."]".. Locale.Lookup(resource.Name);
-                            local instance:table = m_kResourceIM:GetInstance();
+                            local instance:table = m_kResourceLuxuryIM:GetInstance();
                             instance.ResourceText:SetText("[ICON_Plus]");
                             plusInstance = instance.ResourceText;
                         else
@@ -72,8 +75,8 @@ function RefreshResources()
     if plusInstance ~= nil then
         plusInstance:SetToolTipString(overflowString);
     end
-    Controls.ResourceStack:CalculateSize();
-    Controls.Resources:SetHide( Controls.ResourceStack:GetSizeX() == 0 );
+    Controls.ResourceStackLuxury:CalculateSize();
+    Controls.LuxuryResources:SetHide( Controls.ResourceStackLuxury:GetSizeX() == 0 or not CQUI_showLuxury );
 end
 
 -- ===========================================================================

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -383,6 +383,7 @@
 
         <ImportFiles id="CQUI_IMPORT_FILES_TOPPANEL">
             <Items>
+                <File>Assets/UI/toppanel.xml</File>
                 <File>Assets/UI/toppanel_CQUI_basegame.lua</File>
                 <File>Assets/UI/toppanel_CQUI.lua</File>
             </Items>
@@ -1530,6 +1531,7 @@
         <File>Assets/UI/partialscreenhooks_CQUI.lua</File>
         <File>Assets/UI/partialscreenhooks.xml</File>
         <File>Assets/UI/productionpanel.xml</File>
+        <File>Assets/UI/toppanel.xml</File>
         <File>Assets/UI/toppanel_CQUI_basegame.lua</File>
         <File>Assets/UI/toppanel_CQUI.lua</File>
         <File>Assets/UI/unitflagmanager_CQUI.lua</File>


### PR DESCRIPTION
Luxury Resources are now part of their own group in the top panel for visual clarity. I felt like this change makes it a bit easier to quickly glance at Luxury Resources in the top panel if the setting is enabled in CQUI as they're no longer bundled with the Strategic Resources. Overflow logic should prioritize the Strategic Resources before showing the Luxury Resources. The `META_PADDING` constant could be tweaked to make use of extra empty space at the top, but I just left it as default.

![Screenshot 2021-11-21 095948](https://user-images.githubusercontent.com/55824797/142773608-56e9107f-0b9b-4b9d-81ae-5710bab644f2.png)
![Screenshot 2021-11-21 100128](https://user-images.githubusercontent.com/55824797/142773610-eade5d54-c33e-47f6-b078-5c8ff09e55df.png)