### PR TITLE
fix #344 : load order of 1 when importing CQUI_IMPORT_FILES_BTS

### DIFF
--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -1261,6 +1261,9 @@
             </Items>
         </LocalizedText>
         <ImportFiles id="CQUI_IMPORT_FILES_BTS">
+            <Properties>
+                <LoadOrder>1</LoadOrder>
+            </Properties>
             <Items>
                 <File>Integrations/BTS/UI/tradeoverview.xml</File>
                 <File>Integrations/BTS/UI/tradeoverview.lua</File>


### PR DESCRIPTION
If using CQUI along with BBG, Trade Route Panel wont open. This is because both mods overrides tradesupport.lua and BBG override wins, though BBG just do a minor bug fix.