### PR TITLE
adds feature to aggregate identical CombatPreview ModifierStrings

### DIFF
--- a/Assets/UI/Panels/unitpanel_CQUI.lua
+++ b/Assets/UI/Panels/unitpanel_CQUI.lua
@@ -113,6 +113,116 @@ function GetUnitActionsTable( pUnit )
 end
 
 -- ===========================================================================
+--  CQUI modified ModifierStrings on combat preview
+--  If there are identical ModifierStrings except for the number value, they are combined as a single string with
+--  all the numbers combined.
+-- ===========================================================================
+function GetCombatModifierList(combatantHash)
+    local m_combatResults = GetCombatPreviewResults()
+    if (m_combatResults == nil) then return; end
+
+    local baseStrengthValue = 0;
+    local combatantResults = m_combatResults[combatantHash];
+
+    baseStrengthValue = combatantResults[CombatResultParameters.COMBAT_STRENGTH];
+
+    local baseStrengthText = baseStrengthValue .. " " .. Locale.Lookup("LOC_COMBAT_PREVIEW_BASE_STRENGTH");
+    local interceptorModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_INTERCEPTOR];
+    local antiAirModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_ANTI_AIR];
+    local healthModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_HEALTH];
+    local terrainModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_TERRAIN];
+    local opponentModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_OPPONENT];
+    local modifierModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_MODIFIER];
+    local flankingModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_ASSIST];
+    local promotionModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_PROMOTION];
+    local defenseModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_DEFENSES];
+    local resourceModifierText = combatantResults[CombatResultParameters.PREVIEW_TEXT_RESOURCES];
+
+    local modifierList:table = {};
+    local modifierListSize:number = 0;
+    if ( baseStrengthText ~= nil) then
+        modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, baseStrengthText, "ICON_STRENGTH");
+    end
+    if (interceptorModifierText ~= nil) then
+    for i, item in ipairs(interceptorModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STATS_INTERCEPTOR");
+        end
+    end
+    if (antiAirModifierText ~= nil) then
+        for i, item in ipairs(antiAirModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STATS_ANTIAIR");
+        end
+    end
+    if (healthModifierText ~= nil) then
+        for i, item in ipairs(healthModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_DAMAGE");
+        end
+    end
+    if (terrainModifierText ~= nil) then
+        for i, item in ipairs(terrainModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STATS_TERRAIN");
+        end
+    end
+    if (opponentModifierText ~= nil) then
+        for i, item in ipairs(opponentModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STRENGTH");
+        end
+    end
+    if (modifierModifierText ~= nil) then             -- MODDED CHANGES BEGIN
+    local REPLACE_TAG = '{{PLACEHOLDER}}'
+        local tModifierUniques = {}
+        local tNumStrippedUniques = {}
+        local tNumStrippedUniquesAmounts = {}
+        local sStrippedItem
+        local sNewItem
+        local iStrippedAmount
+        for i, item in ipairs(modifierModifierText) do
+            iStrippedAmount = item:match("%d+")
+            if iStrippedAmount then
+                sStrippedItem = item:gsub(iStrippedAmount, REPLACE_TAG, 1)
+                if tNumStrippedUniques[sStrippedItem] then
+                    tNumStrippedUniques[sStrippedItem] = tNumStrippedUniques[sStrippedItem] + iStrippedAmount
+                else
+                    tNumStrippedUniques[sStrippedItem] = iStrippedAmount
+                end
+            else
+                tModifierUniques[item] = 1
+            end
+        end
+        for item, amount in pairs(tNumStrippedUniques) do
+            sNewItem = item:gsub(REPLACE_TAG, tostring(amount), 1)
+            item = sNewItem
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STRENGTH");
+        end
+        for item, amount in pairs(tModifierUniques) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_STRENGTH");
+        end
+    end                                                           -- MODDED CHANGES END
+    if (flankingModifierText ~= nil) then
+        for i, item in ipairs(flankingModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_POSITION");
+        end
+    end
+    if (promotionModifierText ~= nil) then
+        for i, item in ipairs(promotionModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_PROMOTION");
+        end
+    end
+    if (defenseModifierText ~= nil) then
+        for i, item in ipairs(defenseModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_DEFENSE");
+        end
+    end
+    if (resourceModifierText ~= nil) then
+        for i, item in ipairs(resourceModifierText) do
+            modifierList, modifierListSize = AddModifierToList(modifierList, modifierListSize, Locale.Lookup(item), "ICON_RESOURCES");
+        end
+    end
+
+    return modifierList, modifierListSize;
+end
+
+-- ===========================================================================
 --  CQUI modified OnInterfaceModeChanged
 --  Don't always hide the ContextPtr when leaving City/District Range Attack
 -- ===========================================================================


### PR DESCRIPTION
In the unit Combat Preview, strength modifers are listed, even if the values are identical. This can lead to UI bloat if many modifiers are present, as seen in the modded example.

![image](https://github.com/user-attachments/assets/d403944e-7267-46e9-9eb0-adef2b244fbf)

To fix this, Modifier strings are stored and duplicate strings are instead aggregated, I.E. In the mod example, I have given the Battlecry promo a second copy of its normal modifier, but instead of +7 twice, it sums it as +14.
 
![image](https://github.com/user-attachments/assets/ded72030-a7fc-4f71-b636-d6c71c249484)

I am planning on releasing this change with my own associated mod, but other modders have expressed interest in using it, but are not Lua programmers. I figured a good comprise might be a home in CQUI.