### PR TITLE
Add settings for lenses in city view

### DIFF
--- a/Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua
+++ b/Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua
@@ -3,6 +3,24 @@
 -- ===========================================================================
 include("CityPanelOverview_Expansion1");
 
+-- ===========================================================================
+-- CQUI Members
+-- ===========================================================================
+local CQUI_AutoapplyLoyaltyLensInCity :boolean = true;
+local CQUI_ShowCityManageOverLenses :boolean = false;
+
+function CQUI_OnSettingsUpdate()
+    CQUI_AutoapplyLoyaltyLensInCity = GameConfiguration.GetValue("CQUI_AutoapplyLoyaltyLensInCity");
+    CQUI_ShowCityManageOverLenses = GameConfiguration.GetValue("CQUI_ShowCityManageOverLenses");
+end
+
+LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
+LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
+
+-- ===========================================================================
+-- Functions
+-- ===========================================================================
+
 function ViewPanelAmenities(data:table)
     BASE_ViewPanelAmenities(data);  -- AZURENCY : this is the base game version
 
@@ -14,6 +32,14 @@ end
 
 function RefreshCulturalIdentityPanel()
     --UILens.SetActive("Loyalty");
-    SetDesiredLens("Loyalty");
+    if (CQUI_AutoapplyLoyaltyLensInCity) then
+        SetDesiredLens("Loyalty");
+        
+        if (not CQUI_ShowCityManageOverLenses) then
+            LuaEvents.CQUI_HideCitizenManagementLens();
+        end
+    else
+        SetDesiredLens("CityManagement");
+    end
     LuaEvents.CityPanelTabRefresh();
 end

--- a/Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua
+++ b/Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua
@@ -3,6 +3,25 @@
 -- ===========================================================================
 include("CityPanelOverview_Expansion2");
 
+-- ===========================================================================
+-- CQUI Members
+-- ===========================================================================
+local CQUI_AutoapplyLoyaltyLensInCity :boolean = true;
+local CQUI_AutoapplyPowerLensInCity :boolean = true;
+local CQUI_ShowCityManageOverLenses :boolean = false;
+
+function CQUI_OnSettingsUpdate()
+    CQUI_AutoapplyLoyaltyLensInCity = GameConfiguration.GetValue("CQUI_AutoapplyLoyaltyLensInCity");
+    CQUI_AutoapplyPowerLensInCity = GameConfiguration.GetValue("CQUI_AutoapplyPowerLensInCity");
+    CQUI_ShowCityManageOverLenses = GameConfiguration.GetValue("CQUI_ShowCityManageOverLenses");
+end
+
+LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
+LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
+
+-- ===========================================================================
+-- Functions
+-- ===========================================================================
 function ViewPanelAmenities(data:table)
     BASE_ViewPanelAmenities(data);  -- AZURENCY : this is the base game version
 
@@ -14,12 +33,29 @@ end
 
 function RefreshCulturalIdentityPanel()
     --UILens.SetActive("Loyalty");
-    SetDesiredLens("Loyalty");
+    if (CQUI_AutoapplyLoyaltyLensInCity) then
+        SetDesiredLens("Loyalty");
+        
+        if (not CQUI_ShowCityManageOverLenses) then
+            LuaEvents.CQUI_HideCitizenManagementLens();
+        end
+    else
+        SetDesiredLens("CityManagement");
+    end
     LuaEvents.CityPanelTabRefresh();
 end
 
 function RefreshPowerPanel()
     --UILens.SetActive("Power");
-    SetDesiredLens("Power");
+    if (CQUI_AutoapplyPowerLensInCity) then
+        SetDesiredLens("Power");
+
+        if (not CQUI_ShowCityManageOverLenses) then
+            LuaEvents.CQUI_HideCitizenManagementLens();
+        end
+    else
+        SetDesiredLens("CityManagement");
+    end
+
     LuaEvents.CityPanelTabRefresh();
 end

--- a/Assets/Expansion2/Replacements/citypanelpower_CQUI.lua
+++ b/Assets/Expansion2/Replacements/citypanelpower_CQUI.lua
@@ -12,9 +12,11 @@ BASE_CQUI_OnRefresh = OnRefresh;
 -- CQUI Members
 -- ===========================================================================
 local CQUI_ShowCityDetailAdvisor :boolean = false;
