### PR TITLE
Fix trade route arrows becoming stuck on map

### DIFF
--- a/Integrations/BTS/UI/Choosers/traderoutechooser.lua
+++ b/Integrations/BTS/UI/Choosers/traderoutechooser.lua
@@ -1153,6 +1153,7 @@ end
 
 function Close()
     LuaEvents.TradeRouteChooser_SetTradeUnitStatus("");
+    UILens.ClearLayerHexes(m_TradeRouteLens);
     ContextPtr:SetHide(true);
     m_isOpen = false;
 


### PR DESCRIPTION
When selecting a city to send a trader to, sometimes the trade route arrows will become stuck on the map. One way the arrows can become stuck that I found easily reproducible is to select a trader, open the world rankings panel, click through the different world rankings tabs, and then select a city to send the trader to.

This change to the TradeRouteChooser in the BetterTradeScreen integration should prevent this from happening and also fix #335 