### PR TITLE
City/District Strike Button Tweaks

### DIFF
--- a/Assets/Text/cqui_text_general.xml
+++ b/Assets/Text/cqui_text_general.xml
@@ -46,10 +46,10 @@
 
     <!-- ActionPanel -->
     <Row Tag="LOC_CQUI_ACTION_PANEL_ENCAMPMENT_RANGED_ATTACK" Language="en_US">
-      <Text>Encampent Ranged Strike</Text>
+      <Text>{1_DistrictName} RANGED ATTACK</Text>
     </Row>
     <Row Tag="LOC_CQUI_ACTION_PANEL_ENCAMPMENT_RANGED_ATTACK_TOOLTIP" Language="en_US">
-      <Text>Your encampment is able to make a ranged strike</Text>
+      <Text>Your {1_DistrictName} can perform a ranged attack.</Text>
     </Row>
 
     <!-- Policyreminderpopup -->

--- a/Assets/UI/Panels/NotificationPanel_CQUI.lua
+++ b/Assets/UI/Panels/NotificationPanel_CQUI.lua
@@ -28,7 +28,6 @@ function OnCityRangeAttack( notificationEntry : NotificationType )
         if pPlayer ~= nil then
             local attackCity = pPlayer:GetCities():GetFirstRangedAttackCity();
             if (attackCity ~= nil) then
-                LuaEvents.CQUI_Strike_Enter();
                 LuaEvents.CQUI_CityRangeStrike(Game.GetLocalPlayer(), attackCity:GetID());
             else
                 error( "Unable to find selectable attack city while in OnCityRangeAttack()" );

--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -6,6 +6,7 @@ include("GameCapabilities");
 BASE_CQUI_VIEW = View;
 BASE_CQUI_Refresh = Refresh;
 BASE_CQUI_GetUnitActionsTable = GetUnitActionsTable;
+BASE_CQUI_OnInterfaceModeChanged = OnInterfaceModeChanged;
 
 -- ===========================================================================
 -- CQUI Members
@@ -110,3 +111,30 @@ function GetUnitActionsTable( pUnit )
 
     return actionsTable;
 end
+
+-- ===========================================================================
+--  CQUI modified OnInterfaceModeChanged
+--  Don't always hide the ContextPtr when leaving City/District Range Attack
+-- ===========================================================================
+function OnInterfaceModeChanged( eOldMode:number, eNewMode:number )
+    -- Base function call
+    BASE_CQUI_OnInterfaceModeChanged(eOldMode, eNewMode);
+
+    -- The ContextPtr is always set to hide when the old mode is CITY_RANGE_ATTACK or DISTRICT_RANGE_ATTACK
+    -- Unhide it if the new mode is also one of these, or if a unit was selected
+    -- Fixes basegame bug with the UnitPanel being hidden when it's not supposed to be
+    if ((eOldMode == InterfaceModeTypes.CITY_RANGE_ATTACK or eOldMode == InterfaceModeTypes.DISTRICT_RANGE_ATTACK)
+        and ((eNewMode == InterfaceModeTypes.CITY_RANGE_ATTACK or eNewMode == InterfaceModeTypes.DISTRICT_RANGE_ATTACK)
+        or (eNewMode == InterfaceModeTypes.SELECTION and UI.GetHeadSelectedUnit()))) then
+            ContextPtr:SetHide(false);
+    end
+end
+
+-- ===========================================================================
+--  Initialize the context
+-- ===========================================================================
+function Initialize_UnitPanel_CQUI()
+    Events.InterfaceModeChanged.Remove(BASE_CQUI_OnInterfaceModeChanged);
+    Events.InterfaceModeChanged.Add(OnInterfaceModeChanged);
+end
+Initialize_UnitPanel_CQUI();

--- a/Assets/UI/worldinput_CQUI.lua
+++ b/Assets/UI/worldinput_CQUI.lua
@@ -108,13 +108,13 @@ end
 function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, isSelected:boolean, isEditable:boolean )
     -- local msg = "** Function Entry: OnUnitSelectionChanged (CQUI Hook).  playerId:"..tostring(playerID).." unitId:"..tostring(unitID).." hexI:"..tostring(hexI).." hexJ:"..tostring(hexJ).." hexK:"..tostring(hexK).." isSelected:"..tostring(isSelected).." isEditable:"..tostring(isEditable);
     -- print_debug(msg);
-    if playerID ~= Game.GetLocalPlayer() then
+    if (playerID ~= Game.GetLocalPlayer()) then
         return;
     end
 
     -- CQUI (Azurency) : Fixes a Vanilla bug from SelectUnit.lua (not taking in account the district range attack)
     -- CQUI (Azurency) : If a selection is occuring and the district attack interface mode is up, take it down.