+local CQUI_AutoapplyPowerLensInCity :boolean = true;
 
 function CQUI_OnSettingsUpdate()
     CQUI_ShowCityDetailAdvisor = GameConfiguration.GetValue("CQUI_ShowCityDetailAdvisor") == 1;
+    CQUI_AutoapplyPowerLensInCity = GameConfiguration.GetValue("CQUI_AutoapplyPowerLensInCity");
 end
 
 -- ===========================================================================
@@ -38,10 +40,13 @@ function OnRefresh()
 
     BASE_CQUI_OnRefresh();
 
-  -- Hide the advisor if option is disabled
-  if not Controls.PowerAdvisor:IsHidden() then
-      Controls.PowerAdvisor:SetHide( CQUI_ShowCityDetailAdvisor == false );
-  end
+    -- Hide the advisor if option is disabled
+    if not Controls.PowerAdvisor:IsHidden() then
+        Controls.PowerAdvisor:SetHide( CQUI_ShowCityDetailAdvisor == false );
+    end
+  
+    -- Hide the lens key if the power lens isn't shown
+    Controls.KeyPanel:SetHide( CQUI_AutoapplyPowerLensInCity == false );
 
 end
 

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -63,6 +63,12 @@
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="en_US">
       <Text>Shows citizen managament area when hovering over city banner</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEOVERLENSES" Language="en_US">
+      <Text>Show city management over city lenses</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEOVERLENSES_TOOLTIP" Language="en_US">
+      <Text>Shows citizen managament over the lenses activated by the various tabs in the City View, such as the Religion tab.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="en_US">
       <Text>Smartbanners</Text>
     </Row>
@@ -203,6 +209,24 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYENGINEERLENS_TOOLTIP" Language="en_US">
       <Text>Enable this to automatically apply the Routes lens when selecting a Military Engineer.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYRELIGIONLENSINCITY" Language="en_US">
+      <Text>Auto-apply Religion lens in the City View</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYRELIGIONLENSINCITY_TOOLTIP" Language="en_US">
+      <Text>Enable this to automatically apply the Religion lens when selecting the Religion tab in the City View.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYLOYALTYLENSINCITY" Language="en_US">
+      <Text>Auto-apply Loyalty lens in the City View</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYLOYALTYLENSINCITY_TOOLTIP" Language="en_US">
+      <Text>Enable this to automatically apply the Loyalty lens when selecting the Loyalty tab in the City View.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYPOWERLENSINCITY" Language="en_US">
+      <Text>Auto-apply Power lens in the City View</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYPOWERLENSINCITY_TOOLTIP" Language="en_US">
+      <Text>Enable this to automatically apply the Power lens when selecting the Power tab in the City View.</Text>
     </Row>
 
     <Row Tag="LOC_CQUI_POPUPS" Language="en_US">

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -56,6 +56,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
         ('CQUI_ShowCitizenIconsOnCityHover', 0), -- Shows citizen icons when hovering over city banner
         ('CQUI_ShowCityManageAreaOnCityHover', 1), -- Shows citizen management area when hovering over city banner
+        ('CQUI_ShowCityManageOverLenses', 0), -- Shows citizen management over other lenses applied in city view (religion, loyalty, and power)
         ('CQUI_TraderAddDivider', 1), -- Adds a divider between groups in TradeOverview panel
         ('CQUI_TraderShowSortOrder', 0), -- Adds a divider between groups in TradeOverview panel
         ('CQUI_ShowProductionRecommendations', 0), -- Shows the advisor recommendation in the city produciton panel
@@ -74,6 +75,9 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
         ('CQUI_BuilderLensDisableDangerousPlot', 1), -- When enabled, do not show "dangerous / enemy near" plot with the Builder Lens
         ('CQUI_AutoapplyScoutLensExtra', 1), -- When enabled, auto-apply the Scout lens for every military unit
         ('CQUI_AutoapplyEngineerLens', 1), -- When enabled, auto-apply the Routes lens when the Military Engineer is selected
