### PR TITLE
Tech/Civic Tree Related Fixes and Additions

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -253,6 +253,12 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWPRD_TOOLTIP" Language="en_US">
       <Text>Enable a Popup to remind you to change your policy cards before end turn</Text>
     </Row>
+    <Row Tag="LOC_CQUI_GENERAL_AUTOREPEATTECHCIVIC" Language="en_US">
+      <Text>Auto repeat repeatable Techs and Civics</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_GENERAL_AUTOREPEATTECHCIVIC_TOOLTIP" Language="en_US">
+      <Text>Automatically repeat research on technologies and civics that can be repeated (Future Tech and Future Civic)</Text>
+    </Row>
     <Row Tag="LOC_CQUI_TRADER_SCREEN" Language="en_US">
       <Text>Trader Screen</Text>
     </Row>

--- a/Assets/UI/Screens/CivicsTree_CQUI.lua
+++ b/Assets/UI/Screens/CivicsTree_CQUI.lua
@@ -40,9 +40,11 @@ BASE_CQUI_SetCurrentNode = SetCurrentNode;
 local CQUI_STATUS_MESSAGE_CIVIC :number = 3;    -- Number to distinguish civic messages
 local CQUI_halfwayNotified  :table = {};
 local CQUI_ShowTechCivicRecommendations = false;
+local CQUI_AutoRepeatTechCivic:boolean = false;
 
 function CQUI_OnSettingsUpdate()
-    CQUI_ShowTechCivicRecommendations = GameConfiguration.GetValue("CQUI_ShowTechCivicRecommendations") == 1
+    CQUI_ShowTechCivicRecommendations = GameConfiguration.GetValue("CQUI_ShowTechCivicRecommendations") == 1;
+    CQUI_AutoRepeatTechCivic = GameConfiguration.GetValue("CQUI_AutoRepeatTechCivic");
 end
 
 -- ===========================================================================
@@ -140,6 +142,18 @@ function OnCivicComplete( ePlayer:number, eTech:number)
             end
         end
 
+        -- If repeatable, automatically repeat per settings
+        if (currentCivicID ~= -1 and CQUI_AutoRepeatTechCivic) then
+            local civic = GameInfo.Civics[currentCivicID];
+            local kPlayerCivics = kPlayer:GetCulture();
+            local pathToCivic = kPlayerCivics:GetCivicPath(civic.Hash);
+            if ((pathToCivic == nil or next(pathToCivic) == nil) and civic and civic.Repeatable and kPlayerCivics:CanProgress(civic.Index)) then
+                local tParameters = {};
+                tParameters[PlayerOperations.PARAM_CIVIC_TYPE]  = civic.Hash;
+                tParameters[PlayerOperations.PARAM_INSERT_MODE] = PlayerOperations.VALUE_EXCLUSIVE;
+                UI.RequestPlayerOperation(ePlayer, PlayerOperations.PROGRESS_CIVIC, tParameters);
+            end
+        end
     end
 end
 
@@ -171,12 +185,12 @@ function SetCurrentNode( hash )
         local tParameters = {};
         local civic = GameInfo.Civics[hash];
 
-        if next(pathToCivic) == nil and civic and civic.Repeatable and localPlayerCulture:CanProgress(civic.Index) then
+        if (pathToCivc == nil or next(pathToCivic) == nil) and civic and civic.Repeatable and localPlayerCulture:CanProgress(civic.Index) then
             tParameters[PlayerOperations.PARAM_CIVIC_TYPE]  = hash;
             tParameters[PlayerOperations.PARAM_INSERT_MODE] = PlayerOperations.VALUE_EXCLUSIVE;
 
             UI.RequestPlayerOperation(Game.GetLocalPlayer(), PlayerOperations.PROGRESS_CIVIC, tParameters);
-            UI.PlaySound("Confirm_Civic_CivicsTree");
+            --UI.PlaySound("Confirm_Civic_CivicsTree");
         end
     end
 end

--- a/Assets/UI/WorldTracker_CQUI.lua
+++ b/Assets/UI/WorldTracker_CQUI.lua
@@ -97,7 +97,7 @@ end
 function SetMainPanelToolTip(toolTip:string, panelTextureName:string)
     --print("SetMainPanelToolTip", toolTip, panelTextureName);
     -- Get either the MainPanel from the CivicInstance or ResearchInstance
-    for _,ctrl in pairs(Controls.PanelStack:GetChildren()) do
+    for _,ctrl in pairs(Controls.WorldTrackerVerticalContainer:GetChildren()) do
         if (ctrl:GetID() == "MainPanel" and ctrl:GetTexture() == panelTextureName) then
             ctrl:LocalizeAndSetToolTip(toolTip);
         end

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -38,6 +38,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
         ("CQUI_ShowCultureGrowth", 1), -- Shows cultural growth overlay in cityview
         ("CQUI_ShowPolicyReminder", 1),
+        ("CQUI_AutoRepeatTechCivic", 0), -- Automatically repeat techs and civics if repeatable (Only Future Tech/Civic in base game)
         ("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
         ("CQUI_ShowUnitPaths", 1), -- Shows unit paths on hover and selection
         ("CQUI_ShowYieldsOnCityHover", 1), -- Shows city management info like citizens, tile yields, and tile growth on hover

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -551,6 +551,7 @@ function Initialize()
     PopulateCheckBox(Controls.InlineCityStateQuest, "CQUI_InlineCityStateQuest");
     RegisterControl (Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue", UpdateCheckbox);
     PopulateCheckBox(Controls.ShowLuxuryCheckbox, "CQUI_ShowLuxuries");
+    PopulateCheckBox(Controls.AutoRepeatTechCivicCheckbox, "CQUI_AutoRepeatTechCivic", Locale.Lookup("LOC_CQUI_GENERAL_AUTOREPEATTECHCIVIC_TOOLTIP"));
     PopulateCheckBox(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH_TOOLTIP"));
     RegisterControl (Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", UpdateCheckbox);
     PopulateCheckBox(Controls.SmartbannerCheckbox, "CQUI_Smartbanner", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -35,6 +35,9 @@
                             <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
                                 <GridButton ID="ShowPolicyReminderCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWPRD" />
                             </Stack>
+                            <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+                                <GridButton ID="AutoRepeatTechCivicCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_AUTOREPEATTECHCIVIC" />
+                            </Stack>
                             <Stack Anchor="C,T" StackGrowth="Right" Padding="20">
                                 <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE"/>
                                 <PullDown ID="ResourceIconStyle" Style="PullDownBlue" ScrollThreshold="400" Size="200,24" Offset="0,0" SpaceForScroll="0"/>


### PR DESCRIPTION
Makes the following modifications:

1. Fixes the panel tooltip in the WorldTracker_CQUI file to properly show the tech/civic info when hovering over

2. Fixes selecting Future Tech or Future Civic in the Tech/Civic trees. Also comments out playing sound when selecting these as this sound is already played by the base file.

3. Adds in a setting to automatically repeat repeatable techs and civics. In the case of the base game, this is just Future Tech and Future Civic, but should work for custom techs and civics that are repeatable too. Another solution to this that may look nicer would be to have a small button on the tech/civic nodes that can be repeated that can be clicked to repeat that tech/civic. I may look into doing this later, but for now, I think this is suitable. This feature was requested in the comments of #54 , but does not implement the main request of that issue, so it shouldn't be closed yet.

As always, I can made changes or give more info if requested!