-    if UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_RANGE_ATTACK then
+    if (isSelected and UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
         UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
 

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -537,8 +537,11 @@ function OnLensLayerOn( layerNum:number )
     --------------------------------------------------------------------------------------------------
     -- clear unit non-standard layers
     -- do this if no unit is selected, since these lenses are applied on unit selection, so control should be in SelectedUnit.lua
-    if UI.GetHeadSelectedUnit() == nil then
-        UILens.ClearLayerHexes(m_AttackRange);
+    if (UI.GetHeadSelectedUnit() == nil) then
+        local mode = UI.GetInterfaceMode();
+        if (mode ~= InterfaceModeTypes.CITY_RANGE_ATTACK and mode ~= InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
+            UILens.ClearLayerHexes(m_AttackRange);
+        end
         UILens.ClearLayerHexes(m_HexColoringGreatPeople);
         UILens.ClearLayerHexes(m_MovementZoneOfControl);
     end
@@ -583,8 +586,11 @@ function OnLensLayerOff( layerNum:number )
     --------------------------------------------------------------------------------------------------
     -- clear unit non-standard layers
     -- do this if no unit is selected, since these lenses are applied on unit selection, so control should be in SelectedUnit.lua
-    if UI.GetHeadSelectedUnit() == nil then
-        UILens.ClearLayerHexes(m_AttackRange);
+    if (UI.GetHeadSelectedUnit() == nil) then
+        local mode = UI.GetInterfaceMode();
+        if (mode ~= InterfaceModeTypes.CITY_RANGE_ATTACK and mode ~= InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
+            UILens.ClearLayerHexes(m_AttackRange);
+        end
         UILens.ClearLayerHexes(m_HexColoringGreatPeople);
         UILens.ClearLayerHexes(m_MovementZoneOfControl);
     end
@@ -1274,9 +1280,13 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
             end
 
             -- clear any non-standard layers
-            UILens.ClearLayerHexes(m_AttackRange);
-            UILens.ClearLayerHexes(m_HexColoringGreatPeople);
-            UILens.ClearLayerHexes(m_MovementZoneOfControl);
+            if (UI.GetHeadSelectedUnit() == nil) then
+                if (eNewMode ~= InterfaceModeTypes.CITY_RANGE_ATTACK and eNewMode ~= InterfaceModeTypes.DISTRICT_RANGE_ATTACK) then
+                    UILens.ClearLayerHexes(m_AttackRange);
+                end
+                UILens.ClearLayerHexes(m_HexColoringGreatPeople);
+                UILens.ClearLayerHexes(m_MovementZoneOfControl);
+            end
 
             LuaEvents.ML_CloseLensPanels()
             --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Quick Explanation

CQUI makes changes to the City/District strike buttons. The most obvious is the movement of the button locations. However, more changes than that are made, but there are bugs with the implementations. This is purely a bug fix update. No new features are added in this PR. The goals/changes of this PR as as follows:

**1.** Ensure the strike view is always entered and exited on mouse click
**2.** Clicking on another strike button when one is currently selected properly opens the new strike view
**3.** Entering the strike view always shows the strike range and attack arrow
**4.** Selecting a unit while currently in the strike view exits the strike view and shows the unit panel
**5.** Encampment strike button is now updated on settings change
**6.** Updated action panel encampment ranged attack text to be consistent with the city ranged attack text
**7.** The action panel now ignores city centers when looking for a district that can do a ranged attack

## Detailed Explanation
<details>
<summary>Detailed explanation of changes</summary>

---
**1.** Ensure the strike view is always entered and exited on mouse click.
* Base game behavior: Clicking on a strike button opens the strike view. Clicking on it again does not close it.
* Current CQUI behavior: The city strike button opens/closes the strike view on click. The district strike button *only* opens.
* Expected CQUI behavior: Both the city strike button and district strike buttons should open/close the strike view on click.
* Files changed: `CityBannerManager_CQU.lua`, `actionpanel.lua`, `citypanel.lua`, `NotificationPanel_CQUI.lua`

---
**2.** Clicking on another strike button when one is currently selected properly opens the new strike view.
* Base game behavior: Clicking on another strike button changes the strike view to that city/district.
* Current CQUI behavior: When in a city strike view, clicking a district or other city strike button closes the view and does not open a new one. When in a district strike view, clicking a city strike button properly closes and opens a new one.
* Expected CQUI behavior: Both the city/district strike buttons should close their views and open a new one when selecting on another strike button.
* Files changed: `CityBannerManager_CQUI.lua`

---
**3.** Entering the strike view always shows the strike range and attack arrow.
* Base game behavior: Entering the strike view always shows the strike range and attack arrow.
* Current CQUI behavior: Entering the strike view when a lens was previously active will not show the strike range and attack arrow.
* Expected CQUI behavior: Entering the strike view should always show the strike range and attack arrow.
* Files changed: `minimappanel.lua`

---
**4.** Selecting a unit while currently in the strike view exits the strike view and shows the unit panel.
* Base game behavior: Selecting a unit from the city strike view hides the unit panel. Selecting a unit from the district strike view does not close the strike view.
* Current CQUI behavior: Selecting a unit from any strike view hides the unit panel.
* Expected CQUI behavior: Selecting a unit from any strike view should always show the unit panel.
* Files changed: `UnitPanel.lua`, `worldinput_CQUI.lua`

---
**5.** Encampment strike button is now updated on settings change.
* Base game behavior: N/A (Doesn't have strike button settings).
* Current CQUI behavior: Only the city strike button's location is updated on settings change. The district strike button is not changed.
* Expected CQUI behavior: Both strike buttons should update their location when the settings are updated.
* Files changed: `CityBannerManager_CQU.lua`

---
**6.** Updated action panel encampment ranged attack text to be consistent with the city ranged attack text.
* Base game behavior: N/A (Doesn't have encampment ranged attack notifications).
* Current CQUI behavior:
> City Strike Notification: CITY RANGED ATTACK - Your city can perform a ranged attack.
> District Strike Notification: Encampment Ranged Strike - Your encampment is able to make a ranged strike.

* Expected CQUI behavior:
> City Strike Notification: CITY RANGED ATTACK - Your city can perform a ranged attack.
> District Strike Notification: ENCAMPMENT RANGED ATTACK - Your encampment can perform a ranged attack.

* Files changed: `cqui_text_general.xml`

---
**7.** The action panel now ignores city centers when looking for a district that can do a ranged attack.
* Base game behavior: N/A (Doesn't have encampment ranged attack notifications).
* Current CQUI behavior: When clicking the district ranged attack notification, sometimes a city center will be selected instead of a district.
* Expected CQUI behavior: When clicking the district ranged attack notification, districts other than the city center should be selected.
* Files changed: `actionpanel.lua`
</details>