### PR TITLE
City View Tweaks

### DIFF
--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -217,12 +217,12 @@ function AppendGreatWorksData( data:table )
     local pCity:table = data.City;
     local pCityBldgs:table = pCity:GetBuildings();
     -- iterate buildings
-	for buildingInfo in GameInfo.Buildings() do
-		local buildingIndex:number = buildingInfo.Index;
-		local buildingType:string = buildingInfo.BuildingType;
-		if pCityBldgs:HasBuilding(buildingIndex) then
-			local numSlots:number = pCityBldgs:GetNumGreatWorkSlots(buildingIndex);
-			if numSlots ~= nil and numSlots > 0 then
+    for buildingInfo in GameInfo.Buildings() do
+        local buildingIndex:number = buildingInfo.Index;
+        local buildingType:string = buildingInfo.BuildingType;
+        if pCityBldgs:HasBuilding(buildingIndex) then
+            local numSlots:number = pCityBldgs:GetNumGreatWorkSlots(buildingIndex);
+            if numSlots ~= nil and numSlots > 0 then
                 local buildingData:table = {
                     Icon = "ICON_"..buildingInfo.BuildingType,
                     Index = buildingIndex,
@@ -264,8 +264,8 @@ function AppendGreatWorksData( data:table )
                     table.insert(buildingData.Slots, slotData); --GameInfo.GreatWorks[greatWorkType]);
                 end
                 table.insert(data.GreatWorks, buildingData);
-			end -- numSlots > 0
-		end -- has building
+            end -- numSlots > 0
+        end -- has building
     end -- for all buildings
     --dshowrectable(data.GreatWorks); -- debug
 end
@@ -923,6 +923,8 @@ function ViewPanelCitizensGrowth( data:table )
 
     Controls.GrowthLongNum:SetText( not data.Occupied and math.abs(data.TurnsUntilGrowth) or 0);
     Controls.FoodNeededForGrowth:SetText( Locale.ToNumber(data.GrowthThreshold, "#,###.#") );
+    Controls.GrowthLongTurnsBar:SetPercent( data.CurrentFoodPercent );
+    Controls.GrowthLongTurnsBar:SetShadowPercent( data.FoodPercentNextTurn );
 
     local iModifiedFood;
     local total :number;
@@ -1107,13 +1109,7 @@ end
 function OnCloseButtonClicked()
     -- ==== CQUI CUSTOMIZATION BEGIN ====================================================================================== --
     -- CQUI change the behavior of when the Close button is clicked
-    if UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT or UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT then
-        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-        LuaEvents.CQUI_CityviewEnable();
-        return;
-    end
-
-    LuaEvents.CQUI_CityPanel_CityviewDisable();
+    LuaEvents.CQUI_CityviewDisableCurrentMode();
     -- ==== CQUI CUSTOMIZATION END ======================================================================================== --
 end
 
@@ -1422,7 +1418,7 @@ function OnShutdown()
     LuaEvents.Tutorial_ResearchOpen.Remove(OnClose);
     LuaEvents.ActionPanel_OpenChooseResearch.Remove(OnClose);
     LuaEvents.ActionPanel_OpenChooseCivic.Remove(OnClose);
-    LuaEvents.CityPanel_ShowOverviewPanel.Remove( OnShowOverviewPanel );	
+    LuaEvents.CityPanel_ShowOverviewPanel.Remove( OnShowOverviewPanel );
     LuaEvents.CityPanel_ToggleOverviewCitizens.Remove( OnToggleCitizensTab );
     LuaEvents.CityPanel_ToggleOverviewBuildings.Remove( OnToggleBuildingsTab );
     LuaEvents.CityPanel_ToggleOverviewReligion.Remove( OnToggleReligionTab );

--- a/Assets/UI/Panels/citypaneloverview.xml
+++ b/Assets/UI/Panels/citypaneloverview.xml
@@ -83,9 +83,9 @@
                             <Container Size="1,8" />
                             <Grid Anchor="L,B" Offset="-5,0" Size="parent+10,31" Texture="CityPanel_StatPanelHeader" SliceCorner="3,15" SliceTextureSize="28,31" Size="default,auto" MinSize="parent,31" InnerPadding="15,15" AutoSizePadding="0,2">
                                 <Image ID="GrowthLongTurns" Offset="0,1" Anchor="R,C" Size="182,21" Texture="CityPanel_MeterBacking">