+        ('CQUI_AutoapplyReligionLensInCity', 1), -- When enabled, auto-apply the Religion lens when the Religion tab is selected in the city view
+        ('CQUI_AutoapplyLoyaltyLensInCity', 1), -- When enabled, auto-apply the Loyalty lens when the Loyalty tab is selected in the city view
+        ('CQUI_AutoapplyPowerLensInCity', 1), -- When enabled, auto-apply the Power lens when the Power tab is selected in the city view
         ('CQUI_ShowDebugPrint', 0); -- Shows print in the console
 
 /*

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -615,6 +615,9 @@ function Initialize()
     PopulateCheckBox(Controls.ShowWarIconInCityStateBanner, "CQUI_ShowWarIconInCityStateBanner", Locale.Lookup("LOC_CQUI_SHOW_WAR_ICON_IN_CITYSTATE_BANNER_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateCityStrikeCheckbox, "CQUI_RelocateCityStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATECITYSTRIKEBUTTON_TOOLTIP"));
     PopulateCheckBox(Controls.RelocateEncampmentStrikeCheckbox, "CQUI_RelocateEncampmentStrike", Locale.Lookup("LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON_TOOLTIP"));
+    PopulateCheckBox(Controls.ShowCityManageOverLensesCheckbox, "CQUI_ShowCityManageOverLenses", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEOVERLENSES_TOOLTIP"));
+
+    -- Popups
     PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
     PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
     PopulateCheckBox(Controls.WonderBuiltVisualCheckbox, "CQUI_WonderBuiltPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTVISUAL_TOOLTIP"));
@@ -632,6 +635,19 @@ function Initialize()
     PopulateCheckBox(Controls.AutoapplyScoutLensExtraCheckbox, "CQUI_AutoapplyScoutLensExtra", Locale.Lookup("LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS_EXTRA_TOOLTIP"));
     PopulateCheckBox(Controls.AutoapplyEngineerLensCheckbox, "CQUI_AutoapplyEngineerLens", Locale.Lookup("LOC_CQUI_LENSES_AUTOAPPLYENGINEERLENS_TOOLTIP"));
     PopulateComboBox(Controls.ReligionLensHideUnits, icon_style_options, "CQUI_ReligionLensUnitFlagStyle", Locale.Lookup("LOC_CQUI_LENSES_RELIGIONLENSUNITFLAGSTYLE_TOOLTIP"));
+    PopulateCheckBox(Controls.AutoapplyReligionLensInCityCheckbox, "CQUI_AutoapplyReligionLensInCity", Locale.Lookup("LOC_CQUI_LENSES_AUTOAPPLYRELIGIONLENSINCITY_TOOLTIP"));
+    
+    -- Expansion 1 Lens Options
+    if (g_bIsRiseAndFall or g_bIsGatheringStorm) then
+        Controls.AutoapplyLoyaltyLensInCityCheckbox:SetHide(false);
+        PopulateCheckBox(Controls.AutoapplyLoyaltyLensInCityCheckbox, "CQUI_AutoapplyLoyaltyLensInCity", Locale.Lookup("LOC_CQUI_LENSES_AUTOAPPLYLOYALTYLENSINCITY_TOOLTIP"));
+    end
+    
+    -- Expansion 2 Lens Options
+    if (g_bIsGatheringStorm) then
+        Controls.AutoapplyPowerLensInCityCheckbox:SetHide(false);
+        PopulateCheckBox(Controls.AutoapplyPowerLensInCityCheckbox, "CQUI_AutoapplyPowerLensInCity", Locale.Lookup("LOC_CQUI_LENSES_AUTOAPPLYPOWERLENSINCITY_TOOLTIP"));
+    end
     
     -- Add Individual Builder Lenses
     PopulateLensRGBPickerSettings();

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -101,6 +101,9 @@
                                 <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="RelocateEncampmentStrikeCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_RELOCATEENCAMPMENTSTRIKEBUTTON" />
                                 </Stack>
+                                <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="ShowCityManageOverLensesCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEOVERLENSES" />
+                                </Stack>
                                 <Stack Anchor="C,C" StackGrowth="Left">
                                     <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
                                 </Stack>
@@ -480,6 +483,15 @@
                                 </Stack>
                                 <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
                                     <GridButton ID="AutoapplyEngineerLensCheckbox" Anchor="L,C" Offset="0,0" Size="400,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYENGINEERLENS"/>
+                                </Stack>
+                                <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="AutoapplyReligionLensInCityCheckbox" Anchor="L,C" Offset="0,0" Size="400,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYRELIGIONLENSINCITY"/>
+                                </Stack>
+                                <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="AutoapplyLoyaltyLensInCityCheckbox" Anchor="L,C" Offset="0,0" Size="400,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYLOYALTYLENSINCITY" Hidden="1"/>
+                                </Stack>
+                                <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+                                    <GridButton ID="AutoapplyPowerLensInCityCheckbox" Anchor="L,C" Offset="0,0" Size="400,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYPOWERLENSINCITY" Hidden="1"/>
                                 </Stack>
                                 <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
                                     <PullDown ID="ReligionLensHideUnits" Style="PullDownBlue" ScrollThreshold="400" Size="200,24" Offset="0,0" SpaceForScroll="0"/>

--- a/Integrations/ML/Lenses/CQUI_CitizenManagement/ModLens_CQUI_CitizenManagement.lua
+++ b/Integrations/ML/Lenses/CQUI_CitizenManagement/ModLens_CQUI_CitizenManagement.lua
@@ -122,6 +122,22 @@ function RefreshCitizenManagementLens(cityID:number)
 end
 
 -- ===========================================================================
+function HideCitizenManagementLens()
+    -- Hide the highlighted tiles, but don't clear the data
+    if (m_cityID ~= -1 and UILens.IsLayerOn(ML_LENS_LAYER)) then
+        UILens.ToggleLayerOff(ML_LENS_LAYER);
+    end
+end
+
+-- ===========================================================================
+function UnhideCitizenManagementLens()
+    -- Unhides the highlighted tiles
+    if (m_cityID ~= -1 and not UILens.IsLayerOn(ML_LENS_LAYER)) then
+        UILens.ToggleLayerOn(ML_LENS_LAYER);
+    end
+end
+
+-- ===========================================================================
 local function CQUI_OnSettingsInitialized()
     UpdateLensConfiguredColors(m_LensSettings, nil, nil);
 end
@@ -137,6 +153,8 @@ local function OnInitialize()
     LuaEvents.CQUI_ShowCitizenManagement.Add( ShowCitizenManagementLens );
     LuaEvents.CQUI_RefreshCitizenManagement.Add( RefreshCitizenManagementLens );
     LuaEvents.CQUI_ClearCitizenManagement.Add( ClearCitizenManagementLens );
+    LuaEvents.CQUI_HideCitizenManagementLens.Add( HideCitizenManagementLens );
+    LuaEvents.CQUI_UnhideCitizenManagementLens.Add( UnhideCitizenManagementLens );
 end
 
 local CitizenManagementEntry = {


### PR DESCRIPTION
I mentioned I would add this back in #352, so here it finally is. Implements the following two features:

1. Adds in options to choose whether or not the religion, loyalty, and power lenses automatically apply in the city view when selecting on their respective tabs. These new settings are located under the "Lenses" section. If these lenses are set to not apply and they normally have a key displayed, the key is also hidden now since it's pointless. If the lenses are turned off, the lens applied is the standard CityManagement lens. Default setting is on for all.

2. Adds in an option to allow citizen management even when these lenses are applied. This option is located under the "City View" section. If enabled, citizens can be managed even when the other lenses are applied. Default setting is off.

I initially only planned to do 1, but as I was doing it, I felt 2 was an interesting idea. I'm curious to see how you all feel about it. 

I'm also wondering if there are any recommendations on how I could potentially remove the duplicated code. The code for the Loyalty lens is duplicated in both citypaneloverview_expansion1_CQUI.lua and citypaneloverview_expansion2_CQUI.lua. I want to minimize duplicated code, but I wasn't sure how I could do this with how these files are structured.

I'm also open to feedback on the text for these options as well as their placement in the settings. As always, I'm open to making changes if requested!