### PR TITLE
Add Notification Settings

### DIFF
--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -66,10 +66,6 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ('CQUI_InlineCityStateQuest', 1), -- Show city state quest below city state name instead of a tooltip
         ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel
         ('CQUI_ReligionLensUnitFlagStyle', 1), -- When Religion Lens is on, update Flags of non-religious units.  Values of 0 (Solid, unmodified gae), 1 (Transparent), or 2 (Hidden) are acceptable
-        ('CQUI_NotificationGoodyHut', 1), -- Notification - goody hut reward
-        --('CQUI_NotificationTradeDeal', 1), -- Notification - trade deal expired (reserved)
-        --('CQUI_NotificationPopulation', 0), -- Notification - population growth (reserved)
-        --('CQUI_NotificationCityBorder', 0), -- Notification - city border growth (reserved)
         ('CQUI_BuilderLensDisableNothingPlot', 1), -- When enabled, do not show the "nothing to do here" plot with the Builder Lens
         ('CQUI_BuilderLensDisableDangerousPlot', 1), -- When enabled, do not show "dangerous / enemy near" plot with the Builder Lens
         ('CQUI_AutoapplyScoutLensExtra', 1), -- When enabled, auto-apply the Scout lens for every military unit
@@ -228,3 +224,22 @@ INSERT OR REPLACE INTO CQUI_Bindings -- Don't touch this line!
         ("REST_HEAL", "H", "LOC_CQUI_REST_HEAL"),
         ("REBASE", "Alt+R", "LOC_CQUI_REBASE"),
         ("PLACE_PIN", "Shift+P", "LOC_CQUI_PLACE_PIN");
+
+/*
+    ┌────────────────────────────────────────────────────────────────────────────────────────────┐
+    │                                    Notification settings                                   │
+    ├────────────────────────────────────────────────────────────────────────────────────────────┤
+    │These settings control the default state of the Notification checkboxes                     │
+    │Valid values are 0 (disabled) or 1 (enabled). Don't change the names or the first line!     │
+    └────────────────────────────────────────────────────────────────────────────────────────────┘
+*/
+
+INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
+    VALUES  ("CQUI_NotificationGoodyHut", 1), -- Notification - goody hut reward
+        --('CQUI_NotificationTradeDeal', 1), -- Notification - trade deal expired (reserved)
+        --('CQUI_NotificationPopulation', 0), -- Notification - population growth (reserved)
+        --('CQUI_NotificationCityBorder', 0), -- Notification - city border growth (reserved)
+        ("CQUI_NOTIFICATION_CITY_LOW_AMENITIES", 1),
+        ("CQUI_NOTIFICATION_HOUSING_PREVENTING_GROWTH", 1),
+        ("CQUI_NOTIFICATION_CITY_FOOD_FOCUS", 1),
+        ("CQUI_NOTIFICATION_CITY_UNPOWERED", 1);

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -653,9 +653,23 @@ function Initialize()
     
     -- Notifications
     PopulateCheckBox(Controls.NotificationGoodyHutCheckbox,   "CQUI_NotificationGoodyHut");
+    PopulateCheckBox(Controls.NOTIFICATION_CITY_LOW_AMENITIESCheckbox,   "CQUI_NOTIFICATION_CITY_LOW_AMENITIES");
+    PopulateCheckBox(Controls.NOTIFICATION_HOUSING_PREVENTING_GROWTHCheckbox,   "CQUI_NOTIFICATION_HOUSING_PREVENTING_GROWTH");
+    PopulateCheckBox(Controls.NOTIFICATION_CITY_FOOD_FOCUSCheckbox,   "CQUI_NOTIFICATION_CITY_FOOD_FOCUS");
     --PopulateCheckBox(Controls.NotificationTradeDealCheckbox,  "CQUI_NotificationTradeDeal");
     --PopulateCheckBox(Controls.NotificationPopulationCheckbox, "CQUI_NotificationPopulation");
     --PopulateCheckBox(Controls.NotificationCityBorderCheckbox, "CQUI_NotificationCityBorder");
+
+    -- Expansion 1 Notifications
+    if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
+        -- Nothing (for now)
+    end
+
+    -- Expansion 2 Notifications
+    if (g_bIsGatheringStorm) then
+        Controls.NOTIFICATION_CITY_UNPOWEREDCheckbox:SetHide(false);
+        PopulateCheckBox(Controls.NOTIFICATION_CITY_UNPOWEREDCheckbox, "CQUI_NOTIFICATION_CITY_UNPOWERED");
+    end
 
     InitializeGossipCheckboxes();
     InitializeTraderScreenCheckboxes();

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -530,6 +530,14 @@
                     <!-- NOTIFICATIONS -->
                     <Container ID="NotificationsOptions" Size="parent,parent" Hidden="1">
                         <Stack Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">
+                            <!-- City notifications -->
+                            <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CITY_NAME_BLANK"/>
+                            <GridButton ID="NOTIFICATION_CITY_LOW_AMENITIESCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_NOTIFICATION_CITY_LOW_AMENITIES_MESSAGE" />
+                            <GridButton ID="NOTIFICATION_HOUSING_PREVENTING_GROWTHCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_NOTIFICATION_HOUSING_PREVENTING_GROWTH_MESSAGE" />
+                            <GridButton ID="NOTIFICATION_CITY_FOOD_FOCUSCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_NOTIFICATION_CITY_FOOD_FOCUS_MESSAGE" />
+                            <GridButton ID="NOTIFICATION_CITY_UNPOWEREDCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_NOTIFICATION_CITY_UNPOWERED_MESSAGE" Hidden="1" />
+                            <!-- Other notifications -->
+                            <Label Anchor="C,C" Style="ShellOptionText" String="..."/>
                             <GridButton ID="NotificationGoodyHutCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_NOTIFICATION_DISCOVER_GOODY_HUT_MESSAGE" />
                             <!--<GridButton ID="NotificationTradeDealCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="(reserved)Trade Deal" />-->
                             <!--<GridButton ID="NotificationPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="(reserved)Population" />-->


### PR DESCRIPTION
Split off from #353 by request. Implements the following feature:

Adds in settings to turn some notifications off. For now, this just adds in settings for notifications relating to a city lacking amenities, housing, food, and power. Adding in more shouldn't be too difficult though.

Resolves #182 