-                                    <Label ID="GrowthLongLabel" Anchor="L,C" AnchorSide="O,I" Style="CityPanelText" String="{LOC_HUD_CITY_GROWTH_IN:upper}" WrapWidth="100" Offset="2,0" />
-                                    <TextureBar ID="GrowthLongTurnsBar" Anchor="L,T" Size="parent-4,parent-3" Texture="CityPanel_CitizenMeter" ShadowColor="255,255,255,100">
-                                        <Label ID="GrowthLongNum" Style="CityPanelNumLarge" String="-" WrapWidth="parent" Offset="4,-2" />
+                                    <Label ID="GrowthLongLabel" Anchor="L,C" AnchorSide="O,I" Style="CityPanelText" String="{LOC_HUD_CITY_GROWTH_IN:upper}" WrapWidth="100" Offset="2,1" />
+                                    <TextureBar ID="GrowthLongTurnsBar" Anchor="L,T" Size="parent-4,parent-3" Texture="CityPanel_CitizenMeter" ShadowColor="255,255,255,100" Offset="2,2" >
+                                        <Label ID="GrowthLongNum" Style="CityPanelNumLarge" String="-" WrapWidth="parent" Offset="3,-3" />
                                     </TextureBar>
                                 </Image>
                             </Grid>

--- a/Assets/UI/Panels/productionpanel_CQUI.lua
+++ b/Assets/UI/Panels/productionpanel_CQUI.lua
@@ -111,6 +111,7 @@ function CQUI_ClearDistrictBuildingLayers()
     LuaEvents.CQUI_RefreshPurchasePlots();
     LuaEvents.CQUI_DistrictPlotIconManager_ClearEverything();
     LuaEvents.CQUI_Realize2dArtForDistrictPlacement();
+    LuaEvents.CQUI_DisplayGrowthTileIfValid();
 end
 
 -- ===========================================================================
@@ -576,13 +577,7 @@ end
 --    CQUI modified OnClose via click
 -- ===========================================================================
 function OnClose()
-    if UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT or UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT then
-        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-        LuaEvents.CQUI_CityviewEnable();
-        return;
-    end
-
-    LuaEvents.CQUI_CityPanel_CityviewDisable();
+    LuaEvents.CQUI_CityviewDisableCurrentMode();
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/CityBannerManager_CQUI.lua
+++ b/Assets/UI/WorldView/CityBannerManager_CQUI.lua
@@ -1215,7 +1215,7 @@ function OnCityBannerClick( playerID, cityID )
     elseif (localPlayerID == PlayerTypes.OBSERVER 
             or localPlayerID == PlayerTypes.NONE 
             or pPlayer:GetDiplomacy():HasMet(localPlayerID)) then
-        LuaEvents.CQUI_CityviewDisable(); -- Make sure the cityview is disable
+        LuaEvents.CQUI_CityviewDisable(); -- Make sure the cityview is disabled
         local pPlayerConfig :table   = PlayerConfigurations[playerID];
         local isMinorCiv    :boolean = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
         -- print("clicked player " .. playerID .. " city.  IsMinor?: ",isMinorCiv);

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -665,10 +665,9 @@ end
 function OnMouseBuildingPlacementCancel( pInputStruct:table )
     -- print_debug("** Function Entry: OnMouseBuildingPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
-        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-        LuaEvents.CQUI_CityviewEnable();
         -- CQUI: Do not call ExitPlacementMode here
         -- ExitPlacementMode( true );
+        LuaEvents.CQUI_CityviewDisableCurrentMode();
     end
 end
 
@@ -676,11 +675,9 @@ end
 function OnMouseDistrictPlacementCancel( pInputStruct:table )
     -- print_debug("** Function Entry: OnMouseDistrictPlacementCancel (CQUI Hook)");
     if IsCancelAllowed() then
-        LuaEvents.StoreHash(0);
-        UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
-        LuaEvents.CQUI_CityviewEnable();
         -- CQUI: Do not call ExitPlacementMode here
         -- ExitPlacementMode( true );
+        LuaEvents.CQUI_CityviewDisableCurrentMode();
     end
 end
 

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -599,8 +599,11 @@ function OnLensLayerOff( layerNum:number )
     --------------------------------------------------------------------------------------------------
     -- Clear Modded Lens Seperately (Appeal lens included)
     elseif layerNum == m_HexColoringAppeal then
-        UILens.ClearLayerHexes( m_MapHexMask );
-        if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil) then
+        local mode = UI.GetInterfaceMode();
+        if (mode ~= InterfaceModeTypes.CITY_MANAGEMENT and mode ~= InterfaceModeTypes.DISTRICT_PLACEMENT and mode ~= InterfaceModeTypes.BUILDING_PLACEMENT) then
+            UILens.ClearLayerHexes( m_MapHexMask );
+        end
+        if (mode ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil)) then
             UILens.ClearLayerHexes(m_HexColoringAppeal);
         end
         UI.PlaySound("UI_Lens_Overlay_Off");


