### PR TITLE
Compatibility: Allow other mods to extend CQUI's Production Panel

### DIFF
--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -364,6 +364,7 @@
 
         <ImportFiles id="CQUI_IMPORT_FILES_PRODUCTIONPANEL">
             <Items>
+                <File>Assets/UI/Panels/productionpanel_CQUI.lua</File>
                 <File>Assets/UI/productionpanel.xml</File>
             </Items>
         </ImportFiles>


### PR DESCRIPTION
Very small fix that allows other mods to extend and modify CQUI's production panel if desired. Simply adds `productionpanel_CQUI.lua` to the relevant ImportFiles section of the `CQUI.modinfo` file.

This is purely a change to allow compatibility with other mods (including another one I'm helping with right now). There are no gameplay or UI changes to CQUI itself with this.