### PR DESCRIPTION
This pull request implements the following seven items:

1. Refactor city view closing code to simplify closing the view with LuaEvents. For example, CityPanelOverview no longer needs to check the interface mode to decide what to do when the close button is clicked. This change also makes better use of the CQUI_OnInterfaceModeChanged function in the CityPanel file.

2. Ensure the city view is closed when the city is deselected. Sometimes the city view can stay up even when the city is deselected. One case I noticed this happening in was the OnCityLoyaltyChanged function being called while being selected on a city. I would be selected on a city in-between turns, and it would deselect the city at the beginning of the next turn, but leave the city view up. This isn't game breaking, but causes bad UI. For instance, clicking through the tabs on the overview panel will show some blank tabs and also throw out errors in the Lua.log file With these changes, the city view is always closed if the city is deselected for any reason.

3. Exit out of the District/Building placement mode when a new turn begins. The SelectedUnit file from the base game sets the lens to Default in its OnLocalPlayerTurnBegin function. This clears out the District/Building placement view, but doesn't exit it, which looks confusing. Now the District/Building placement mode is exited as well.

4. Properly add shadow to non-valid tiles when in District/Building Placement mode without having to click twice.

5. Show/Hide growth tile based on whether it's a valid spot when clicking through various Districts/Buildings. Previously, it's visibility would only be determined for the first district selected. If you selected another district/building without exiting the placement mode, the growth tile's visibility would not change. Now it will update for each district/building selected.

6. Do not add shadow to tiles within cities when not in District/Building Placement mode. An example of this happening before would be when a city can no longer purchase any more tiles (after growing to include all tiles within 3 of the city center). The citizen management view will then add shadows to tiles that cannot be worked. This is due to how the ShowPurchases function works in the base game. It will add city tiles to its list if any tile can be purchased. This would not happen if tiles cannot be purchased. After this PR, no city tiles will have a shadow on them.

7. In the CityOverviewPanel, there is a bar for the city growth. However, it is unused for some reason. It is redundant information since it's displayed elsewhere on the CityPanel, but I feel it should either be used or removed. I chose to use it here.

I want to make note of a couple things I noticed while making these changes:

When implementing change 2, I noticed that the OnCityLoyaltyChanged function (which can be found in files such as CityPanel_Expansion1) was being called in CQUI, but not in the base game (for the same turns on the same game). This function is called by the engine though, so why is this happening? In CQUI, it deselects the city I'm selected on even though the city's loyalty didn't change?

When implementing change 3, I originally wanted to modify SelectedUnit to only set the lens to Default if not in the District/Building placement mode. However, I had difficulty doing this because of how SelectedUnit_Expansion2 is added to the game. I think the problem is that in the Expansion2.modinfo file, "SelectedUnit_Expansion2" is not listed under the Import Files section. This seems to make it impossible to include the file in a modded SelectedUnit file? As a result, I think I'd either have to completely replace the base game's SelectedUnit file, or copy/paste all of the code from SelectedUnit_Expansion2 into a new file if I wanted to modify it? As shown in this PR though, I ultimately decided to not touch it and resolve this small bug with a different approach.

These were just a couple things I thought were interesting.

Anyway, I'm more than happy to make any changes or provide additional info if requested!